### PR TITLE
#125: Fix style issues on contact us page and mobile display

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,114 +3,150 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { AiOutlineMenu, AiOutlineClose } from "react-icons/ai";
 import { useRouter } from "next/router";
+import { Box } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+
+const useStyles = makeStyles((theme) => ({
+	mobileHamburgerMenu: {
+		fontSize: "1.5rem",
+	},
+}));
 
 const NavBar = (): JSX.Element => {
-  const [nav, setNav] = useState(false);
-  const [navBackgroundColor, setNavBackgroundColor] = useState("transparent");
+	const [nav, setNav] = useState(false);
+	const [navBackgroundColor, setNavBackgroundColor] = useState("transparent");
 
-  const handleNav = () => {
-    setNav(!nav);
-  };
+	const handleNav = () => {
+		setNav(!nav);
+	};
 
-  useEffect(() => {
-    const changeBackgroundColor = () => {
-      if (window.scrollY >= 90) {
-        setNavBackgroundColor("salmonpink");
-      } else {
-        setNavBackgroundColor("transparent");
-      }
-    };
+	useEffect(() => {
+		const changeBackgroundColor = () => {
+			if (window.scrollY >= 90) {
+				setNavBackgroundColor("salmonpink");
+			} else {
+				setNavBackgroundColor("transparent");
+			}
+		};
+		window.addEventListener("scroll", changeBackgroundColor);
+	}, []);
 
-    window.addEventListener("scroll", changeBackgroundColor);
-  }, []);
+	const router = useRouter();
+	const classes = useStyles();
 
-  const router = useRouter();
+	return (
+		<div
+			className={`absolute left-0 top-0 w-full z-50 ease-in duration-300 bg-${navBackgroundColor}`}
+		>
+			<div
+				className={`flex justify-between items-center 2xl:max-w-[1536px] pt-8 pb-12 pl-0 pr-0 mx-auto`}
+			>
+				<ul className="hidden min-[768px]:flex pl-[2.5%]">
+					<li
+						className={`navbar-title ${
+							router.pathname == "/" && "navbar-title-active"
+						}`}
+					>
+						<Link href="/">Home</Link>
+					</li>
+					<li
+						className={`navbar-title ${
+							router.pathname == "/advisory" &&
+							"navbar-title-active"
+						}`}
+					>
+						<Link href="/advisory">Advisory</Link>
+					</li>
+					<li
+						className={`navbar-title ${
+							router.pathname.startsWith("/news") &&
+							"navbar-title-active"
+						}`}
+					>
+						<Link href="/news">News</Link>
+					</li>
+					<li
+						className={`navbar-title ${
+							router.pathname == "/about" && "navbar-title-active"
+						}`}
+					>
+						<Link href="/about">About</Link>
+					</li>
+					<li
+						className={`navbar-title ${
+							router.pathname == "/contact" &&
+							"navbar-title-active"
+						}`}
+					>
+						<Link href="/contact">Contact Us</Link>
+					</li>
+				</ul>
 
-  return (
-    <div
-      className={`absolute left-0 top-0 w-full z-50 ease-in duration-300 bg-${navBackgroundColor}`}
-    >
-      <div
-        className={`flex justify-between items-center 2xl:max-w-[1536px] pt-8 pb-12 pl-0 pr-0 mx-auto`}
-      >
-        <ul className="hidden min-[768px]:flex pl-[2.5%]">
-          <li
-            className={`navbar-title ${
-              router.pathname == "/" && "navbar-title-active"
-            }`}
-          >
-            <Link href="/">Home</Link>
-          </li>
-          <li
-            className={`navbar-title ${
-              router.pathname == "/advisory" && "navbar-title-active"
-            }`}
-          >
-            <Link href="/advisory">Advisory</Link>
-          </li>
-          <li
-            className={`navbar-title ${
-              router.pathname.startsWith("/news") && "navbar-title-active"
-            }`}
-          >
-            <Link href="/news">News</Link>
-          </li>
-          <li
-            className={`navbar-title ${
-              router.pathname == "/about" && "navbar-title-active"
-            }`}
-          >
-            <Link href="/about">About</Link>
-          </li>
-          <li
-            className={`navbar-title ${
-              router.pathname == "/contact" && "navbar-title-active"
-            }`}
-          >
-            <Link href="/contact">Contact Us</Link>
-          </li>
-        </ul>
+				{/* Mobile Button */}
+				<div
+					onClick={handleNav}
+					className="block min-[768px]:hidden pl-[25px] z-50"
+				>
+					{nav ? (
+						<AiOutlineClose size={35} color={"white"} />
+					) : (
+						<AiOutlineMenu size={35} />
+					)}
+				</div>
 
-        {/* Mobile Button */}
-        <div
-          onClick={handleNav}
-          className="block min-[768px]:hidden pl-[25px] z-50"
-        >
-          {nav ? (
-            <AiOutlineClose size={35} color={"white"} />
-          ) : (
-            <AiOutlineMenu size={35} />
-          )}
-        </div>
-
-        {/* Mobile Menu */}
-        <div
-          className={`min-[768px]:hidden absolute ${
-            nav ? "left-0" : "left-[-100%]"
-          } top-0 bottom-0 right-0 flex justify-center items-center w-full
-          h-screen bg-frenchviolet text-white text-center ease-in duration-300`}
-        >
-          <ul>
-            <li className="p-4 text-5xl uppercase">
-              <Link href="/">Home</Link>
-            </li>
-            <li className="p-4 text-5xl uppercase">
-              <Link href="/advisory">Advisory</Link>
-            </li>
-            <li className="p-4 text-5xl uppercase">
-              <Link href="/news">News</Link>
-            </li>
-            <li className="p-4 text-5xl uppercase">
-              <Link href="/about">About</Link>
-            </li>
-            <li className="p-4 text-5xl uppercase">
-              <Link href="/contact">Contact Us</Link>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  );
+				{/* Mobile Menu */}
+				<div
+					className={`min-[768px]:hidden absolute ${
+						nav ? "left-0" : "left-[-100%]"
+					} top-0 bottom-0 right-0 flex justify-center items-center w-full
+          h-screen bg-frenchviolet text-white text-center ease-in duration-300 `}
+				>
+					<ul>
+						<li className="p-4 text-5xl uppercase">
+							<Link
+								className={`${classes.mobileHamburgerMenu}`}
+								href="/"
+							>
+								Home
+							</Link>
+						</li>
+						<li className="p-4 text-5xl uppercase">
+							<Link
+								className={`${classes.mobileHamburgerMenu}`}
+								href="/advisory"
+							>
+								Advisory
+							</Link>
+						</li>
+						<li className="p-4 text-5xl uppercase">
+							<Link
+								className={`${classes.mobileHamburgerMenu}`}
+								href="/news"
+							>
+								News
+							</Link>
+						</li>
+						<li className="p-4 text-5xl uppercase">
+							<Link
+								className={`${classes.mobileHamburgerMenu}`}
+								href="/about"
+							>
+								About
+							</Link>
+						</li>
+						<li className="p-4 text-5xl uppercase">
+							<Link
+								className={`${classes.mobileHamburgerMenu}`}
+								href="/contact"
+							>
+								Contact Us
+							</Link>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default NavBar;

--- a/src/components/news/PostList.tsx
+++ b/src/components/news/PostList.tsx
@@ -15,16 +15,16 @@ type Props = {
 };
 export default function PostList({ posts, tags, pagination }: Props) {
   return (
-    <div className={"container"}>
-      <div className={"posts"}>
-        <ul className={"post-list"}>
-          {posts.map((it, i) => (
-            <li key={i}>
-              <PostItem post={it} />
-            </li>
-          ))}
-        </ul>
-        {/* <Pagination
+		<div className="container px-5">
+			<div className={"posts"}>
+				<ul className={"post-list"}>
+					{posts.map((it, i) => (
+						<li key={i}>
+							<PostItem post={it} />
+						</li>
+					))}
+				</ul>
+				{/* <Pagination
           current={pagination.current}
           pages={pagination.pages}
           link={{
@@ -32,52 +32,52 @@ export default function PostList({ posts, tags, pagination }: Props) {
             as: (page) => (page === 1 ? null : "/news/page/" + page),
           }}
         /> */}
-      </div>
-      <ul className={"categories"}>
-        {tags.map((it, i) => (
-          <li key={i}>
-            <TagLink tag={it} />
-          </li>
-        ))}
-      </ul>
-      <style jsx>{`
-        .container {
-          display: flex;
-          margin: 0 auto;
-          max-width: 1068px;
-          width: 100%;
-        }
-        ul {
-          margin: 0;
-          padding: 0;
-        }
-        li {
-          list-style: none;
-        }
-        .posts {
-          display: flex;
-          flex-direction: column;
-          flex: 1 1 auto;
-        }
-        .posts li {
-          margin-bottom: 1.5rem;
-        }
-        .post-list {
-          flex: 1 0 auto;
-        }
-        .categories {
-          display: none;
-        }
-        .categories li {
-          margin-bottom: 0.75em;
-        }
+			</div>
+			<ul className={"categories"}>
+				{tags.map((it, i) => (
+					<li key={i}>
+						<TagLink tag={it} />
+					</li>
+				))}
+			</ul>
+			<style jsx>{`
+				.container {
+					display: flex;
+					margin: 0 auto;
+					max-width: 1068px;
+					width: 100%;
+				}
+				ul {
+					margin: 0;
+					padding: 0;
+				}
+				li {
+					list-style: none;
+				}
+				.posts {
+					display: flex;
+					flex-direction: column;
+					flex: 1 1 auto;
+				}
+				.posts li {
+					margin-bottom: 1.5rem;
+				}
+				.post-list {
+					flex: 1 0 auto;
+				}
+				.categories {
+					display: none;
+				}
+				.categories li {
+					margin-bottom: 0.75em;
+				}
 
-        @media (min-width: 769px) {
-          .categories {
-            display: block;
-          }
-        }
-      `}</style>
-    </div>
+				@media (min-width: 769px) {
+					.categories {
+						display: block;
+					}
+				}
+			`}</style>
+		</div>
   );
 }

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -64,273 +64,290 @@ const About: NextPage = () => {
   const handleClose = () => setOpen(false);
 
   return (
-    <>
-      <Header title={"About"} />
-      <NavBar />
-      <TopLines />
-      <Modal
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="modal-modal-title"
-        aria-describedby="modal-modal-description"
-      >
-        <Box sx={modalBoxStyle}>
-          <div>
-            <Button
-              sx={{
-                minWidth: "unset",
-                padding: 0,
-                float: "right",
-                marginBottom: "10px",
-              }}
-              onClick={handleClose}
-            >
-              <AiOutlineClose size={25} color="white" />
-            </Button>
-          </div>
-          <div className="bg-orange-300 clear-both max-w-[1068px] h-1 max-md:max-w-full max-h-full" />
-          <div className="self-center w-full mt-10 max-md:max-w-full">
-            <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
-              <div className="flex flex-col items-stretch w-3/12 max-md:w-full max-md:ml-0">
-                <div className="flex flex-col max-md:mt-10">
-                  <img
-                    loading="lazy"
-                    srcSet={people[bio].image}
-                    className="aspect-[0.94] object-cover object-center w-full overflow-hidden"
-                    alt={people[bio].name}
-                  />
-                  <div className="text-2xl font-bold leading-[133.333%] mt-6">
-                    {people[bio].name}
-                  </div>
-                  <div className="text-lg font-medium leading-[177.778%] mt-2.5">
-                    {people[bio].affiliation}
-                  </div>
-                  {Object.keys(people[bio].links).map((id, index) => (
-                    <div
-                      key={index}
-                      className="text-lg font-medium leading-[177.778%] mt-2.5"
-                    >
-                      <a
-                        href={people[bio].links[id]}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        {id}
-                      </a>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className="flex flex-col items-stretch w-9/12 max-md:w-full max-md:ml-0">
-                <div className="text-lg font-medium leading-[177.778%] w-[848px] max-w-full max-md:mt-10">
-                  {people[bio].long.map((p, index) => (
-                    <div
-                      key={index}
-                      style={{ marginBottom: "10px" }}
-                      dangerouslySetInnerHTML={{ __html: p }}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="bg-orange-300 w-full h-1 mt-10" />
-        </Box>
-      </Modal>
-      <div className="flex flex-col">
-        <div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
-          <h1 className="font-fredoka">About</h1>
-          <div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
-            <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
-              <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
-                <div className="text-stone-900 text-2xl leading-[133.333%] w-[1068px] max-w-[1068px] max-md:max-w-full max-md:mt-10">
-                  <p style={{ marginBottom: "10px" }}>
-                    The SDOH & Place Project provides access to spatially
-                    indexed and curated databases, specifically designed for
-                    conducting health equity research. We will achieve this goal
-                    by:
-                  </p>
-                  <ol
-                    style={{
-                      paddingLeft: "25px",
-                      marginBottom: "10px",
-                      listStyle: "numbered",
-                    }}
-                  >
-                    <li>
-                      Developing and disseminating a toolkit on integrating
-                      User-Centered Design principles in place-based web
-                      applications.
-                    </li>
-                    <li>
-                      Creating an innovative product for place-based data
-                      discovery to link data needed for app development and
-                      related neighborhood health data exploration.
-                    </li>
-                  </ol>
-                  <p>
-                    Our mission is to make the process of building web
-                    applications that support community health by being more
-                    accessible, enjoyable, and empowering.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="px-[2.5%] mt-[100px] relative self-center">
-          <Image priority src={sdohGraphic} alt="The SDOH & Place graphic" />
-        </div>
-        <div className="self-center z-[1] flex w-full max-w-[1068px] flex-col mt-[100px] mb-[200px] px-5 max-md:max-w-full max-md:mt-10">
-          <div className="self-center text-center w-full max-md:max-w-full text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
-            <h2 className="font-fredoka">Core Team</h2>
-          </div>
-          <p className="text-stone-900 text-2xl leading-8 mt-10 self-center max-w-[1259px] max-md:max-w-full max-md:mt-10">
-            Our team is based out of the University of Illinois at
-            Urbana-Champaign via Dr. Kolak&apos;s{" "}
-            <a
-              className="underline"
-              href="http://www.healthyregions.org/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Healthy Regions & Policies (HEROP) Lab
-            </a>{" "}
-            at the Department of Geography & GIScience, and{" "}
-            <a
-              className="underline"
-              href="http://czhai.cs.illinois.edu/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Dr. Zhai&apos;s
-            </a>{" "}
-            team at the Department of Computer Science.
-            <br />
-            <br />
-            This project is funded in part by the Robert Wood Johnson
-            Foundation.
-          </p>
-        </div>
-        <div className="self-stretch flex mt-0 w-full flex-col max-md:max-w-full">
-          <div className="bg-lightbisque self-stretch flex w-full flex-col px-5 max-md:max-w-full">
-            <div
-              className="self-center flex w-full max-w-[1246px] flex-col mt-0.5 max-md:max-w-full"
-              style={{ marginTop: "-110px" }}
-            >
-              <div className="self-center w-full max-md:max-w-full">
-                <div className="flex flex-wrap max-md:flex-col max-md:items-stretch max-md:gap-0">
-                  {teamList.map((item, index) => (
-                    <div
-                      key={index}
-                      className="flex flex-col items-stretch w-1/4 p-[25px] mb-[70px] max-md:w-full max-md:ml-0"
-                    >
-                      <div className="flex flex-col items-stretch w-full max-md:w-full max-md:ml-0">
-                        <div
-                          className="flex flex-col items-stretch mb-[30px] max-md:w-full max-md:ml-0"
-                          style={{ paddingRight: "100px" }}
-                        >
-                          <img
-                            loading="lazy"
-                            srcSet={item.image}
-                            className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet]"
-                            alt={item.name}
-                          />
-                        </div>
-                        <div className="flex grow flex-col max-md:mt-10">
-                          <div className="text-stone-900 text-2xl font-bold leading-[133.333%]">
-                            {item.name}
-                          </div>
-                          <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-1">
-                            {item.title}
-                          </div>
-                          <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-6">
-                            {item.text}
-                          </div>
-                          <Button
-                            sx={modalBtnStyle}
-                            onClick={() => {
-                              setBio(item.id);
-                              handleOpen();
-                            }}
-                          >
-                            Read More
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="self-center z-[1] flex w-full max-w-[1068px] flex-col mt-[100px] mb-[200px] px-5 max-md:max-w-full max-md:mt-10">
-          <div className="self-center text-center w-full max-md:max-w-full text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
-            <h2 className="font-fredoka">Past Team Members</h2>
-          </div>
-        </div>
-        <div className="self-stretch flex mt-0 w-full flex-col max-md:max-w-full">
-          <div className="bg-lightbisque self-stretch flex w-full flex-col px-5 max-md:max-w-full">
-            <div
-              className="self-center flex w-full max-w-[1246px] flex-col mt-0.5 max-md:max-w-full"
-              style={{ marginTop: "-110px" }}
-            >
-              <div className="self-center w-full max-md:max-w-full">
-                <div className="flex flex-wrap max-md:flex-col max-md:items-stretch max-md:gap-0">
-                  {pastTeamList.map((item, index) => (
-                    <div
-                      key={index}
-                      className="flex flex-col items-stretch w-1/4 p-[25px] mb-[70px] max-md:w-full max-md:ml-0"
-                    >
-                      <div className="flex flex-col items-stretch w-full max-md:w-full max-md:ml-0">
-                        <div
-                          className="flex flex-col items-stretch mb-[30px] max-md:w-full max-md:ml-0"
-                          style={{ paddingRight: "100px" }}
-                        >
-                          <img
-                            loading="lazy"
-                            srcSet={item.image}
-                            className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet]"
-                            alt={item.name}
-                          />
-                        </div>
-                        <div className="flex grow flex-col max-md:mt-10">
-                          <div className="text-stone-900 text-2xl font-bold leading-[133.333%]">
-                            {item.name}
-                          </div>
-                          <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-1">
-                            {item.title}
-                          </div>
-                          <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-6">
-                            {item.text}
-                          </div>
-                          <Button
-                            sx={modalBtnStyle}
-                            onClick={() => {
-                              setBio(item.id);
-                              handleOpen();
-                            }}
-                          >
-                            Read More
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="text-stone-900 py-[50px] text-2xl leading-[133.333%] self-center ml-0 w-[1068px] max-w-[1068px] my-20 max-md:max-w-full max-md:mt-10">
-          Spring 2023 research assistants supporting Place metadata
-          harmonization and other activites included Elaina Katz, Sarthak Joshi,
-          Augustyn Crane, and Jorge Corral.
-        </div>
-        <Footer />
-      </div>
-    </>
+		<>
+			<Header title={"About"} />
+			<NavBar />
+			<TopLines />
+			<Modal
+				open={open}
+				onClose={handleClose}
+				aria-labelledby="modal-modal-title"
+				aria-describedby="modal-modal-description"
+			>
+				<Box sx={modalBoxStyle}>
+					<div>
+						<Button
+							sx={{
+								minWidth: "unset",
+								padding: 0,
+								float: "right",
+								marginBottom: "10px",
+							}}
+							onClick={handleClose}
+						>
+							<AiOutlineClose size={25} color="white" />
+						</Button>
+					</div>
+					<div className="bg-orange-300 clear-both max-w-[1068px] h-1 max-md:max-w-full max-h-full" />
+					<div className="self-center w-full mt-10 max-md:max-w-full">
+						<div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
+							<div className="flex flex-col items-stretch w-3/12 max-md:w-full max-md:ml-0">
+								<div className="flex flex-col max-md:mt-10">
+									<img
+										loading="lazy"
+										srcSet={people[bio].image}
+										className="aspect-[0.94] object-cover object-center w-full overflow-hidden"
+										alt={people[bio].name}
+									/>
+									<div className="text-2xl font-bold leading-[133.333%] mt-6">
+										{people[bio].name}
+									</div>
+									<div className="text-lg font-medium leading-[177.778%] mt-2.5">
+										{people[bio].affiliation}
+									</div>
+									{Object.keys(people[bio].links).map(
+										(id, index) => (
+											<div
+												key={index}
+												className="text-lg font-medium leading-[177.778%] mt-2.5"
+											>
+												<a
+													href={people[bio].links[id]}
+													target="_blank"
+													rel="noreferrer"
+												>
+													{id}
+												</a>
+											</div>
+										)
+									)}
+								</div>
+							</div>
+							<div className="flex flex-col items-stretch w-9/12 max-md:w-full max-md:ml-0">
+								<div className="text-lg font-medium leading-[177.778%] w-[848px] max-w-full max-md:mt-10">
+									{people[bio].long.map((p, index) => (
+										<div
+											key={index}
+											style={{ marginBottom: "10px" }}
+											dangerouslySetInnerHTML={{
+												__html: p,
+											}}
+										/>
+									))}
+								</div>
+							</div>
+						</div>
+					</div>
+					<div className="bg-orange-300 w-full h-1 mt-10" />
+				</Box>
+			</Modal>
+			<div className="flex flex-col">
+				<div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
+					<h1 className="font-fredoka">About</h1>
+					<div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
+						<div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
+							<div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
+								<div className="text-stone-900 text-2xl leading-[133.333%] w-[1068px] max-w-[1068px] max-md:max-w-full max-md:mt-10">
+									<p style={{ marginBottom: "10px" }}>
+										The SDOH & Place Project provides access
+										to spatially indexed and curated
+										databases, specifically designed for
+										conducting health equity research. We
+										will achieve this goal by:
+									</p>
+									<ol
+										style={{
+											paddingLeft: "25px",
+											marginBottom: "10px",
+											listStyle: "numbered",
+										}}
+									>
+										<li>
+											Developing and disseminating a
+											toolkit on integrating User-Centered
+											Design principles in place-based web
+											applications.
+										</li>
+										<li>
+											Creating an innovative product for
+											place-based data discovery to link
+											data needed for app development and
+											related neighborhood health data
+											exploration.
+										</li>
+									</ol>
+									<p>
+										Our mission is to make the process of
+										building web applications that support
+										community health by being more
+										accessible, enjoyable, and empowering.
+									</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div className="px-[2.5%] mt-[100px] relative self-center">
+					<Image
+						priority
+						src={sdohGraphic}
+						alt="The SDOH & Place graphic"
+					/>
+				</div>
+				<div className="self-center z-[1] flex w-full max-w-[1068px] flex-col mt-[100px] mb-[200px] px-5 max-md:max-w-full max-md:mt-10">
+					<div className="self-center text-center w-full max-md:max-w-full text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
+						<h2 className="font-fredoka">Core Team</h2>
+					</div>
+					<p className="text-stone-900 text-2xl leading-8 mt-10 self-center max-w-[1259px] max-md:max-w-full max-md:mt-10">
+						Our team is based out of the University of Illinois at
+						Urbana-Champaign via Dr. Kolak&apos;s{" "}
+						<a
+							className="underline"
+							href="http://www.healthyregions.org/"
+							target="_blank"
+							rel="noreferrer"
+						>
+							Healthy Regions & Policies (HEROP) Lab
+						</a>{" "}
+						at the Department of Geography & GIScience, and{" "}
+						<a
+							className="underline"
+							href="http://czhai.cs.illinois.edu/"
+							target="_blank"
+							rel="noreferrer"
+						>
+							Dr. Zhai&apos;s
+						</a>{" "}
+						team at the Department of Computer Science.
+						<br />
+						<br />
+						This project is funded in part by the Robert Wood
+						Johnson Foundation.
+					</p>
+				</div>
+				<div className="self-stretch flex mt-0 w-full flex-col max-md:max-w-full">
+					<div className="bg-lightbisque self-stretch flex w-full flex-col px-5 max-md:max-w-full">
+						<div
+							className="self-center flex w-full max-w-[1246px] flex-col mt-0.5 max-md:max-w-full"
+							style={{ marginTop: "-110px" }}
+						>
+							<div className="self-center w-full max-md:max-w-full">
+								<div className="flex flex-wrap max-md:flex-col max-md:items-stretch max-md:gap-0">
+									{teamList.map((item, index) => (
+										<div
+											key={index}
+											className="flex flex-col items-stretch w-1/4 p-[25px] mb-[70px] max-md:w-full max-md:ml-0"
+										>
+											<div className="flex flex-col items-stretch w-full max-md:w-full max-md:ml-0">
+												<div
+													className="flex flex-col items-stretch mb-[30px] max-md:w-full max-md:ml-0"
+													style={{
+														paddingRight: "100px",
+													}}
+												>
+													<img
+														loading="lazy"
+														srcSet={item.image}
+														className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet]"
+														alt={item.name}
+													/>
+												</div>
+												<div className="flex grow flex-col max-md:mt-10">
+													<div className="text-stone-900 text-2xl font-bold leading-[133.333%]">
+														{item.name}
+													</div>
+													<div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-1">
+														{item.title}
+													</div>
+													<div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-6">
+														{item.text}
+													</div>
+													<Button
+														sx={modalBtnStyle}
+														onClick={() => {
+															setBio(item.id);
+															handleOpen();
+														}}
+													>
+														Read More
+													</Button>
+												</div>
+											</div>
+										</div>
+									))}
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div className="self-center z-[1] flex w-full max-w-[1068px] flex-col mt-[100px] mb-[200px] px-5 max-md:max-w-full max-md:mt-10">
+					<div className="self-center text-center w-full max-md:max-w-full text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
+						<h2 className="font-fredoka">Past Team Members</h2>
+					</div>
+				</div>
+				<div className="self-stretch flex mt-0 w-full flex-col max-md:max-w-full">
+					<div className="bg-lightbisque self-stretch flex w-full flex-col px-5 max-md:max-w-full">
+						<div
+							className="self-center flex w-full max-w-[1246px] flex-col mt-0.5 max-md:max-w-full"
+							style={{ marginTop: "-110px" }}
+						>
+							<div className="self-center w-full max-md:max-w-full">
+								<div className="flex flex-wrap max-md:flex-col max-md:items-stretch max-md:gap-0">
+									{pastTeamList.map((item, index) => (
+										<div
+											key={index}
+											className="flex flex-col items-stretch w-1/4 p-[25px] mb-[70px] max-md:w-full max-md:ml-0"
+										>
+											<div className="flex flex-col items-stretch w-full max-md:w-full max-md:ml-0">
+												<div
+													className="flex flex-col items-stretch mb-[30px] max-md:w-full max-md:ml-0"
+													style={{
+														paddingRight: "100px",
+													}}
+												>
+													<img
+														loading="lazy"
+														srcSet={item.image}
+														className="aspect-[0.98] object-cover rounded-full object-center w-full overflow-hidden grow max-md:mt-10 border-4 border-solid border-salmonpink shadow-[2px_4px_0px_0px_frenchviolet]"
+														alt={item.name}
+													/>
+												</div>
+												<div className="flex grow flex-col max-md:mt-10">
+													<div className="text-stone-900 text-2xl font-bold leading-[133.333%]">
+														{item.name}
+													</div>
+													<div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-1">
+														{item.title}
+													</div>
+													<div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-6">
+														{item.text}
+													</div>
+													<Button
+														sx={modalBtnStyle}
+														onClick={() => {
+															setBio(item.id);
+															handleOpen();
+														}}
+													>
+														Read More
+													</Button>
+												</div>
+											</div>
+										</div>
+									))}
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div className="text-stone-900 py-[50px] text-2xl leading-[133.333%] self-center ml-0 w-[1068px] max-w-[1068px] my-20 max-md:max-w-full max-md:mt-10 max-md:px-5">
+					Spring 2023 research assistants supporting Place metadata
+					harmonization and other activites included Elaina Katz,
+					Sarthak Joshi, Augustyn Crane, and Jorge Corral.
+				</div>
+				<Footer />
+			</div>
+		</>
   );
 };
 

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -71,145 +71,161 @@ const Contact: NextPage = () => {
     },
   })(TextField);
   return (
-    <>
-      <Header title={"Contact Us"} />
-      <NavBar />
-      <TopLines />
-      <div className="flex flex-col">
-        <div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
-          <h1 className="font-fredoka">Contact Us</h1>
-          <div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
-            <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
-              <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
-                <div className="text-stone-900 text-2xl leading-[133.333%] w-[1068px] max-w-[1068px] max-md:max-w-full max-md:mt-10">
-                  Thank you for your interest. Please don&apos;t hesitate to
-                  reach out to us if you need assistance or information
-                  regarding the Community Toolkit, Data Discovery Application,
-                  or The SDOH & Place Project in general. We value your input
-                  and welcome any comments you may have. Your feedback is
-                  essential in helping us improve and refine The SDOH & Place
-                  Project.
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="flex mb-10 mt-10">
-            <Link
-              className="mr-10"
-              href="https://github.com/healthyregions/SDOHPlace"
-              title="View code on GitHub"
-            >
-              <Image
-                priority
-                src={githubIcon}
-                height={36}
-                alt="View code on GitHub"
-              />
-            </Link>
-            <Link
-              className="mr-10"
-              href="https://www.linkedin.com/groups/12857797/"
-              title="Follow us on LinkedIn"
-            >
-              <Image
-                priority
-                src={linkedinIcon}
-                height={36}
-                alt="Follow us on LinkedIn"
-              />
-            </Link>
-            <Link
-              className="mr-10"
-              href="https://www.facebook.com/HealthyRegions"
-              title="HealthyRegions on Facebook"
-            >
-              <Image
-                priority
-                src={facebookIcon}
-                height={36}
-                alt="HealthyRegions on Facebook"
-              />
-            </Link>
-            <Link
-              className="mr-10"
-              href="https://x.com/healthyregions"
-              title="@healthyregions on X"
-            >
-              <Image
-                priority
-                src={xIcon}
-                height={36}
-                alt="@healthyregions on X"
-              />
-            </Link>
-          </div>
-        </div>
-      </div>
-      <div className="w-full min-h-[20rem] bg-lightbisque">
-        <div className="max-md:max-w-[87%] max-w-[1068px] mx-auto py-[5rem]">
-          <div className="text-almostblack text-2xl-rfs font-normal leading-8 ml mb-5">
-            Send us a Message
-          </div>
-          <div className="">
-            {(success && (
-              <p className="text-almostblack pt-[1rem]">
-                Message received. Thank you!
-              </p>
-            )) || (
-              <form
-                className="w-full"
-                name="contact"
-                method="POST"
-                data-netlify="true"
-                action="/contact?success=true"
-              >
-                <input type="hidden" name="form-name" value="contact" />
-                <div className="flex justify-start mb-5">
-                  <CssTextField
-                    label="Name"
-                    name="name"
-                    focused
-                    sx={{
-                      marginRight: "20px",
-                    }}
-                  />
-                  <CssTextField label="Email" name="email" focused />
-                </div>
-                <div className="w-full mb-5">
-                  <CssTextField
-                    id="outlined-multiline-flexible"
-                    label="Message"
-                    name="message"
-                    minRows={4}
-                    focused
-                    multiline
-                    sx={{
-                      width: "100%",
-                    }}
-                  />
-                </div>
-                <div className="mb-5">
-                  <Button
-                    variant="contained"
-                    type="submit"
-                    sx={{
-                      height: "2.5rem",
-                      width: "6em",
-                      borderRadius: "6.25rem",
-                      background: `${fullConfig.theme.colors["frenchviolet"]}`,
-                      textTransform: "none",
-                      color: `${fullConfig.theme.colors["white"]}`,
-                      fontSize: "clamp(1.125rem, 1vw + 0.5rem, 1.25rem)",
-                      fontStyle: "normal",
-                      fontWeight: 700,
-                      lineHeight: "1.5rem",
-                      letterSpacing: "0.00938rem",
-                      marginRight: "20px",
-                    }}
-                  >
-                    Send
-                  </Button>
-                  {/* <Button
+		<>
+			<Header title={"Contact Us"} />
+			<NavBar />
+			<TopLines />
+			<div className="flex flex-col">
+				<div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
+					<h1 className="font-fredoka">Contact Us</h1>
+					<div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
+						<div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
+							<div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
+								<div className="text-stone-900 text-2xl leading-[133.333%] w-[1068px] max-w-[1068px] max-md:max-w-full max-md:mt-10">
+									Thank you for your interest. Please
+									don&apos;t hesitate to reach out to us if
+									you need assistance or information regarding
+									the Community Toolkit, Data Discovery
+									Application, or The SDOH & Place Project in
+									general. We value your input and welcome any
+									comments you may have. Your feedback is
+									essential in helping us improve and refine
+									The SDOH & Place Project.
+								</div>
+							</div>
+						</div>
+					</div>
+					<div className="flex mb-10 mt-10">
+						<Link
+							className="mr-10"
+							href="https://github.com/healthyregions/SDOHPlace"
+							title="View code on GitHub"
+							target="_blank"
+						>
+							<Image
+								priority
+								src={githubIcon}
+								height={36}
+								alt="View code on GitHub"
+							/>
+						</Link>
+						<Link
+							className="mr-10"
+							href="https://www.linkedin.com/groups/12857797/"
+							title="Follow us on LinkedIn"
+							target="_blank"
+						>
+							<Image
+								priority
+								src={linkedinIcon}
+								height={36}
+								alt="Follow us on LinkedIn"
+							/>
+						</Link>
+						<Link
+							className="mr-10"
+							href="https://www.facebook.com/HealthyRegions"
+							title="HealthyRegions on Facebook"
+							target="_blank"
+						>
+							<Image
+								priority
+								src={facebookIcon}
+								height={36}
+								alt="HealthyRegions on Facebook"
+							/>
+						</Link>
+						<Link
+							className="mr-10"
+							href="https://x.com/healthyregions"
+							title="@healthyregions on X"
+							target="_blank"
+						>
+							<Image
+								priority
+								src={xIcon}
+								height={36}
+								alt="@healthyregions on X"
+							/>
+						</Link>
+					</div>
+				</div>
+			</div>
+			<div className="w-full min-h-[20rem] bg-lightbisque">
+				<div className="max-md:max-w-[87%] max-w-[1068px] mx-auto py-[5rem]">
+					<div className="text-almostblack text-2xl-rfs font-normal leading-8 ml mb-5">
+						Send us a Message
+					</div>
+					<div className="">
+						{(success && (
+							<p className="text-almostblack pt-[1rem]">
+								Message received. Thank you!
+							</p>
+						)) || (
+							<form
+								className="w-full"
+								name="contact"
+								method="POST"
+								data-netlify="true"
+								action="/contact?success=true"
+							>
+								<input
+									type="hidden"
+									name="form-name"
+									value="contact"
+								/>
+								<div className="flex justify-start mb-5">
+									<CssTextField
+										label="Name"
+										name="name"
+										focused
+										sx={{
+											marginRight: "20px",
+										}}
+									/>
+									<CssTextField
+										label="Email"
+										name="email"
+										focused
+									/>
+								</div>
+								<div className="w-full mb-5">
+									<CssTextField
+										id="outlined-multiline-flexible"
+										label="Message"
+										name="message"
+										minRows={4}
+										focused
+										multiline
+										sx={{
+											width: "100%",
+										}}
+									/>
+								</div>
+								<div className="mb-5">
+									<Button
+										variant="contained"
+										type="submit"
+										sx={{
+											height: "2.5rem",
+											width: "6em",
+											borderRadius: "6.25rem",
+											background: `${fullConfig.theme.colors["frenchviolet"]}`,
+											textTransform: "none",
+											color: `${fullConfig.theme.colors["white"]}`,
+											fontSize:
+												"clamp(1.125rem, 1vw + 0.5rem, 1.25rem)",
+											fontStyle: "normal",
+											fontWeight: 400,
+											lineHeight: "1.5rem",
+											letterSpacing: "0.00938rem",
+											marginRight: "20px",
+                      fontFamily: "nunito",
+										}}
+									>
+										Send
+									</Button>
+									{/* <Button
                     variant="outlined"
                     onClick={handleClear}
                     sx={{
@@ -227,14 +243,14 @@ const Contact: NextPage = () => {
                       letterSpacing: "0.00938rem",
                     }}
                   >Clear</Button> */}
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
-      </div>
-      <Footer />
-    </>
+								</div>
+							</form>
+						)}
+					</div>
+				</div>
+			</div>
+			<Footer />
+		</>
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,293 +109,343 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
   }
 
   return (
-    <>
-      <Header title={null} />
-      <NavBar />
-      <div className="w-full h-screen max-md:h-auto max-md:min-h-[60rem] -z-50 absolute">
-        <div className="absolute left-[70%] top-0 w-[13vw] max-md:w-[22vw] max-md:left-[28%] h-auto">
-          <Image priority src={line1} alt="" className="w-full h-full" />
-        </div>
-        <div className="absolute right-0 top-[2%] w-[11vw] max-md:w-[18vw] max-md:top-[5%] h-auto">
-          <Image priority src={line2} alt="" className="w-full h-full" />
-        </div>
-        <div className="absolute right-0 top-[43%] w-[5vw] max-[1150px]:hidden h-auto">
-          <Image priority src={line3} alt="" className="w-full h-full" />
-        </div>
-        <div className="absolute right-0 bottom-0 w-[5vw] max-md:[8vw] max-md:hidden  h-auto">
-          <Image priority src={line4} alt="" className="w-full h-full" />
-        </div>
-        <div className="absolute left-[80%] bottom-0 w-[7vw] max-md:hidden h-auto">
-          <Image priority src={line5} alt="" className="w-full h-full" />
-        </div>
-        <div className="absolute left-[65%] bottom-0 w-[2vw] max-md:hidden h-auto">
-          <Image priority src={line6} alt="" className="w-full h-full" />
-        </div>
-      </div>
+		<>
+			<Header title={null} />
+			<NavBar />
+			<div className="w-full h-screen max-md:h-auto max-md:min-h-[60rem] -z-50 absolute">
+				<div className="absolute left-[70%] top-0 w-[13vw] max-md:w-[22vw] max-md:left-[28%] h-auto">
+					<Image
+						priority
+						src={line1}
+						alt=""
+						className="w-full h-full"
+					/>
+				</div>
+				<div className="absolute right-0 top-[2%] w-[11vw] max-md:w-[18vw] max-md:top-[5%] h-auto">
+					<Image
+						priority
+						src={line2}
+						alt=""
+						className="w-full h-full"
+					/>
+				</div>
+				<div className="absolute right-0 top-[43%] w-[5vw] max-[1150px]:hidden h-auto">
+					<Image
+						priority
+						src={line3}
+						alt=""
+						className="w-full h-full"
+					/>
+				</div>
+				<div className="absolute right-0 bottom-0 w-[5vw] max-md:[8vw] max-md:hidden  h-auto">
+					<Image
+						priority
+						src={line4}
+						alt=""
+						className="w-full h-full"
+					/>
+				</div>
+				<div className="absolute left-[80%] bottom-0 w-[7vw] max-md:hidden h-auto">
+					<Image
+						priority
+						src={line5}
+						alt=""
+						className="w-full h-full"
+					/>
+				</div>
+				<div className="absolute left-[65%] bottom-0 w-[2vw] max-md:hidden h-auto">
+					<Image
+						priority
+						src={line6}
+						alt=""
+						className="w-full h-full"
+					/>
+				</div>
+			</div>
 
-      <div className="grid grid-flow-row max-md:grid-rows-[1fr_1fr] max-md:gap-y-[0.1rem] md:grid-flow-col md:max-[921px]:grid-cols-[1fr_1fr] min-[921px]:grid-cols-[2fr_3fr] w-full h-screen max-md:h-auto  2xl:max-w-[1536px] 2xl:mx-auto">
-        <div className="flex flex-col justify-center items-center max-md:max-w-[26.43rem] max-md:mx-auto">
-          <div className="mt-auto max-[460px]:pt-[10vw] min-[460px]:max-[500px]:pt-[15vw] min-[500px]:max-[768px]:pt-[20vw] px-[5%] relative top-[3%] min-[768px]:max-[921px]:top-[-3%]">
-            <Image
-              priority
-              src={mainLogo}
-              alt="The SDOH & Place Project logo"
-            />
-          </div>
-          <div className="max-md:hidden self-end text-center pr-[20%] mt-auto">
-            <div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
-              Learn More
-            </div>
-            <div className="mx-auto w-[1.25rem] h-[1.25rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="18"
-                height="15"
-                viewBox="0 0 18 15"
-                fill="none"
-              >
-                <path
-                  d="M9 15L0.339745 0L17.6603 0L9 15Z"
-                  className="fill-frenchviolet"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
+			<div className="grid grid-flow-row max-md:grid-rows-[1fr_1fr] max-md:gap-y-[0.1rem] md:grid-flow-col md:max-[921px]:grid-cols-[1fr_1fr] min-[921px]:grid-cols-[2fr_3fr] w-full h-screen max-md:h-auto  2xl:max-w-[1536px] 2xl:mx-auto">
+				<div className="flex flex-col justify-center items-center max-md:max-w-[26.43rem] max-md:mx-auto">
+					<div className="mt-auto max-[460px]:pt-[10vw] min-[460px]:max-[500px]:pt-[15vw] min-[500px]:max-[768px]:pt-[20vw] px-[5%] relative top-[3%] min-[768px]:max-[921px]:top-[-3%]">
+						<Image
+							priority
+							src={mainLogo}
+							alt="The SDOH & Place Project logo"
+						/>
+					</div>
+					<div className="max-md:hidden self-end text-center pr-[20%] mt-auto">
+						<div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase">
+							Learn More
+						</div>
+						<div className="mx-auto w-[1.25rem] h-[1.25rem]">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="18"
+								height="15"
+								viewBox="0 0 18 15"
+								fill="none"
+							>
+								<path
+									d="M9 15L0.339745 0L17.6603 0L9 15Z"
+									className="fill-frenchviolet"
+								/>
+							</svg>
+						</div>
+					</div>
+				</div>
 
-        <div className="flex flex-col gap-8 items-center justify-center px-[5%] max-md:h-fit max-md:mt-[15%]">
-          <div className="md:mx-auto max-w-[26.43rem]  max-md:w-full text-justify">
-            <p className="text-almostblack text-2xl-rfs font-normal leading-8">
-              A{" "}
-              <span className="text-frenchviolet font-bold">free platform</span>{" "}
-              to discover and practice with place-based data for health equity,
-              connecting the Social Determinants of Health to communities,
-              researchers, policymakers, & health practitioners.
-            </p>
-          </div>
-          <div className="flex flex-row gap-4 flex-wrap max-[460px]:flex-col max-[460px]:items-center min-[768px]:max-[921px]:flex-col min-[768px]:max-[921px]:items-center ">
-            <div>
-              <ButtonWithIcon
-                label={"Data Discovery"}
-                svgIcon={dataDiscoveryIcon}
-                fillColor={"salmonpink"}
-                labelColor={"almostblack"}
-                onClick={scrollToComingSoon}
-              ></ButtonWithIcon>
-            </div>
-            <div>
-              <ButtonWithIcon
-                label={"Community Toolkit"}
-                svgIcon={communityToolkitIcon}
-                fillColor={"frenchviolet"}
-                labelColor={"white"}
-                onClick={scrollToComingSoon}
-              ></ButtonWithIcon>
-            </div>
-          </div>
-        </div>
-        <div className="md:hidden text-center">
-          <div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase max-[460px]:mt-[7%]">
-            Learn More
-          </div>
-          <div className="mx-auto w-[1.25rem] h-[1.25rem]">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="18"
-              height="15"
-              viewBox="0 0 18 15"
-              fill="none"
-            >
-              <path
-                d="M9 15L0.339745 0L17.6603 0L9 15Z"
-                className="fill-frenchviolet"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
+				<div className="flex flex-col gap-8 items-center justify-center px-[5%] max-md:h-fit max-md:mt-[15%]">
+					<div className="md:mx-auto max-w-[26.43rem]  max-md:w-full text-justify">
+						<p className="text-almostblack text-2xl-rfs font-normal leading-8">
+							A{" "}
+							<span className="text-frenchviolet font-bold">
+								free platform
+							</span>{" "}
+							to discover and practice with place-based data for
+							health equity, connecting the Social Determinants of
+							Health to communities, researchers, policymakers, &
+							health practitioners.
+						</p>
+					</div>
+					<div className="flex flex-row gap-4 flex-wrap max-[460px]:flex-col max-[460px]:items-center min-[768px]:max-[921px]:flex-col min-[768px]:max-[921px]:items-center ">
+						<div>
+							<ButtonWithIcon
+								label={"Data Discovery"}
+								svgIcon={dataDiscoveryIcon}
+								fillColor={"salmonpink"}
+								labelColor={"almostblack"}
+								onClick={scrollToComingSoon}
+							></ButtonWithIcon>
+						</div>
+						<div>
+							<ButtonWithIcon
+								label={"Community Toolkit"}
+								svgIcon={communityToolkitIcon}
+								fillColor={"frenchviolet"}
+								labelColor={"white"}
+								onClick={scrollToComingSoon}
+							></ButtonWithIcon>
+						</div>
+					</div>
+				</div>
+				<div className="md:hidden text-center">
+					<div className="text-frenchviolet text-center text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase max-[460px]:mt-[7%]">
+						Learn More
+					</div>
+					<div className="mx-auto w-[1.25rem] h-[1.25rem]">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="18"
+							height="15"
+							viewBox="0 0 18 15"
+							fill="none"
+						>
+							<path
+								d="M9 15L0.339745 0L17.6603 0L9 15Z"
+								className="fill-frenchviolet"
+							/>
+						</svg>
+					</div>
+				</div>
+			</div>
 
-      <div className="w-full h-auto bg-lightbisque">
-        <div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem]">
-          <div className="text-almostblack  text-2xl-rfs font-normal leading-8 ml-[2.5%] max-md:max-w-[16rem]">
-            Social Determinants of Health
-          </div>
-          <div className="pt-[3rem] grid grid-flow-col justify-between px-[2.5%] max-md:grid-flow-row max-md:grid-cols-2 gap-y-12 gap-x-6 max-md:justify-items-center ">
-            {sdohFactors.map((factor) => (
-              <Card
-                key={factor.id}
-                svgIcon={factor.svgIcon}
-                title={factor.title}
-                text={factor.text}
-              />
-            ))}
-          </div>
-        </div>
-      </div>
+			<div className="w-full h-auto bg-lightbisque">
+				<div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem]">
+					<div className="text-almostblack  text-2xl-rfs font-normal leading-8 ml-[2.5%] max-md:max-w-[16rem]">
+						Social Determinants of Health
+					</div>
+					<div className="pt-[3rem] grid grid-flow-col justify-between px-[2.5%] max-md:grid-flow-row max-md:grid-cols-2 gap-y-12 gap-x-6 max-md:justify-items-center ">
+						{sdohFactors.map((factor) => (
+							<Card
+								key={factor.id}
+								svgIcon={factor.svgIcon}
+								title={factor.title}
+								text={factor.text}
+							/>
+						))}
+					</div>
+				</div>
+			</div>
 
-      <div className="w-full h-auto">
-        <div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem]">
-          <div className="flex flex-col px-[2.5%] gap-12">
-            <div className="flex flex-row justify-between gap-4">
-              <div className=" text-2xl-rfs font-normal leading-8">
-                News & Updates
-              </div>
-              <div className=" text-2xl-rfs font-normal leading-8 text-end">
-                <Link
-                  style={{
-                    textTransform: "uppercase",
-                    color: `${fullConfig.theme.colors["frenchviolet"]}`,
-                  }}
-                  href="/news"
-                >
-                  All News & Updates
-                </Link>
-              </div>
-            </div>
+			<div className="w-full h-auto">
+				<div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem]">
+					<div className="flex flex-col px-[2.5%] gap-12">
+						<div className="flex flex-row justify-between gap-4">
+							<div className=" text-2xl-rfs font-normal leading-8">
+								News & Updates
+							</div>
+							<div className=" text-2xl-rfs font-normal leading-8 text-end">
+								<Link
+									style={{
+										textTransform: "uppercase",
+										color: `${fullConfig.theme.colors["frenchviolet"]}`,
+									}}
+									href="/news"
+								>
+									All News & Updates
+								</Link>
+							</div>
+						</div>
 
-            <div className="flex flex-row justify-between flex-wrap gap-12 max-[803px]:flex-col max-[803px]:items-center">
-              {newsItem.map((item) => (
-                <CardWithImage
-                  key={item.id}
-                  image={item.thumbnail}
-                  title={item.title}
-                  text={item.excerpt}
-                  url={"news/" + item.slug}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
+						<div className="flex flex-row justify-between flex-wrap gap-12 max-[803px]:flex-col max-[803px]:items-center">
+							{newsItem.map((item) => (
+								<CardWithImage
+									key={item.id}
+									image={item.thumbnail}
+									title={item.title}
+									text={item.excerpt}
+									url={"news/" + item.slug}
+								/>
+							))}
+						</div>
+					</div>
+				</div>
+			</div>
 
-      <div className="w-full h-auto bg-frenchviolet">
-        <div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem] grid grid-flow-row max-md:grid-rows-[1fr_1fr] max-md:gap-y-12 md:grid-flow-col md:grid-cols-[1fr_2fr] text-start">
-          <div className="my-auto text-white text-2xl-rfs font-normal leading-8 px-[5.5%]">
-            Brought to you by
-          </div>
-          <div className="grid grid-flow-col grid-cols-[1fr_1fr] items-center">
-            <div className="mx-auto md:my-auto w-[14.75rem] max-h-[3.25rem] max-md:w-[7.8125rem] max-md:h-[1.75rem]">
-              <Link
-                href="http://www.healthyregions.org/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Image
-                  alt="Healthy Regions & Policies Lab"
-                  src={heropLightLogo}
-                />
-              </Link>
-            </div>
-            <div className="mx-auto md:my-auto w-[12.5625rem] h-[3.1875rem] max-md:w-[6.6875rem] max-md:h-[1.6875rem]">
-              <Link
-                href="https://illinois.edu/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Image alt="University of Illinois" src={universityWordmark} />
-              </Link>
-            </div>
-            <div className="mx-auto md:my-auto w-[12.5625rem] h-[3.1875rem] max-md:w-[6.6875rem] max-md:h-[1.6875rem]">
-              <Link
-                href="https://spatial.uchicago.edu/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Image alt="Center for Spatial Data Science" src={csdsLogo} />
-              </Link>
-            </div>
-          </div>
-        </div>
-      </div>
+			<div className="w-full h-auto bg-frenchviolet">
+				<div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem] grid grid-flow-row md:grid-flow-col md:grid-cols-[1fr_2fr] text-start">
+					<div className="my-auto text-white text-2xl-rfs font-normal leading-8 px-[5.5%] max-md:mb-[2rem] ">
+						Brought to you by
+					</div>
+					<div className="flex flex-col md:grid md:grid-flow-col md:grid-cols-[1fr_1fr] items-center">
+						<div className="mx-auto md:my-auto w-[14.75rem] max-h-[3.25rem] max-md:w-[7.8125rem] max-md:h-[1.75rem] max-md:mb-[2rem]">
+							<Link
+								href="http://www.healthyregions.org/"
+								target="_blank"
+								rel="noreferrer"
+							>
+								<Image
+									alt="Healthy Regions & Policies Lab"
+									src={heropLightLogo}
+								/>
+							</Link>
+						</div>
+						<div className="mx-auto md:my-auto w-[12.5625rem] h-[3.1875rem] max-md:w-[6.6875rem] max-md:h-[1.6875rem] max-md:mb-[2rem]">
+							<Link
+								href="https://illinois.edu/"
+								target="_blank"
+								rel="noreferrer"
+							>
+								<Image
+									alt="University of Illinois"
+									src={universityWordmark}
+								/>
+							</Link>
+						</div>
+						<div className="mx-auto md:my-auto w-[12.5625rem] h-[3.1875rem] max-md:w-[6.6875rem] max-md:h-[1.6875rem] max-md:mb-[2rem]">
+							<Link
+								href="https://spatial.uchicago.edu/"
+								target="_blank"
+								rel="noreferrer"
+							>
+								<Image
+									alt="Center for Spatial Data Science"
+									src={csdsLogo}
+								/>
+							</Link>
+						</div>
+					</div>
+				</div>
+			</div>
 
-      <div id="coming-soon-section" className="w-full h-auto">
-        <div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem] flex flex-col gap-12">
-          <div className="text-almostblack text-2xl-rfs font-normal leading-8 px-[2.5%]">
-            Access Data & Resources on SDOH & Place
-          </div>
+			<div id="coming-soon-section" className="w-full h-auto">
+				<div className="max-md:max-w-[87%] 2xl:max-w-[1536px] mx-auto py-[5rem] flex flex-col gap-12">
+					<div className="text-almostblack text-2xl-rfs font-normal leading-8 px-[2.5%]">
+						Access Data & Resources on SDOH & Place
+					</div>
 
-          <div className="px-[2.5%]">
-            <div className="flex flex-row justify-between flex-wrap items-center gap-y-12 max-[1150px]:flex-col before:border-2 before:border-solid before:border-neutralgray before:self-stretch min-[1150px]:before:[border-image:linear-gradient(to_bottom,white_33%,#AAA_33%,#AAA_75%,white_75%)_1] max-[1149px]:before:[border-image:linear-gradient(to_right,white_5%,#AAA_5%,#AAA_95%,white_95%)_1]">
-              <div className="flex flex-col gap-8 -order-1">
-                <div className="w-[3.5rem] h-[3.5rem]">
-                  <Image
-                    priority
-                    src={dataDiscoveryIconEnlarged}
-                    alt="Data Discovery Enlarged icon"
-                  />
-                </div>
+					<div className="px-[2.5%]">
+						<div className="flex flex-row justify-between flex-wrap items-center gap-y-12 max-[1150px]:flex-col before:border-2 before:border-solid before:border-neutralgray before:self-stretch min-[1150px]:before:[border-image:linear-gradient(to_bottom,white_33%,#AAA_33%,#AAA_75%,white_75%)_1] max-[1149px]:before:[border-image:linear-gradient(to_right,white_5%,#AAA_5%,#AAA_95%,white_95%)_1]">
+							<div className="flex flex-col gap-8 -order-1">
+								<div className="w-[3.5rem] h-[3.5rem]">
+									<Image
+										priority
+										src={dataDiscoveryIconEnlarged}
+										alt="Data Discovery Enlarged icon"
+									/>
+								</div>
 
-                <div className="text-almostblack text-2xl-rfs font-bold leading-8">
-                  Data Discovery{" "}
-                  <em style={{ color: "grey" }}> &mdash; coming soon!</em>
-                </div>
+								<div className="text-almostblack text-2xl-rfs font-bold leading-8">
+									Data Discovery{" "}
+									<em style={{ color: "grey" }}>
+										{" "}
+										&mdash; coming soon!
+									</em>
+								</div>
 
-                <div className="max-w-[34.0625rem] text-black text-xl-rfs font-normal leading-6 tracking-[0.03125rem]">
-                  Our data discovery platform provides access to spatially
-                  indexed and curated databases, specifically designed for
-                  conducting health equity research.
-                </div>
+								<div className="max-w-[34.0625rem] text-black text-xl-rfs font-normal leading-6 tracking-[0.03125rem]">
+									Our data discovery platform provides access
+									to spatially indexed and curated databases,
+									specifically designed for conducting health
+									equity research.
+								</div>
 
-                <div className="flex flex-row gap-6 items-center">
-                  <div className="text-frenchviolet font-nunito text-base-rfs leading-8 tracking-[0.25rem] uppercase text-center">
-                    <div>
-                      <ButtonWithIcon
-                        label={"Data Discovery"}
-                        svgIcon={dataDiscoveryIcon}
-                        fillColor={"salmonpink"}
-                        labelColor={"almostblack"}
-                        onClick={scrollToComingSoon}
-                        disabled={true}
-                      ></ButtonWithIcon>
-                    </div>
-                  </div>
-                </div>
-              </div>
+								<div className="flex flex-row gap-6 items-center">
+									<div className="text-frenchviolet font-nunito text-base-rfs leading-8 tracking-[0.25rem] uppercase text-center">
+										<div>
+											<ButtonWithIcon
+												label={"Data Discovery"}
+												svgIcon={dataDiscoveryIcon}
+												fillColor={"salmonpink"}
+												labelColor={"almostblack"}
+												onClick={scrollToComingSoon}
+												disabled={true}
+											></ButtonWithIcon>
+										</div>
+									</div>
+								</div>
+							</div>
 
-              <div className="flex flex-col gap-8">
-                <div className="w-[3.5rem] h-[3.5rem]">
-                  <Image
-                    priority
-                    src={communityToolkitIconEnlarged}
-                    alt="Data Practice Enlarged icon"
-                  />
-                </div>
+							<div className="flex flex-col gap-8">
+								<div className="w-[3.5rem] h-[3.5rem]">
+									<Image
+										priority
+										src={communityToolkitIconEnlarged}
+										alt="Data Practice Enlarged icon"
+									/>
+								</div>
 
-                <div className="text-almostblack text-2xl-rfs font-bold leading-8">
-                  Community Toolkit
-                </div>
+								<div className="text-almostblack text-2xl-rfs font-bold leading-8">
+									Community Toolkit
+								</div>
 
-                <div className="max-w-[34.0625rem] text-black text-xl-rfs font-normal leading-6 tracking-[0.03125rem]">
-                  Enhance your health and equity initiatives with our toolkit.
-                  You will be able to create captivating spatial visualizations
-                  for community engagement using free and user-friendly tools
-                  including open-source GIS tools.
-                </div>
+								<div className="max-w-[34.0625rem] text-black text-xl-rfs font-normal leading-6 tracking-[0.03125rem]">
+									Enhance your health and equity initiatives
+									with our toolkit. You will be able to create
+									captivating spatial visualizations for
+									community engagement using free and
+									user-friendly tools including open-source
+									GIS tools.
+								</div>
 
-                <div className="flex flex-row gap-6 items-center">
-                  <div>
-                    <ButtonWithIcon
-                      label={"Community Toolkit"}
-                      svgIcon={communityToolkitIcon}
-                      fillColor={"frenchviolet"}
-                      labelColor={"white"}
-                      onClick={() => {
-                        window.location.href = "https://toolkit.sdohplace.org";
-                      }}
-                    ></ButtonWithIcon>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+								<div className="flex flex-row gap-6 items-center">
+									<div>
+										<ButtonWithIcon
+											label={"Community Toolkit"}
+											svgIcon={communityToolkitIcon}
+											fillColor={"frenchviolet"}
+											labelColor={"white"}
+											onClick={() => {
+												window.location.href =
+													"https://toolkit.sdohplace.org";
+											}}
+										></ButtonWithIcon>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
 
-          <div className="relative self-center">
-            <Image priority src={sdohGraphic} alt="The SDOH & Place graphic" />
-          </div>
-        </div>
-      </div>
-      <Footer />
-    </>
+					<div className="relative self-center">
+						<Image
+							priority
+							src={sdohGraphic}
+							alt="The SDOH & Place graphic"
+						/>
+					</div>
+				</div>
+			</div>
+			<Footer />
+		</>
   );
 };
 


### PR DESCRIPTION
This PR is for #125 , which includes the following items after discussing with the designer:

For CONTACT US page:

- Open social media links in a new tab
- Add these styles to the "Send" button: font-family: 'Nunito'; font-weight: 400;

For MOBILE display (whole site):

-  Change hamburger menu items font size to 1.5rem
-  "Brought to you" on the home page to display vertically aligned icons instead of horizontally displayed icons as we currently have
 - Add padding left and right for posts on the News page and "Past Team Members" section on the Above page

### How to Test (You can compare the current version and the production version to see the difference)

1. In the desktop display, go to the "Contact Us" page
2. All social media icons should open the link in the new tab now
3. The 'Send' button should have `font-family: 'Nunito'; font-weight: 400`
4. In the mobile display, open the Hamberger button for the menu. 
5. All text should have a "1.5rem" font size
6. Move to the "Brought to you" section on the home page. Icons should not be vertically aligned instead horizontally aligned
7. Check the "News" page, the posts section should have left and right padding now
8. Check the "About" page, the "Past Team Member" section should have left and right padding now (I will fix the padding error in the PR for #124)