### PR TITLE
refactor: align theme color names with design, implement in main content

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -15,7 +15,7 @@ const NavBar = (): JSX.Element => {
   useEffect(() => {
     const changeBackgroundColor = () => {
       if (window.scrollY >= 90) {
-        setNavBackgroundColor("lightsalmon");
+        setNavBackgroundColor("salmonpink");
       } else {
         setNavBackgroundColor("transparent");
       }
@@ -84,7 +84,7 @@ const NavBar = (): JSX.Element => {
           className={`min-[768px]:hidden absolute ${
             nav ? "left-0" : "left-[-100%]"
           } top-0 bottom-0 right-0 flex justify-center items-center w-full
-          h-screen bg-darkorchid text-center ease-in duration-300`}
+          h-screen bg-frenchviolet text-center ease-in duration-300`}
         >
           <ul>
             <li className="p-4 text-5xl uppercase">

--- a/src/components/homepage/buttonwithicon/buttonwithicon.tsx
+++ b/src/components/homepage/buttonwithicon/buttonwithicon.tsx
@@ -34,13 +34,14 @@ const ButtonWithIcon = (props: Props): JSX.Element => {
           background: `${fullConfig.theme.colors[props.fillColor]}`,
           textTransform: "none",
           color: `${fullConfig.theme.colors[props.labelColor]}`,
+          fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
           fontSize: "clamp(1.125rem, 1vw + 0.1rem, 1.25rem)",
           fontStyle: "normal",
           fontWeight: 700,
           lineHeight: "1.5rem",
           letterSpacing: "0.00938rem",
-          '&:hover': {
-            boxShadow: '3px 3px 5px rgba(0, 0, 0, 0.3)',
+          "&:hover": {
+            boxShadow: "3px 3px 5px rgba(0, 0, 0, 0.3)",
             backgroundColor: `${fullConfig.theme.colors[props.fillColor]}`,
             color: `${fullConfig.theme.colors[props.labelColor]}`,
           },

--- a/src/components/homepage/cardwithimage/cardwithimage.tsx
+++ b/src/components/homepage/cardwithimage/cardwithimage.tsx
@@ -15,7 +15,7 @@ interface Props {
 const CardWithImage = (props: Props): JSX.Element => {
   return (
     <div className="flex flex-col items-start">
-      <div className="h-[12.9375rem] w-[22.3125rem] relative border-4 border-solid border-lightsalmon shadow-[2px_4px_0px_0px_darkorchid] max-sm:h-[14rem] max-sm:w-[20rem]">
+      <div className="h-[12.9375rem] w-[22.3125rem] relative border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet] max-sm:h-[14rem] max-sm:w-[20rem]">
         <Link href={props.url}>
           <Image
             priority
@@ -34,7 +34,7 @@ const CardWithImage = (props: Props): JSX.Element => {
       </div>
       <a
         href={props.url}
-        className="text-darkorchid text-[0.6875rem] font-bold leading-4 tracking-[0.03125rem] uppercase mt-[1.25rem]"
+        className="text-frenchviolet text-[0.6875rem] font-bold leading-4 tracking-[0.03125rem] uppercase mt-[1.25rem]"
       >
         Learn More
       </a>

--- a/src/components/homepage/footer/footer.tsx
+++ b/src/components/homepage/footer/footer.tsx
@@ -25,36 +25,41 @@ import facebookIcon from "@/public/logos/facebook-purple-icon.svg";
 import xIcon from "@/public/logos/x-purple-icon.svg";
 import sendIcon from "@/public/logos/send-icon.svg";
 
+import resolveConfig from "tailwindcss/resolveConfig";
+import tailwindConfig from "tailwind.config.js";
+
+const fullConfig = resolveConfig(tailwindConfig);
+
 const Footer = (): JSX.Element => {
   const CssTextField = withStyles({
     root: {
       "& label.Mui-focused": {
-        color: "#7e1cc4",
+        color: `${fullConfig.theme.colors["frenchviolet"]}`,
       },
       "& label": {
-        color: "#CAC4D0",
+        color: `${fullConfig.theme.colors["lightgray"]}`,
       },
       "& .MuiInput-underline:after": {
-        borderBottomColor: "#7e1cc4",
+        borderBottomColor: `${fullConfig.theme.colors["frenchviolet"]}`,
       },
       "& .MuiOutlinedInput-root": {
         "& fieldset": {
-          borderColor: "#CAC4D0",
+          borderColor: `${fullConfig.theme.colors["lightgray"]}`,
         },
         "&.Mui-focused input": {
           "--tw-ring-color": "none",
           outline: "none",
         },
         "&:hover fieldset": {
-          borderColor: "#CAC4D0",
+          borderColor: `${fullConfig.theme.colors["lightgray"]}`,
         },
         "&.Mui-focused fieldset": {
-          borderColor: "#7e1cc4",
+          borderColor: `${fullConfig.theme.colors["frenchviolet"]}`,
           outline: "none",
         },
       },
       "& input": {
-        color: "#CAC4D0",
+        color: `${fullConfig.theme.colors["lightgray"]}`,
       },
     },
   })(TextField);
@@ -228,19 +233,19 @@ const Footer = (): JSX.Element => {
           </div>
 
           <ul className="flex flex-col justify-center gap-5 items-start flex-[26.8]">
-            <li className="uppercase text-lightsalmon text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
+            <li className="uppercase text-salmonpink text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
               <Link href="/">Home</Link>
             </li>
-            <li className="uppercase text-lightsalmon text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
+            <li className="uppercase text-salmonpink text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
               <Link href="/advisory">Advisory</Link>
             </li>
-            <li className="uppercase text-lightsalmon text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
+            <li className="uppercase text-salmonpink text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
               <Link href="/news">News</Link>
             </li>
-            <li className="uppercase text-lightsalmon text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
+            <li className="uppercase text-salmonpink text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
               <Link href="/about">About</Link>
             </li>
-            <li className="uppercase text-lightsalmon text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
+            <li className="uppercase text-salmonpink text-center text-xl-rfs leading-4 tracking-[0.03125rem]">
               <Link href="/contact">Contact Us</Link>
             </li>
           </ul>
@@ -249,7 +254,7 @@ const Footer = (): JSX.Element => {
             <div className=" text-white text-2xl-rfs leading-8 tracking-[0.03125rem]">
               Sign up for our newsletter!
             </div>
-            <div className=" text-lightsalmon text-xl-rfs leading-6 tracking-[0.03125rem]">
+            <div className=" text-salmonpink text-xl-rfs leading-6 tracking-[0.03125rem]">
               For all the latest and greatest
             </div>
             <div className="relative mt-[1.25rem]">

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -28,8 +28,8 @@ const modalBoxStyle = {
   width: "90%",
   maxWidth: "1068px",
   maxHeight: "100vh",
-  color: "white",
-  bgcolor: "#1e1e1e",
+  color: `${fullConfig.theme.colors["white"]}`,
+  bgcolor: `${fullConfig.theme.colors["almostblack"]}`,
   border: "2px solid #000",
   boxShadow: 24,
   p: 4,
@@ -42,7 +42,7 @@ const modalBtnStyle = {
   fontSize: "1em",
   fontWeight: 700,
   width: "unset",
-  color: `${fullConfig.theme.colors["darkorchid"]}`,
+  color: `${fullConfig.theme.colors["frenchviolet"]}`,
   textTransform: "uppercase",
 };
 
@@ -230,7 +230,7 @@ const About: NextPage = () => {
                           <img
                             loading="lazy"
                             srcSet={item.image}
-                            className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-lightsalmon shadow-[2px_4px_0px_0px_darkorchid]"
+                            className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet]"
                             alt={item.name}
                           />
                         </div>

--- a/src/pages/advisory.tsx
+++ b/src/pages/advisory.tsx
@@ -25,8 +25,8 @@ const modalBoxStyle = {
   width: "90%",
   maxWidth: "1068px",
   maxHeight: "100vh",
-  color: "white",
-  bgcolor: "#1e1e1e",
+  color: `${fullConfig.theme.colors["white"]}`,
+  bgcolor: `${fullConfig.theme.colors["almostblack"]}`,
   border: "2px solid #000",
   boxShadow: 24,
   p: 4,
@@ -39,7 +39,7 @@ const modalBtnStyle = {
   fontSize: "1em",
   fontWeight: 700,
   width: "unset",
-  color: `${fullConfig.theme.colors["darkorchid"]}`,
+  color: `${fullConfig.theme.colors["frenchviolet"]}`,
   textTransform: "uppercase",
 };
 
@@ -185,7 +185,7 @@ const Advisory: NextPage = () => {
                             <img
                               loading="lazy"
                               srcSet={item.image}
-                              className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-lightsalmon shadow-[2px_4px_0px_0px_darkorchid]"
+                              className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet]"
                               alt={item.name}
                             />
                           </div>
@@ -243,7 +243,7 @@ const Advisory: NextPage = () => {
                         <img
                           loading="lazy"
                           srcSet={item.image}
-                          className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-lightsalmon shadow-[2px_4px_0px_0px_darkorchid]"
+                          className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet]"
                           alt={item.name}
                         />
                       </div>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -33,36 +33,39 @@ const Contact: NextPage = () => {
   const CssTextField = withStyles({
     root: {
       "& label.Mui-focused": {
-        color: "#49454F",
+        color: `${fullConfig.theme.colors["darkgray"]}`,
       },
       "& label": {
-        color: "#49454F",
+        color: `${fullConfig.theme.colors["darkgray"]}`,
       },
       "& .MuiInput-underline:after": {
-        borderBottomColor: "#79747E",
+        borderBottomColor: `${fullConfig.theme.colors["darkgray"]}`,
       },
       "& .MuiOutlinedInput-root": {
         "& fieldset": {
-          borderColor: "#CAC4D0",
+          borderColor: `${fullConfig.theme.colors["darkgray"]}`,
         },
         "&.Mui-focused input": {
-          "--tw-ring-color": "#79747E",
+          "--tw-ring-color": "none",
+          outline: "none",
+        },
+        "&.Mui-focused textarea": {
+          "--tw-ring-color": "none",
           outline: "none",
         },
         "&:hover fieldset": {
-          borderColor: "#CAC4D0",
+          borderColor: `${fullConfig.theme.colors["darkgray"]}`,
         },
         "&.Mui-focused fieldset": {
-          borderColor: "#79747E",
+          borderColor: `${fullConfig.theme.colors["darkgray"]}`,
           outline: "none",
         },
       },
       "& input": {
-        color: `${fullConfig.theme.colors["almostblack"]}`,
-        outline: "none",
+        color: `${fullConfig.theme.colors["darkgray"]}`,
       },
       "& textarea": {
-        color: `${fullConfig.theme.colors["almostblack"]}`,
+        color: `${fullConfig.theme.colors["darkgray"]}`,
         outline: "none",
       },
     },
@@ -193,7 +196,7 @@ const Contact: NextPage = () => {
                       height: "2.5rem",
                       width: "6em",
                       borderRadius: "6.25rem",
-                      background: `${fullConfig.theme.colors["darkorchid"]}`,
+                      background: `${fullConfig.theme.colors["frenchviolet"]}`,
                       textTransform: "none",
                       color: `${fullConfig.theme.colors["white"]}`,
                       fontSize: "clamp(1.125rem, 1vw + 0.5rem, 1.25rem)",
@@ -212,10 +215,10 @@ const Contact: NextPage = () => {
                     sx={{
                       height: "2.5rem",
                       borderRadius: "6.25rem",
-                      borderColor: `${fullConfig.theme.colors["darkorchid"]}`,
+                      borderColor: `${fullConfig.theme.colors["frenchviolet"]}`,
                       background: 'none',
                       textTransform: "none",
-                      color: `${fullConfig.theme.colors["darkorchid"]}`,
+                      color: `${fullConfig.theme.colors["frenchviolet"]}`,
                       fontFamily: "nunito",
                       fontSize: "clamp(1.125rem, 1vw + 0.5rem, 1.25rem)",
                       fontStyle: "normal",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,6 +37,11 @@ import CardWithImage from "@/components/homepage/cardwithimage/cardwithimage";
 import Footer from "@/components/homepage/footer";
 import Card from "@/components/homepage/card";
 
+import resolveConfig from "tailwindcss/resolveConfig";
+import tailwindConfig from "tailwind.config.js";
+
+const fullConfig = resolveConfig(tailwindConfig);
+
 interface HomePageProps {
   newsItem: PostData[];
 }
@@ -163,7 +168,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
             Coming Soon
           </div>
           <div className="max-md:hidden self-end text-center pr-[20%] mt-auto">
-            <div className="text-darkorchid text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
+            <div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
               Learn More
             </div>
             <div className="mx-auto w-[1.25rem] h-[1.25rem]">
@@ -176,7 +181,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
               >
                 <path
                   d="M9 15L0.339745 0L17.6603 0L9 15Z"
-                  className="fill-darkorchid"
+                  className="fill-frenchviolet"
                 />
               </svg>
             </div>
@@ -191,7 +196,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
             />
           </div>
           <div className="max-md:hidden self-end text-center pr-[20%] mt-auto">
-            <div className="text-darkorchid text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
+            <div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
               Learn More
             </div>
             <div className="mx-auto w-[1.25rem] h-[1.25rem]">
@@ -204,7 +209,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
               >
                 <path
                   d="M9 15L0.339745 0L17.6603 0L9 15Z"
-                  className="fill-darkorchid"
+                  className="fill-frenchviolet"
                 />
               </svg>
             </div>
@@ -214,7 +219,8 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
         <div className="flex flex-col gap-8 items-center justify-center px-[5%] max-md:h-fit max-md:mt-[15%]">
           <div className="md:mx-auto max-w-[26.43rem]  max-md:w-full text-justify">
             <p className="text-almostblack text-2xl-rfs font-normal leading-8">
-              A <span className="text-darkorchid font-bold">free platform</span>{" "}
+              A{" "}
+              <span className="text-frenchviolet font-bold">free platform</span>{" "}
               to discover and practice with place-based data for health equity,
               connecting the Social Determinants of Health to communities,
               researchers, policymakers, & health practitioners.
@@ -225,7 +231,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
               <ButtonWithIcon
                 label={"Data Discovery"}
                 svgIcon={dataDiscoveryIcon}
-                fillColor={"lightsalmon"}
+                fillColor={"salmonpink"}
                 labelColor={"almostblack"}
                 onClick={scrollToComingSoon}
               ></ButtonWithIcon>
@@ -234,14 +240,14 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
               <ButtonWithIcon
                 label={"Community Toolkit"}
                 svgIcon={communityToolkitIcon}
-                fillColor={"darkorchid"}
+                fillColor={"frenchviolet"}
                 labelColor={"white"}
                 onClick={scrollToComingSoon}
               ></ButtonWithIcon>
             </div>
           </div>
           {/* <div className="md:hidden self-center text-center mt-[5%]">
-            <div className="text-darkorchid text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
+            <div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
               Learn More
             </div>
             <div className="mx-auto w-[1.25rem] h-[1.25rem]">
@@ -254,14 +260,14 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
               >
                 <path
                   d="M9 15L0.339745 0L17.6603 0L9 15Z"
-                  className="fill-darkorchid"
+                  className="fill-frenchviolet"
                 />
               </svg>
             </div>
           </div> */}
         </div>
         <div className="md:hidden text-center">
-          <div className="text-darkorchid text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase max-[460px]:mt-[7%]">
+          <div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase max-[460px]:mt-[7%]">
             Learn More
           </div>
           <div className="mx-auto w-[1.25rem] h-[1.25rem]">
@@ -274,7 +280,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
             >
               <path
                 d="M9 15L0.339745 0L17.6603 0L9 15Z"
-                className="fill-darkorchid"
+                className="fill-frenchviolet"
               />
             </svg>
           </div>
@@ -308,7 +314,10 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
               </div>
               <div className=" text-2xl-rfs font-normal leading-8 text-end">
                 <Link
-                  style={{ textTransform: "uppercase", color: "#7e1cc4" }}
+                  style={{
+                    textTransform: "uppercase",
+                    color: `${fullConfig.theme.colors["frenchviolet"]}`,
+                  }}
                   href="/news"
                 >
                   All News & Updates
@@ -331,7 +340,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
         </div>
       </div>
 
-      <div className="w-full h-auto bg-darkorchid">
+      <div className="w-full h-auto bg-frenchviolet">
         <div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem] grid grid-flow-row max-md:grid-rows-[1fr_1fr] max-md:gap-y-12 md:grid-flow-col md:grid-cols-[1fr_2fr] text-start">
           <div className="my-auto text-white text-2xl-rfs font-normal leading-8 px-[5.5%]">
             Brought to you by
@@ -387,12 +396,12 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
                 </div>
 
                 <div className="flex flex-row gap-6 items-center">
-                  <div className="text-darkorchid font-nunito text-base-rfs leading-8 tracking-[0.25rem] uppercase text-center">
+                  <div className="text-frenchviolet font-nunito text-base-rfs leading-8 tracking-[0.25rem] uppercase text-center">
                     <div>
                       <ButtonWithIcon
                         label={"Data Discovery"}
                         svgIcon={dataDiscoveryIcon}
-                        fillColor={"lightsalmon"}
+                        fillColor={"salmonpink"}
                         labelColor={"almostblack"}
                         onClick={scrollToComingSoon}
                         disabled={true}
@@ -427,7 +436,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
                     <ButtonWithIcon
                       label={"Community Toolkit"}
                       svgIcon={communityToolkitIcon}
-                      fillColor={"darkorchid"}
+                      fillColor={"frenchviolet"}
                       labelColor={"white"}
                       onClick={scrollToComingSoon}
                       disabled={true}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -31,5 +31,5 @@ h5 {
 }
 
 .navbar-title-active {
-  @apply text-darkorchid before:content-[''] before:border-l-[0.25rem] before:border-darkorchid before:pr-[0.5rem];
+  @apply text-frenchviolet before:content-[''] before:border-l-[0.25rem] before:border-frenchviolet before:pr-[0.5rem];
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,14 +12,15 @@ module.exports = {
     extend: {
       colors: {
         white: "#fff",
-        almostblack: "#1e1e1e",
-        lightsalmon: "#ff9c77",
-        black: "#000",
-        darkorchid: "#7e1cc4",
-        mediumpurple: "#b379dd",
-        lightbisque: "#ffe5c4",
+        // lightgray used to be called ms_on_surface (a mui holdover)
+        lightgray: "#CAC4D0",
         neutralgray: "#AAA",
-        m3_on_surface: "#CAC4D0",
+        darkgray: "#79747e",
+        almostblack: "#1e1e1e",
+        black: "#000",
+        salmonpink: "#ff9c77",
+        frenchviolet: "#7e1cc4",
+        lightbisque: "#ffe5c4",
       },
       spacing: {},
       fontFamily: {


### PR DESCRIPTION
Closes #63.

Consolidate all colors throughout the main site into using the theme defined via Tailwind. The intention was to reduce the number of raw hex codes in the codebase, and align the names of colors with our design materials, to reduce future confusion.

One note: the components that build the blog admin/editing interface (in `components/news/`) still have a lot of boilerplate colors from before. Those pages are not public-facing though, so much lower priority to implement our theme there.
