### PR TITLE
#102: Add a button to start over user search

### DIFF
--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -122,21 +122,24 @@ export default function SearchArea({
 	};
 
 	const handleUserInputChange = async (event, value) => {
-		setUserInput(value);
 		setQueryData({
 			...queryData,
 			userInput: value,
 		});
-		searchQueryBuilder.suggestQuery(value);
-		searchQueryBuilder
-			.fetchResult()
-			.then((result) => {
-				processResults(result, value);
-				setOptions(suggestResultBuilder.getTerms());
-			})
-			.catch((error) => {
-				console.error("Error fetching result:", error);
-			});
+		if (value !== "") {
+			searchQueryBuilder.suggestQuery(value);
+			searchQueryBuilder
+				.fetchResult()
+				.then((result) => {
+					processResults(result, value);
+					setOptions(suggestResultBuilder.getTerms());
+				})
+				.catch((error) => {
+					console.error("Error fetching result:", error);
+				});
+		} else {
+			handleReset();
+		}
 	};
 
 	const handleSubmit = (event) => {
@@ -145,7 +148,6 @@ export default function SearchArea({
 		handleSearch(userInput);
 	};
 	const handleDropdownSelect = (event, value) => {
-		setUserInput(value);
 		searchQueryBuilder.suggestQuery(value);
 		handleSearch(value);
 	};
@@ -154,7 +156,18 @@ export default function SearchArea({
 		suggestResultBuilder.setSuggestInput(value);
 		suggestResultBuilder.setResultTerms(JSON.stringify(results));
 	};
-
+	const handleReset = () => {
+		setAutocompleteKey(autocompleteKey + 1);
+		setCheckboxes([]);
+		setCurrentFilter(
+			generateFilter(
+				allResults,
+				[],
+				filterAttributeList.map((filter) => filter.attribute)
+			)
+		);
+		setFetchResults(allResults);
+	};
 	const handleFilter = (attr, value) => (event) => {
 		const newCheckboxes = [...checkboxes];
 		if (
@@ -267,12 +280,16 @@ export default function SearchArea({
 									key={autocompleteKey}
 									freeSolo
 									options={options}
-									onInputChange={(event, value) => {
+									onInputChange={(event, value, reason) => {
 										if (event && event.type === "change") {
+
+											setUserInput(value);
 											handleUserInputChange(event, value);
 										}
 									}}
 									onChange={(event, value) => {
+
+		setUserInput(value);
 										handleDropdownSelect(event, value);
 									}}
 									sx={{ minWidth: 250 }}
@@ -313,18 +330,19 @@ export default function SearchArea({
 								color="primary"
 								fullWidth
 								onClick={() => {
-									setAutocompleteKey(autocompleteKey + 1);
-									setCheckboxes([]);
-									setCurrentFilter(
-										generateFilter(
-											allResults,
-											[],
-											filterAttributeList.map(
-												(filter) => filter.attribute
-											)
-										)
-									);
-									setFetchResults(allResults);
+									// setAutocompleteKey(autocompleteKey + 1);
+									// setCheckboxes([]);
+									// setCurrentFilter(
+									// 	generateFilter(
+									// 		allResults,
+									// 		[],
+									// 		filterAttributeList.map(
+									// 			(filter) => filter.attribute
+									// 		)
+									// 	)
+									// );
+									// setFetchResults(allResults);
+									handleReset();
 								}}
 							>
 								Clear Results

--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -10,9 +10,6 @@ import {
 	Checkbox,
 	Divider,
 	Grid,
-	IconButton,
-	InputAdornment,
-	Switch,
 	Typography,
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
@@ -21,13 +18,10 @@ import SolrQueryBuilder from "./helper/SolrQueryBuilder";
 import SuggestedResult from "./helper/SuggestedResultBuilder";
 import ParentList from "./parentList";
 import { generateSolrParentList } from "meta/helper/solrObjects";
-// import { SolrParent } from "meta/interface/SolrParent";
 import FilterObject from "./interface/FilterObject";
 import {
 	generateFilter,
-	filterResults,
-	runningFilter,
-	updateFilter,
+	runningFilter
 } from "./helper/FilterHelpMethods";
 
 export default function SearchArea({
@@ -330,22 +324,10 @@ export default function SearchArea({
 								color="primary"
 								fullWidth
 								onClick={() => {
-									// setAutocompleteKey(autocompleteKey + 1);
-									// setCheckboxes([]);
-									// setCurrentFilter(
-									// 	generateFilter(
-									// 		allResults,
-									// 		[],
-									// 		filterAttributeList.map(
-									// 			(filter) => filter.attribute
-									// 		)
-									// 	)
-									// );
-									// setFetchResults(allResults);
 									handleReset();
 								}}
 							>
-								Clear Results
+								Start Over
 							</Button>
 						</Grid>
 					) : null}


### PR DESCRIPTION
This PR is for issue #102, intending to perform the same functionality as the "Start Over" function currently available in the GeoBlacklight platform:
<img width="256" alt="Screenshot 2024-02-29 at 11 27 31 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/db2f1370-ad29-43e9-a670-3ed7c65f241c">

I also added the feature that when the user clicks the 'X' on the input button, we should treat it the same as if the user wants to start over (i.e., clear out all filters and reset both results and the input box).

## How to Test

1. Run the app and input "av" in the input box, then click "Search":
<img width="1191" alt="Screenshot 2024-02-29 at 11 30 37 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/0b7dd06c-ae51-4da5-a8e9-2f7ce261ecc7">

2. You should see all results based on the suggestions of "av" returned. Select any filter to apply it.

3. You should see a "Start Over" button appear. Click it.

4. Now all filters and results should be reset to their original status, and the input box should be cleared.

5. Run the app and input "av" in the input box, then click "Search" again. You can perform some filtering actions.

6. This time, click the 'x' button in the pop-up in the input box:
<img width="1057" alt="Screenshot 2024-02-29 at 11 34 45 AM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/e81a9c12-d7c1-4de9-95ac-6f66f375d9e2">

7. The same reset effect should apply to the page. All filters, the input box, and results should be reset.