### PR TITLE
#164 change the point color on map to purple

### DIFF
--- a/src/components/map/mapArea.tsx
+++ b/src/components/map/mapArea.tsx
@@ -244,7 +244,7 @@ export default function MapArea({
                   source: id,
                   paint: {
                     "circle-radius": 5,
-                    "circle-color": "#007cbf", // future improvement: pass search result with its color code match to this component and put it here
+                    "circle-color": "#7E1CC4", // future improvement: pass search result with its color code match to this component and put it here
                   },
                 });
               }

--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -310,7 +310,7 @@ export default function SearchArea({
   return (
     <Grid container height={"calc(100vh - 172px)"}>
       <Grid item height={"100%"} sx={{ overflow: "scroll" }} xs={3}>
-        <Grid item xs={12} sx={{background: "aqua"}}>
+        <Grid item xs={12} sx={{background: "rgb(25, 118, 210)"}}>
             <h5>Spacial Resolution Select</h5>
             {Array.from(sRCheckboxes).map((checkbox, index) => (
               <span key={index}>


### PR DESCRIPTION
This PR is for issue #164. Based on the designer's request, temporarily change the points on the discovery map to #7E1CC4. Also, modify the color of the Spatial Resolution Selection to match the Search icon.

I put temporary color codes here. In the future, these will be modified based on the designer's final design

### How to Test

1. Run the app and navigate to the search page.
2. Verify that the map pin color has been changed to purple and the background color of the Spatial Resolution Selection has been changed to MUI blue.


