### PR TITLE
#176: add other meta fields to solrObject type

### DIFF
--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -31,7 +31,9 @@ const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
           return year.toString();
         })
     : [];
-  result.meta = {};
+  result.meta = {
+    
+  };
   result.years = new Set();
   if (rawSolrObject.dct_isVersionOf_sm)
     // child object only

--- a/meta/interface/SolrObject.ts
+++ b/meta/interface/SolrObject.ts
@@ -1,29 +1,41 @@
 /**
- * ISSUE 74: Take raw solr object and re-structure it to be more readable
- * Principle: all required attributes of Aardvark are first level attributes; all other attributes are nested under meta
- *
- * Structure:
- * {
- * "id": "123",
- * "title": "dct_title_s",
- * "id", "modified",...
- * "meta":
- *  {
- *  ALL OTHER FIELDS since we don't know what need to be used for now
- * }
- * }
- */
+ * Principle: all required attributes of Aardvark are first level attributes; 
+ * All other attributes are nested under meta with clear type definition and additional attributes are added as needed.
+ * Note that not all attributes in metadata managers are here. Only ones returned by search results are included.
+*/
 export interface SolrObject {
   id: string;
   title: string;
   creator: string[];
   description: string;
-  index_year: string[]; //this is the year attribute of the original SolrObject
+  index_year: string[];
   metadata_version: string;
   modified: string;
   access_rights: string[];
   resource_class: string[];
-  meta: { [key: string]: string | string[] };
+  meta: { 
+    access_rights?: string;
+    language?: string;
+    publisher?: string;
+    provider?: string;
+    resource_type?: string;
+    subject?: string;
+    theme?: string;
+    issued?: string;
+    temporal?: string;
+    reference?: any;
+    rights?: string;
+    md_modified?: string;
+    md_version?: string;
+    suppress?: boolean;
+    spacial_resolution?: string[];
+    data_usage_notes?: string;
+    data_variables?: string[];
+    methods_variables?: string[];
+    version?: string;
+    timestamp?: string;
+    score?: number;
+   };
   years: Set<string>;
   parents?: string[];
 }


### PR DESCRIPTION
This PR addresses #176. It is a simple update to the Solr object type before moving on to the next stage of UI development. By adding clear types for attributes, we can avoid many "if" loops in the data processing.

I'll continue to update the attributes list while working on #172.