### PR TITLE
Feature/#83: build the basic search feature for search page

### DIFF
--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -1,5 +1,5 @@
 import { SolrObject } from "../interface/SolrObject";
-import { SolrParent } from "../interface/SolrParent";
+import { SolrParent } from '../interface/SolrParent';
 import aardvark_json from "../../src/pages/search/_metadata/aardvark_schema.json";
 import sdoh_json from "../../src/pages/search/_metadata/sdohplace_schema.json";
 import { AardvarkSdohSchemaMatch, findFirstSentence } from "./util";
@@ -45,19 +45,23 @@ const initSolrObject = (rawSolrObject: any): SolrObject => {
  */
 const generateSolrParentList = (solrObjects: SolrObject[]): SolrParent[] => {
 	let result = [] as SolrParent[];
-
 	solrObjects
 		.filter((solrObject) => !solrObject.parents)
 		.forEach((parentObject) => {
 			let solrParent = {} as SolrParent;
 			solrParent.id = parentObject.id;
-			solrParent.title = parentObject.title;
+			solrParent.title = parentObject.title? parentObject.title : "";
 			solrParent.creator = parentObject.meta["creator"]
 				? parentObject.meta["creator"][0]
-				: undefined;
+				: "";
 			solrParent.description = parentObject.meta["description"]
 				? findFirstSentence(parentObject.meta["description"][0])
-				: undefined;
+				: "";
+			solrParent.meta = parentObject.meta? parentObject.meta : {};
+			solrParent.metadata_version = parentObject.metadata_version? parentObject.metadata_version : "";
+			solrParent.modified = parentObject.modified? parentObject.modified : "";
+			solrParent.access_rights = parentObject.access_rights? parentObject.access_rights : "";
+			solrParent.resource_class = parentObject.resource_class? parentObject.resource_class : "";
 			solrParent.years = new Set([]);
 			result.push(solrParent);
 		});

--- a/meta/interface/SolrObject.ts
+++ b/meta/interface/SolrObject.ts
@@ -20,6 +20,6 @@ export interface SolrObject {
   modified: string;
   access_rights: string;
   resource_class: string;
-  meta: any;
+  meta: {};
   parents?: string[];
 }

--- a/meta/interface/SolrParent.ts
+++ b/meta/interface/SolrParent.ts
@@ -2,6 +2,7 @@
 /**
  * ISSUE 75
  * Note that this interface use Aardvark's attribute name instead of raw Solr's attribute name
+ * Required attributes in SolrObject are also required here
  */
 export interface SolrParent {
   id: string;
@@ -9,4 +10,9 @@ export interface SolrParent {
   creator: string[];
   description: string;
   years: Set<string>; // use Set instead of array to avoid duplicate years, change this back to array if we want to see duplicate years
+  metadata_version: string;
+  modified: string;
+  access_rights: string;
+  resource_class: string;
+  meta: {};
 }

--- a/src/components/search/helper/SolrQueryBuilder.tsx
+++ b/src/components/search/helper/SolrQueryBuilder.tsx
@@ -1,0 +1,182 @@
+import { initSolrObject } from "meta/helper/solrObjects";
+import { SolrObject } from "meta/interface/SolrObject";
+
+export default class SolrQueryBuilder {
+	private query: QueryObject = {
+		solrUrl: process.env.NEXT_PUBLIC_SOLR_URL || "",
+		query: "",
+	};
+
+	// Method to set the basic query string. Don't call this. Call individual query methods instead.
+	// TODO: if our query will have more syntax, move the select part to individual query methods
+	setQuery(queryString: string): SolrQueryBuilder {
+		this.query.query = `${this.query.solrUrl}/select?q=${queryString}`;
+		return this;
+	}
+
+	public fetchResult(): Promise<SolrObject[]> {
+		console.log("Request query:", this.query.query);
+		return new Promise((resolve, reject) => {
+			fetch(this.query.query)
+				.then((res) => res.json())
+				.then((response) => {
+					const result = this.getSearchResult(response);
+					resolve(result);
+				})
+				.catch((error) => {
+					console.error("Error performing search:", error);
+					reject(error);
+				});
+		});
+	}
+
+	/**
+	 * Based on the response from solr, return a list of SolrObjects as the search result.
+	 * @param response_json object of the response from solr
+	 * @returns a list of SolrObjects as the search result. If no result, return empty list.
+	 */
+	getSearchResult(response_json: any): SolrObject[] {
+		let result = [] as SolrObject[];
+		const rawSolrObjects =
+			response_json.response && response_json.response.docs
+				? response_json.response.docs
+				: [];
+		rawSolrObjects.forEach((rawSolrObject) => {
+			result.push(initSolrObject(rawSolrObject));
+		});
+		return result;
+	}
+
+	/**
+	 * Search Methods based on Solr syntax. Not all methods are used in the search component
+	 *
+	 * Following methods are just placeholders for now.
+	 * Will add details/modify queries after we determine exact queries we want to perform.
+	 * */
+
+	public autocompleteQuery(
+		prefix: string,
+		limit: number = 10,
+		field: string = "dct_title_s"
+	): SolrQueryBuilder {
+		// TODO: switch this to geoblacklight's suggester and update method accordingly
+		//	const autocompleteQuery = `/suggest`;
+		// return this.setQuery(autocompleteQuery);
+
+		return this.prefixQuery(field, prefix);
+	}
+	public generalQuery(searchTerm: string) {
+		const generalQuery = `${searchTerm}`;
+		return this.setQuery(generalQuery);
+	}
+	public wildcardQuery(field: string, searchTerm: string): SolrQueryBuilder {
+		const wildcardQuery = `${field}:${searchTerm}*`;
+		return this.setQuery(wildcardQuery);
+	}
+	public regexQuery(field: string, regex: string): SolrQueryBuilder {
+		const regexQuery = `${field}:${regex}`;
+		return this.setQuery(regexQuery);
+	}
+	public fieldQuery(field: string, queryTerms: string): SolrQueryBuilder {
+		const fieldQuery = `${field}:${queryTerms}`;
+		return this.setQuery(fieldQuery);
+	}
+	public rangeQuery(
+		field: string,
+		startDate: string,
+		endDate: string
+	): SolrQueryBuilder {
+		const rangeQuery = `${field}:[${startDate} TO ${endDate}]`;
+		return this.setQuery(rangeQuery);
+	}
+	public fuzzyQuery(
+		field: string,
+		queryTerms: string,
+		fuzziness: number
+	): SolrQueryBuilder {
+		const fuzzyQuery = `${field}:${queryTerms}~${fuzziness}`;
+		return this.setQuery(fuzzyQuery);
+	}
+	public boostQuery(
+		field: string,
+		queryTerms: string,
+		boost: number
+	): SolrQueryBuilder {
+		const boostQuery = `${field}:${queryTerms}^${boost}`;
+		return this.setQuery(boostQuery);
+	}
+	public booleanQuery(
+		queryTerms: string,
+		operator: "AND" | "OR" | "NOT",
+		otherQueryTerms: string
+	): SolrQueryBuilder {
+		const booleanQuery = `${queryTerms} ${operator} ${otherQueryTerms}`;
+		return this.setQuery(booleanQuery);
+	}
+	public proximityQuery(
+		field: string,
+		queryTerms: string,
+		proximity: number
+	): SolrQueryBuilder {
+		const proximityQuery = `${field}:${queryTerms}~${proximity}`;
+		return this.setQuery(proximityQuery);
+	}
+	public phraseQuery(field: string, queryTerms: string): SolrQueryBuilder {
+		const phraseQuery = `${field}:"${queryTerms}"`;
+		return this.setQuery(phraseQuery);
+	}
+	public functionQuery(func: string, field: string): SolrQueryBuilder {
+		const functionQuery = `${func}(${field})`;
+		return this.setQuery(functionQuery);
+	}
+	public joinQuery(
+		field1: string,
+		queryTerms1: string,
+		field2: string,
+		queryTerms2: string
+	): SolrQueryBuilder {
+		const joinQuery = `${field1}:${queryTerms1} JOIN ${field2}:${queryTerms2}`;
+		return this.setQuery(joinQuery);
+	}
+	public prefixQuery(field: string, queryTerms: string): SolrQueryBuilder {
+		const prefixQuery = `${field}:${queryTerms}*`;
+		return this.setQuery(prefixQuery);
+	}
+	public moreLikeThisQuery(
+		field: string,
+		queryTerms: string
+	): SolrQueryBuilder {
+		const mltQuery = `mlt:${field}:${queryTerms}`;
+		return this.setQuery(mltQuery);
+	}
+	public geospatialQuery(
+		field: string,
+		queryTerms: string,
+		distance: string,
+		latitude: number,
+		longitude: number
+	): SolrQueryBuilder {
+		const geospatialQuery = `${field}:${queryTerms} WITHIN ${distance} OF ${latitude},${longitude}`;
+		return this.setQuery(geospatialQuery);
+	}
+	public termRangeQuery(
+		field: string,
+		startTerm: string,
+		endTerm: string
+	): SolrQueryBuilder {
+		const termRangeQuery = `${field}:[${startTerm} TO ${endTerm}]`;
+		return this.setQuery(termRangeQuery);
+	}
+
+	// If we need to add sorting
+	public addSort(
+		field: string,
+		order: "asc" | "desc" = "asc"
+	): SolrQueryBuilder {
+		if (!this.query.sort) {
+			this.query.sort = [];
+		}
+		this.query.sort.push(`${field} ${order}`);
+		return this;
+	}
+}

--- a/src/components/search/helper/SolrQueryBuilder.tsx
+++ b/src/components/search/helper/SolrQueryBuilder.tsx
@@ -10,13 +10,13 @@ export default class SolrQueryBuilder {
 	// Method to set the basic query string. Don't call this. Call individual query methods instead.
 	// TODO: if our query will have more syntax, move the select part to individual query methods
 	setQuery(queryString: string): SolrQueryBuilder {
-		this.query.query = `${this.query.solrUrl}/select?q=${queryString}`;
+		this.query.query = `${this.query.solrUrl}/${queryString}`;
 		return this;
 	}
 
 	public fetchResult(): Promise<SolrObject[]> {
-		console.log("Request query:", this.query.query);
 		return new Promise((resolve, reject) => {
+			console.log("fetching query:", this.query.query)
 			fetch(this.query.query)
 				.then((res) => res.json())
 				.then((response) => {
@@ -35,138 +35,144 @@ export default class SolrQueryBuilder {
 	 * @param response_json object of the response from solr
 	 * @returns a list of SolrObjects as the search result. If no result, return empty list.
 	 */
-	getSearchResult(response_json: any): SolrObject[] {
+	getSearchResult(response_json: {}): any {
 		let result = [] as SolrObject[];
+
+		//if return suggest
+		if (response_json["suggest"]) return response_json;
+		//if return select
 		const rawSolrObjects =
-			response_json.response && response_json.response.docs
-				? response_json.response.docs
+			response_json["response"] && response_json["response"].docs
+				? response_json["response"].docs
 				: [];
 		rawSolrObjects.forEach((rawSolrObject) => {
 			result.push(initSolrObject(rawSolrObject));
 		});
 		return result;
 	}
+	escapeQueryChars(input: string): string {
+		if (!input) return "*";
+		return input.replace(/[-!(){}[\]^"~:*?\\]/g, "\\$&");
+	}
 
 	/**
 	 * Search Methods based on Solr syntax. Not all methods are used in the search component
-	 *
-	 * Following methods are just placeholders for now.
-	 * Will add details/modify queries after we determine exact queries we want to perform.
 	 * */
 
-	public autocompleteQuery(
-		prefix: string,
-		limit: number = 10,
-		field: string = "dct_title_s"
-	): SolrQueryBuilder {
-		// TODO: switch this to geoblacklight's suggester and update method accordingly
-		//	const autocompleteQuery = `/suggest`;
-		// return this.setQuery(autocompleteQuery);
-
-		return this.prefixQuery(field, prefix);
+	public suggestQuery(searchTerm: string): SolrQueryBuilder {
+		const suggestQuery = `suggest?q=${this.escapeQueryChars(searchTerm)}`;
+		return this.setQuery(suggestQuery);
+	}
+	public contentQuery(searchTerm: string): SolrQueryBuilder {
+		const contentQuery = `select?q=content:"${this.escapeQueryChars(
+			searchTerm
+		)}"`;
+		return this.setQuery(contentQuery);
 	}
 	public generalQuery(searchTerm: string) {
-		const generalQuery = `${searchTerm}`;
+		const generalQuery = `select?q=${this.escapeQueryChars(searchTerm)}`;
 		return this.setQuery(generalQuery);
 	}
-	public wildcardQuery(field: string, searchTerm: string): SolrQueryBuilder {
-		const wildcardQuery = `${field}:${searchTerm}*`;
-		return this.setQuery(wildcardQuery);
-	}
-	public regexQuery(field: string, regex: string): SolrQueryBuilder {
-		const regexQuery = `${field}:${regex}`;
-		return this.setQuery(regexQuery);
-	}
-	public fieldQuery(field: string, queryTerms: string): SolrQueryBuilder {
-		const fieldQuery = `${field}:${queryTerms}`;
-		return this.setQuery(fieldQuery);
-	}
-	public rangeQuery(
-		field: string,
-		startDate: string,
-		endDate: string
-	): SolrQueryBuilder {
-		const rangeQuery = `${field}:[${startDate} TO ${endDate}]`;
-		return this.setQuery(rangeQuery);
-	}
-	public fuzzyQuery(
-		field: string,
-		queryTerms: string,
-		fuzziness: number
-	): SolrQueryBuilder {
-		const fuzzyQuery = `${field}:${queryTerms}~${fuzziness}`;
-		return this.setQuery(fuzzyQuery);
-	}
-	public boostQuery(
-		field: string,
-		queryTerms: string,
-		boost: number
-	): SolrQueryBuilder {
-		const boostQuery = `${field}:${queryTerms}^${boost}`;
-		return this.setQuery(boostQuery);
-	}
-	public booleanQuery(
-		queryTerms: string,
-		operator: "AND" | "OR" | "NOT",
-		otherQueryTerms: string
-	): SolrQueryBuilder {
-		const booleanQuery = `${queryTerms} ${operator} ${otherQueryTerms}`;
-		return this.setQuery(booleanQuery);
-	}
-	public proximityQuery(
-		field: string,
-		queryTerms: string,
-		proximity: number
-	): SolrQueryBuilder {
-		const proximityQuery = `${field}:${queryTerms}~${proximity}`;
-		return this.setQuery(proximityQuery);
-	}
-	public phraseQuery(field: string, queryTerms: string): SolrQueryBuilder {
-		const phraseQuery = `${field}:"${queryTerms}"`;
-		return this.setQuery(phraseQuery);
-	}
-	public functionQuery(func: string, field: string): SolrQueryBuilder {
-		const functionQuery = `${func}(${field})`;
-		return this.setQuery(functionQuery);
-	}
-	public joinQuery(
-		field1: string,
-		queryTerms1: string,
-		field2: string,
-		queryTerms2: string
-	): SolrQueryBuilder {
-		const joinQuery = `${field1}:${queryTerms1} JOIN ${field2}:${queryTerms2}`;
-		return this.setQuery(joinQuery);
-	}
-	public prefixQuery(field: string, queryTerms: string): SolrQueryBuilder {
-		const prefixQuery = `${field}:${queryTerms}*`;
-		return this.setQuery(prefixQuery);
-	}
-	public moreLikeThisQuery(
-		field: string,
-		queryTerms: string
-	): SolrQueryBuilder {
-		const mltQuery = `mlt:${field}:${queryTerms}`;
-		return this.setQuery(mltQuery);
-	}
-	public geospatialQuery(
-		field: string,
-		queryTerms: string,
-		distance: string,
-		latitude: number,
-		longitude: number
-	): SolrQueryBuilder {
-		const geospatialQuery = `${field}:${queryTerms} WITHIN ${distance} OF ${latitude},${longitude}`;
-		return this.setQuery(geospatialQuery);
-	}
-	public termRangeQuery(
-		field: string,
-		startTerm: string,
-		endTerm: string
-	): SolrQueryBuilder {
-		const termRangeQuery = `${field}:[${startTerm} TO ${endTerm}]`;
-		return this.setQuery(termRangeQuery);
-	}
+
+	// UNCOMMENT THE FOLLOWING METHODS IF NEEDED
+	// public wildcardQuery(field: string, searchTerm: string): SolrQueryBuilder {
+	// 	const wildcardQuery = `select?q=${field}:${this.escapeQueryChars(searchTerm)}*`;
+	// 	return this.setQuery(wildcardQuery);
+	// }
+	// public regexQuery(field: string, regex: string): SolrQueryBuilder {
+	// 	const regexQuery = `select?q=${field}:${regex}`;
+	// 	return this.setQuery(regexQuery);
+	// }
+	// public fieldQuery(field: string, queryTerms: string): SolrQueryBuilder {
+	// 	const fieldQuery = `select?q=${field}:${queryTerms}`;
+	// 	return this.setQuery(fieldQuery);
+	// }
+	// public rangeQuery(
+	// 	field: string,
+	// 	startDate: string,
+	// 	endDate: string
+	// ): SolrQueryBuilder {
+	// 	const rangeQuery = `select?q=${field}:[${startDate} TO ${endDate}]`;
+	// 	return this.setQuery(rangeQuery);
+	// }
+	// public fuzzyQuery(
+	// 	field: string,
+	// 	queryTerms: string,
+	// 	fuzziness: number
+	// ): SolrQueryBuilder {
+	// 	const fuzzyQuery = `select?q=${field}:${queryTerms}~${fuzziness}`;
+	// 	return this.setQuery(fuzzyQuery);
+	// }
+	// public boostQuery(
+	// 	field: string,
+	// 	queryTerms: string,
+	// 	boost: number
+	// ): SolrQueryBuilder {
+	// 	const boostQuery = `select?q=${field}:${queryTerms}^${boost}`;
+	// 	return this.setQuery(boostQuery);
+	// }
+	// public booleanQuery(
+	// 	queryTerms: string,
+	// 	operator: "AND" | "OR" | "NOT",
+	// 	otherQueryTerms: string
+	// ): SolrQueryBuilder {
+	// 	const booleanQuery = `select?q=${queryTerms} ${operator} ${otherQueryTerms}`;
+	// 	return this.setQuery(booleanQuery);
+	// }
+	// public proximityQuery(
+	// 	field: string,
+	// 	queryTerms: string,
+	// 	proximity: number
+	// ): SolrQueryBuilder {
+	// 	const proximityQuery = `select?q=${field}:${queryTerms}~${proximity}`;
+	// 	return this.setQuery(proximityQuery);
+	// }
+	// public phraseQuery(field: string, queryTerms: string): SolrQueryBuilder {
+	// 	const phraseQuery = `select?q=${field}:"${queryTerms}"`;
+	// 	return this.setQuery(phraseQuery);
+	// }
+	// public functionQuery(func: string, field: string): SolrQueryBuilder {
+	// 	const functionQuery = `select?q=${func}(${field})`;
+	// 	return this.setQuery(functionQuery);
+	// }
+	// public joinQuery(
+	// 	field1: string,
+	// 	queryTerms1: string,
+	// 	field2: string,
+	// 	queryTerms2: string
+	// ): SolrQueryBuilder {
+	// 	const joinQuery = `select?q=${field1}:${queryTerms1} JOIN ${field2}:${queryTerms2}`;
+	// 	return this.setQuery(joinQuery);
+	// }
+	// public prefixQuery(field: string, queryTerms: string): SolrQueryBuilder {
+	// 	const prefixQuery = `select?q=${field}:${queryTerms}*`;
+	// 	return this.setQuery(prefixQuery);
+	// }
+	// public moreLikeThisQuery(
+	// 	field: string,
+	// 	queryTerms: string
+	// ): SolrQueryBuilder {
+	// 	const mltQuery = `select?q=mlt:${field}:${queryTerms}`;
+	// 	return this.setQuery(mltQuery);
+	// }
+	// public geospatialQuery(
+	// 	field: string,
+	// 	queryTerms: string,
+	// 	distance: string,
+	// 	latitude: number,
+	// 	longitude: number
+	// ): SolrQueryBuilder {
+	// 	const geospatialQuery = `select?q=${field}:${queryTerms} WITHIN ${distance} OF ${latitude},${longitude}`;
+	// 	return this.setQuery(geospatialQuery);
+	// }
+	// public termRangeQuery(
+	// 	field: string,
+	// 	startTerm: string,
+	// 	endTerm: string
+	// ): SolrQueryBuilder {
+	// 	const termRangeQuery = `select?q=${field}:[${startTerm} TO ${endTerm}]`;
+	// 	return this.setQuery(termRangeQuery);
+	// }
 
 	// If we need to add sorting
 	public addSort(

--- a/src/components/search/helper/SuggestedResultBuilder.tsx
+++ b/src/components/search/helper/SuggestedResultBuilder.tsx
@@ -1,0 +1,35 @@
+import TermResult from "../interface/TermResult";
+
+// include methods to parse the suggested result from the Solr query
+export default class SuggestedResultBuilder {
+	private result = {} as TermResult;
+	private term = [] as string[];
+	private suggester = "mySuggester" as string; // change this later
+	private suggestInput = "*" as string; // change this later
+	getTerms(): string[] {
+		return this.term;
+	}
+	setSuggestInput(input: string): void {
+		this.suggestInput = input;
+	}
+	setSuggester(suggester: string): void {
+		this.suggester = suggester;
+	}
+	setResultTerms(result: string): void {
+		this.result = JSON.parse(result) as TermResult;
+		console.log("setResultTerms", this.result);
+		this.term = this.getTermsFromTermResult(this.result);
+	}
+
+	// Method to parse the suggested result from the Solr query
+	private getTermsFromTermResult(response_json: TermResult): string[] {
+		let result = [] as string[];
+		if (!this.suggestInput) return result;
+		response_json.suggest[this.suggester][
+			this.suggestInput
+		].suggestions.forEach((res) => {
+			result.push(res["term"]);
+		});
+		return result;
+	}
+}

--- a/src/components/search/interface/QueryObject.tsx
+++ b/src/components/search/interface/QueryObject.tsx
@@ -1,0 +1,10 @@
+/**
+ * Interface for a Solr query object
+ * Defines the properties of a Solr query object
+ * 
+*/
+interface QueryObject {
+    solrUrl: string;
+	query: string;
+	sort?: string[];
+}

--- a/src/components/search/interface/SearchObject.tsx
+++ b/src/components/search/interface/SearchObject.tsx
@@ -1,0 +1,20 @@
+/**
+ * Define the search object that will be used to conduct query. 
+ * For now, only requires user input field and make optional fields as defined in http://52.14.175.140:3000/
+ */
+export interface SearchObject{
+    userInput: string;
+    year?: string;
+    place?: string;
+    resource_class?: string;
+    resource_type?: string;
+    format?: string;
+    subject?: string;
+    theme?: string;
+    creator?: string;
+    publisher?: string;
+    provider?: string;
+    spatial_solution?: string;
+    methods_variables?: string;
+    data_variables?: string;
+}

--- a/src/components/search/interface/TermResult.tsx
+++ b/src/components/search/interface/TermResult.tsx
@@ -1,0 +1,19 @@
+export default interface TermResult {
+	responseHeader: {
+		status: number;
+		QTime: number;
+	};
+	suggest: {
+		[key: string]: {
+			// This is a placeholder. The actual key is the name of the suggester
+			[key: string]: {
+				numFound: number;
+				suggestions: {
+					term: string;
+					weight: number;
+					payload: string;
+				}[];
+			};
+		};
+	};
+}

--- a/src/components/search/parentList.tsx
+++ b/src/components/search/parentList.tsx
@@ -24,41 +24,52 @@ export default function ParentList({
 		return (
 			<div>
 				<h3>Parent List</h3>
-				{solrParents.map((solrParent, index) => {
-					return (
-						<Accordion
-							key={solrParent.id}
-							expanded={expanded === solrParent.id}
-							onChange={handleChange(solrParent.id)}
-						>
-							<AccordionSummary
-								expandIcon={<ExpandMoreIcon />}
-								aria-controls={`${solrParent.id}bh-content`}
-								id={`${solrParent.id}bh-header`}
+				{solrParents.length === 0 ? (
+					<div>No parent found</div>
+				) : (
+					solrParents.map((solrParent, index) => {
+						return (
+							<Accordion
+								key={solrParent.id}
+								expanded={expanded === solrParent.id}
+								onChange={handleChange(solrParent.id)}
 							>
-								<Typography sx={{ color: "text.primary" }}>
-									{solrParent.title}
-								</Typography>
-							</AccordionSummary>
-							<AccordionDetails>
-								<List>
-									<ListItem>
-										Created by: {solrParent.creator}
-									</ListItem>
-									<ListItem>
-										Description: {solrParent.description}
-									</ListItem>
-									<ListItem>
-										Years:{" "}
-										{Array.from(solrParent.years).join(
-											", "
-										)}
-									</ListItem>
-								</List>
-							</AccordionDetails>
-						</Accordion>
-					);
-				})}
+								<AccordionSummary
+									expandIcon={<ExpandMoreIcon />}
+									aria-controls={`${solrParent.id}bh-content`}
+									id={`${solrParent.id}bh-header`}
+								>
+									<Typography sx={{ color: "text.primary" }}>
+										{solrParent.title}
+									</Typography>
+								</AccordionSummary>
+								<AccordionDetails>
+									<List>
+										<ListItem>
+											Created by: {solrParent.creator}
+										</ListItem>
+										<ListItem>
+											Description:{" "}
+											{solrParent.description}
+										</ListItem>
+										<ListItem>
+											Years:{" "}
+											{Array.from(solrParent.years).join(
+												", "
+											)}
+										</ListItem>
+										<ListItem>
+											Metadata:{" "}
+											{Object.values(solrParent.meta).join(
+												", "
+											)}
+										</ListItem>
+									</List>
+								</AccordionDetails>
+							</Accordion>
+						);
+					})
+				)}
 			</div>
 		);
 	else {

--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -1,0 +1,118 @@
+import { use, useState } from "react";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import { SolrObject } from "meta/interface/SolrObject";
+import { Autocomplete, Grid } from "@mui/material";
+import { SearchObject } from "./interface/SearchObject";
+import SearchResults from "./searchResults";
+import SolrQueryBuilder from "./helper/SolrQueryBuilder";
+
+export default function SearchArea(): JSX.Element {
+	const [fetchResults, setFetchResults] = useState<SolrObject[]>([]);
+	const [queryData, setQueryData] = useState<SearchObject>({
+		userInput: "",
+		// other attributes are pending to be added with the development of the search component
+	});
+	const [options, setOptions] = useState([]);
+	const [userInput, setUserInput] = useState("");
+	const [afterSearch, setAfterSearch] = useState(false);
+
+	let searchQueryBuilder = new SolrQueryBuilder();
+
+	const handleSearch = async () => {
+		searchQueryBuilder
+			.fetchResult()
+			.then((result) => {
+				setFetchResults(result);
+			})
+			.catch((error) => {
+				console.error("Error fetching result:", error);
+			});
+		setAfterSearch(true); // Set afterSearch to true after search to remove "You can start your search now."
+	};
+
+	const handleUserInputChange = async (event, value) => {
+		setUserInput(value);
+		setQueryData({
+			...queryData,
+			userInput: value,
+		});
+		searchQueryBuilder.autocompleteQuery(value); 
+		searchQueryBuilder
+			.fetchResult()
+			.then((result) => {
+				const autoCompleteResult = result.map((doc) => doc.title);
+				setOptions(autoCompleteResult);
+			})
+			.catch((error) => {
+				console.error("Error fetching result:", error);
+			});
+	};
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+		userInput.length === 0
+			? searchQueryBuilder.generalQuery("*")
+			: searchQueryBuilder.generalQuery(userInput); //change query type based on form's situation
+		handleSearch();
+	};
+	 const handleDropdownSelect = (event, value) => {
+			searchQueryBuilder.phraseQuery("dct_title_s", value);
+			handleSearch();
+		};
+
+	return (
+		<div className="flex flex-col">
+			<Grid container spacing={4}>
+				<form id="search-form" onSubmit={handleSubmit}>
+					<Grid container spacing={2} alignItems="center">
+						<Grid item xs={9}>
+							<Autocomplete
+								freeSolo
+								disableClearable
+								options={options}
+								onInputChange={(event, value) => {
+									if (event.type === "change") {
+										handleUserInputChange(event, value);
+									}
+								}}
+								onChange={(event, value) =>
+									handleDropdownSelect(event, value)
+								}
+								sx={{ width: 300 }}
+								renderInput={(params) => (
+									<TextField
+										{...params}
+										label="Search input"
+										variant="outlined"
+										fullWidth
+										InputProps={{
+											...params.InputProps,
+											type: "search",
+										}}
+									/>
+								)}
+							/>
+						</Grid>
+						<Grid item xs={3}>
+							<Button
+								type="submit"
+								variant="contained"
+								color="primary"
+								fullWidth
+							>
+								Search
+							</Button>
+						</Grid>
+					</Grid>
+				</form>
+			</Grid>
+			<Grid item xs={6}>
+				<SearchResults
+					searchResults={fetchResults}
+					afterSearch={afterSearch}
+				/>
+			</Grid>
+		</div>
+	);
+}

--- a/src/components/search/searchResults.tsx
+++ b/src/components/search/searchResults.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { List, ListItem, ListItemText, Typography } from "@mui/material";
+import { SolrObject } from "meta/interface/SolrObject";
+
+/**
+ * Display search results. Will be updated after re-design
+ */
+export default function SearchResults({
+	searchResults,
+    afterSearch
+}: {
+	searchResults: SolrObject[];
+    afterSearch: boolean;
+}): JSX.Element {
+    if (!afterSearch) {
+        return <Typography>You can start your search now.</Typography>;
+    }
+	return searchResults.length === 0 ? (
+		<Typography>No results found</Typography>
+	) : (
+		<List>
+			{searchResults.map((object, index) => (
+				<ListItem key={index}>
+					<ListItemText
+						primary={`Object ${index + 1}`}
+						secondary={
+							<React.Fragment>
+								{Object.entries(object).map(([key, value]) => (
+									<Typography
+										key={key}
+									>{`${key}: ${value}`}</Typography>
+								))}
+							</React.Fragment>
+						}
+					/>
+				</ListItem>
+			))}
+		</List>
+	);
+}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -19,6 +19,7 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "tailwind.config.js";
 import { Grid } from "@mui/material";
 import ParentList from "../../components/search/parentList";
+import SearchArea from "@/components/search/searchArea";
 
 const fullConfig = resolveConfig(tailwindConfig);
 
@@ -99,8 +100,8 @@ const Search: NextPage = () => {
 			.then((data) => {
 				setData(data);
 				setLoading(false);
-				
-        console.log("rawSolr ", data.response.docs);
+
+				console.log("rawSolr ", data.response.docs);
 
 				// test issue 74 and issue 75
 				const solrObjectResults = [];
@@ -108,7 +109,7 @@ const Search: NextPage = () => {
 					solrObjectResults.push(initSolrObject(doc));
 				});
 				setSolrObjectResults(solrObjectResults);
-        console.log("solrObjectResults ", solrObjectResults);
+				console.log("solrObjectResults ", solrObjectResults);
 			});
 	}, []);
 
@@ -181,6 +182,11 @@ const Search: NextPage = () => {
 							))}
 						</Grid>
 					</Grid>
+				</div>
+			</div>
+			<div className="flex flex-col">
+				<div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
+					<SearchArea />
 				</div>
 			</div>
 		</>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -6,20 +6,16 @@ import Modal from "@mui/material/Modal";
 import Box from "@mui/material/Box";
 import { useState, useEffect } from "react";
 
-import {
-	initSolrObject,
-	generateSolrParentList,
-} from "../../../meta/helper/solrObjects";
-
 import Header from "@/components/Header";
 import TopLines from "@/components/TopLines";
-import { SearchResults, getResults } from "@/components/SearchResults";
+import { SearchResults} from "@/components/SearchResults";
 
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "tailwind.config.js";
 import { Grid } from "@mui/material";
-import ParentList from "../../components/search/parentList";
 import SearchArea from "@/components/search/searchArea";
+import { initSolrObject } from "meta/helper/solrObjects";
+import { SolrObject } from "meta/interface/SolrObject";
 
 const fullConfig = resolveConfig(tailwindConfig);
 
@@ -91,7 +87,7 @@ const Search: NextPage = () => {
 	const handleClose = () => setOpen(false);
 
 	const [data, setData] = useState(null);
-	const [solrObjectResults, setSolrObjectResults] = useState([]);
+	const [solrObjectResults, setSolrObjectResults] = useState([] as SolrObject[]);
 	const [isLoading, setLoading] = useState(true);
 
 	useEffect(() => {
@@ -99,17 +95,13 @@ const Search: NextPage = () => {
 			.then((res) => res.json())
 			.then((data) => {
 				setData(data);
-				setLoading(false);
-
 				console.log("rawSolr ", data.response.docs);
-
-				// test issue 74 and issue 75
 				const solrObjectResults = [];
 				data.response.docs.map((doc, index) => {
 					solrObjectResults.push(initSolrObject(doc));
 				});
 				setSolrObjectResults(solrObjectResults);
-				console.log("solrObjectResults ", solrObjectResults);
+				setLoading(false);
 			});
 	}, []);
 
@@ -162,13 +154,9 @@ const Search: NextPage = () => {
 			<div className="flex flex-col">
 				<div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
 					<h1 className="font-fredoka">Data Discovery</h1>
-					<Grid container spacing={4}>
+					<Grid container mt={4}>
 						<Grid item xs={6}>
-							<ParentList
-								solrParents={generateSolrParentList(
-									solrObjectResults
-								)}
-							/>
+							<SearchArea results={solrObjectResults}/>
 						</Grid>
 						<Grid item xs={6}>
 							<h3>All Item List</h3>
@@ -182,11 +170,6 @@ const Search: NextPage = () => {
 							))}
 						</Grid>
 					</Grid>
-				</div>
-			</div>
-			<div className="flex flex-col">
-				<div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
-					<SearchArea />
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
This PR includes a basic search box and backend that we can do further extension later.

### How to Test

1. Run the app and navigate to http://localhost:3000/search.
2. You should see an unstyled basic search box at the bottom of the page. We can restyle it later.
Type anything in the search box:
- If there's any prefix match on the title, you should see a popup appear (Try "new" and you should see "new one" popup):
<img width="490" alt="Screenshot 2024-02-13 at 11 04 22 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/ff3104dc-b708-434f-b21c-c9b130f6f258">

- If you are typing stuff that won't have a *prefix match*, you won't see anything pop up

4. Click "new one" in the popup. You should see the exact object returned (we can choose to expand the object later; for now, I'm just outputting basic attributes of it).

<img width="490" alt="Screenshot 2024-02-13 at 11 34 04 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/1b932867-3598-4bb5-b475-0849c2ff009a">

6. Don't type anything in the search box, just click it. You should see all results available because this means the user is using the prefix `*`. We can disable this function later if we don't need it.
<img width="516" alt="Screenshot 2024-02-13 at 11 34 31 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/aaf219ce-5578-4efc-8c8b-1653130ae3f8">

 7. Type 'US' in the search box (representing random user input) and click 'Search', you see should multiple results returned because the general query `https://solr.sdohplace.org/solr/blacklight-core/select?q=US` is called:
<img width="538" alt="Screenshot 2024-02-13 at 11 33 12 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/8688b930-ef0d-4524-ae88-1f4cb710d967">

 8. Type 'US' in the search box again and select one result from the pop up, you should see only one result returned based on your selection:

<img width="510" alt="Screenshot 2024-02-13 at 11 33 33 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/5fb83bd5-0071-4407-a127-07b4eb05eab0">

 ### Future Actions
 
1. I'd like to know what the query syntax is for autocomplete in GeoBlacklight (sorry, I'm not very familiar with it). Currently, I just use prefix search for the title field. After I learn the detailed syntax, I'll replace it.
2. Currently, I only use user input to search, but I have defined other GeoBlacklight fields in the interface. After we finalize other criteria for searching, they will be used.
3. I have listed a variety of query methods, but currently, only general query and prefix query are used in this PR. Once we discuss the exact query features we need, we can call these methods.