### PR TITLE
#103: remember filter selection and display on top of the search result

### DIFF
--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -7,15 +7,14 @@ import {
 	AccordionDetails,
 	AccordionSummary,
 	Autocomplete,
+	Box,
 	Checkbox,
 	Divider,
 	Grid,
-	IconButton,
-	InputAdornment,
-	Switch,
 	Typography,
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import CloseIcon from "@mui/icons-material/Close";
 import { SearchObject } from "./interface/SearchObject";
 import SolrQueryBuilder from "./helper/SolrQueryBuilder";
 import SuggestedResult from "./helper/SuggestedResultBuilder";
@@ -33,6 +32,7 @@ import {
 	updateFilter,
 } from "./helper/FilterHelpMethods";
 import { fi } from "date-fns/locale";
+import CheckBoxObject from "./interface/CheckboxObject";
 
 export default function SearchArea({
 	results,
@@ -186,12 +186,6 @@ export default function SearchArea({
 	};
 
 	useEffect(() => {
-		console.log(
-			"all parent objects:",
-			fetchResults,
-			"their raw results:",
-			results
-		);
 		const generateFilterFromCurrentResults = generateFilter(
 			fetchResults,
 			checkboxes,
@@ -257,7 +251,25 @@ export default function SearchArea({
 			</Accordion>
 		) : null;
 	}
-
+	function filterStatusButton(c: CheckBoxObject) {
+		return (
+			<Button
+				key={c.value}
+				sx={{margin: "0.5em"}}
+				variant="outlined"
+				color="success"
+				endIcon={<CloseIcon />}
+				onClick={() => {
+					const cancelEvent = {
+						target: { checked: false },
+					};
+					handleFilter(c.attribute, c.value)(cancelEvent);
+				}}
+			>
+				{c.attribute}:{c.value}
+			</Button>
+		);
+	}
 	return (
 		<Grid container spacing={2}>
 			<Grid container xs={4}>
@@ -325,6 +337,11 @@ export default function SearchArea({
 				</Grid>
 			</Grid>
 			<Grid item xs={8}>
+				<Box sx={{ display: "flex", justifyContent: "flex-start" }}>
+					{checkboxes
+						.filter((c) => c.checked === true)
+						.map((c) => filterStatusButton(c))}
+				</Box>
 				<ParentList
 					solrParents={fetchResults}
 					filterAttributeList={filterAttributeList}


### PR DESCRIPTION
This PR is for #103. The purpose of this PR is to achieve the same function as the filter remembering feature in our GeoBlacklight platform.

### How to Test

1. Run the app and perform filter actions for default results or searched results.

2. You should see that every time you select a filter item, your choice is recorded at the top of the list section as a list of buttons:
<img width="1157" alt="Screenshot 2024-02-29 at 2 08 51 PM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/9a343573-2b2b-4e40-a721-98894da98ced">

3. Click on a button, and you should see that you performed a de-selection action and the result reverse back to your last step:
<img width="1196" alt="Screenshot 2024-02-29 at 2 09 08 PM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/1c27d795-b9a3-449f-ae05-8e4bdc64adef">

4. You should also see that if you de-select any filter from the filter list (instead of the button list), the button list automatically updates with your selection.

5. The start-over button will clear out the button list as it does the filter list.