### PR TITLE
#172: add result list item component

### DIFF
--- a/src/components/search/iconText.tsx
+++ b/src/components/search/iconText.tsx
@@ -1,0 +1,36 @@
+import Image from "next/image";
+
+interface Props {
+  svgIcon: any;
+  label: string;
+  labelClass: string;
+  labelColor: string;
+  roundBackground: boolean;
+}
+const IconText: React.FC<Props> = ({
+  svgIcon,
+  label,
+  labelClass,
+  labelColor,
+  roundBackground,
+}): JSX.Element => {
+  return (
+    <div className="flex items-center shadow-none">
+      {roundBackground ? (
+        <div
+          className={`relative w-10 h-10 mr-2 flex items-center justify-center bg-white rounded-full`}
+        >
+          <Image src={svgIcon} alt="Icon" className="w-6 h-6" />
+        </div>
+      ) : (
+        // for single icon without background
+        <Image src={svgIcon} alt="Icon" className="w-6 h-6" />
+      )}
+      <span className={`${labelClass} truncate`} style={{ color: labelColor }}>
+        {label}
+      </span>
+    </div>
+  );
+};
+
+export default IconText;

--- a/src/components/search/resultCard.tsx
+++ b/src/components/search/resultCard.tsx
@@ -1,0 +1,85 @@
+import { makeStyles } from "@mui/styles";
+import * as React from "react";
+import tailwindConfig from "../../../tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+import IconText from "./iconText";
+
+interface Props {
+  title: string;
+  subject: string[];
+  creator: string;
+  publisher: string;
+  index_year: string[];
+  spatial_resolution: string[];
+  resource_class: string[];
+  icon: any;
+  link: string;
+}
+const fullConfig = resolveConfig(tailwindConfig);
+const useStyles = makeStyles((theme) => ({
+  resultCard: {
+    color: `${fullConfig.theme.colors["almostblack"]}`,
+    fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+    fontWeight: "400",
+    fontSize: "0.875rem",
+    paddingBottom: "0.5rem",
+  },
+}));
+
+const ResultCard = (props: Props): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <div
+      className={`container mx-auto p-5 bg-lightbisque shadow-none rounded-sm overflow-hidden aspect-ratio`}
+    >
+      <div className="flex flex-col sm:flex-row items-center mb-4">
+        <div className="flex flex-col sm:flex-row items-center w-full">
+          <IconText
+            roundBackground={true}
+            svgIcon={props.icon}
+            label={props.title}
+            labelClass={`text-l font-medium ${fullConfig.theme.fontFamily["sans"]}`}
+            labelColor={fullConfig.theme.colors["almostblack"]}
+          />
+          <div className="md:mt-4 sm:mt-0 order-1 sm:order-none w-full sm:ml-auto">
+            <a
+              href={props.link}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center justify-center sm:justify-end"
+              style={{ color: fullConfig.theme.colors["frenchviolet"] }}
+            >
+              View <span className="ml-1">&#8594;</span>
+            </a>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-col sm:flex-row">
+        <div className="flex-1 w-full sm:w-1/2">
+          <div className={`${classes.resultCard} truncate mb-1 md:mb-4 `}>
+            Subject: {props.subject[0]}
+          </div>
+          <div className={`${classes.resultCard} truncate mb-1 md:mb-4`}>
+            Creator: {props.creator}
+          </div>
+          <div className={`${classes.resultCard} truncate mb-1 md:mb-0`}>
+            Publisher: {props.publisher}
+          </div>
+        </div>
+        <div className="flex-1 w-full sm:w-1/2 sm:pl-8">
+          <div className={`${classes.resultCard} truncate mb-1 md:mb-4`}>
+            Year: {props.index_year.join(", ")}
+          </div>
+          <div className={`${classes.resultCard} truncate mb-1 md:mb-4`}>
+            Spatial Res: {props.spatial_resolution[0]}
+          </div>
+          <div className={`${classes.resultCard} truncate`}>
+            Resource: {props.resource_class[0]}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResultCard;

--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -24,8 +24,9 @@ import FilterObject from "./interface/FilterObject";
 import { generateFilter, runningFilter } from "./helper/FilterHelpMethods";
 import MapArea from "../map/mapArea";
 import { displayLayers } from "../map/helper/layers";
-
+import dataDiscoveryIcon from "@/public/logos/data-discovery-icon.svg";
 import CheckBoxObject from "../search/interface/CheckboxObject";
+import ResultCard from "./resultCard";
 
 export default function SearchArea({
   results,
@@ -414,19 +415,43 @@ export default function SearchArea({
           </Grid>
         </Grid>
       </Grid>
-      <Grid item xs={9}>
-        {fetchResults.length > 0 ? (
+
+      {fetchResults.length > 0 ? (
+        <Grid item xs={9}>
+          {/* NOTE: following styled items are matching the new design and will be moved to the new iframe once we are ready */}
+
+          {/* ViewOnly's width is set to 499px, same to design as example */}
+          <Grid item id="ResultCardViewOnly" width="499px">
+            {/* Result Card's width is set to fill its container's width */}
+            <ResultCard 
+              title="CDC Social Vulnerability Index"
+              subject={["Social Vulnerability Index"]}
+              creator="Agency for Toxic Substances and Disease Registry"
+              publisher="Centers for Disease Control and Prevention"
+              index_year={["2020", "2021", "2022", "2016", "2017", "2018", "2019"]}
+              spatial_resolution={["County", "ZCTA"]}
+              resource_class={["Dataset"]}
+              icon={dataDiscoveryIcon}
+              link="https://www.cdc.gov/socialvulnerability/index.html"
+            />
+          </Grid>
+
           <MapArea
             searchResult={fetchResults}
             resetStatus={resetStatus}
             srChecked={sRCheckboxes}
           />
-        ) : isLoading ? (
+        </Grid>
+      ) : isLoading ? (
+        <Grid item xs={9}>
+          {" "}
           <h1>Loading map...</h1>
-        ) : (
+        </Grid>
+      ) : (
+        <Grid item xs={9}>
           <h1>No results.</h1>
-        )}
-      </Grid>
+        </Grid>
+      )}
     </Grid>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,6 +41,7 @@ module.exports = {
     fontSize: {
       sm: "0.8rem",
       base: "1rem",
+      "l": "1.125rem",
       xl: "1.25rem",
       "2xl": "1.563rem",
       "3xl": "1.953rem",


### PR DESCRIPTION
This PR is for #172. I created the component to fit the container's size (in the code, I made the example container 499px to simulate the design). We don't have the mobile design, but I aligned the elements vertically for small screens.

Note that we will need new icons. Currently, I just pass an existing icon on the home page to the test component.

-----
### How to Test

- Navigate to the search page; an example result component should be on the top.
<img width="995" alt="Screenshot 2024-07-01 at 3 17 18 PM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/844bb47b-da43-46a2-9d15-6bc0bc199fac">

- Change to mobile view and check the mobile layout of this component.
<img width="331" alt="Screenshot 2024-07-01 at 3 17 44 PM" src="https://github.com/healthyregions/SDOHPlace/assets/92752107/be91cff8-b6d7-4774-9efa-9c2d66c204e8">

-----
During the development, I found that it would be better to define the exact objects under 'meta' field for the SolrObject. 

Originally I have 
``` javascript
export interface SolrObject {
  id: string;
  title: string;
  ...
  meta: { [key: string]: string | string[] };
  ...
}
```
but `string | string[]` type can cause some problems when passing these meta fields as attributes of the component, so I will work on #176 

After this ticket, I will work on #173.