### PR TITLE
#181: add html parsing to description, usage tips and display_notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "axios": "^1.6.8",
     "classnames": "2.3.2",
     "date-fns": "^2.30.0",
+    "dompurify": "^3.1.6",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
     "maplibre-gl": "2.4.0",

--- a/src/components/search/detailPanel/headerRow/headerRow.tsx
+++ b/src/components/search/detailPanel/headerRow/headerRow.tsx
@@ -6,7 +6,8 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import { SolrObject } from "../../../../../meta/interface/SolrObject";
 import { updateSearchParams } from "../../helper/ManageURLParams";
 import Image from "next/image";
-import { Box, Button, IconButton, Typography } from "@mui/material";
+import DOMPurify from 'dompurify';
+import { Box } from "@mui/material";
 import ButtonWithIcon from "@/components/homepage/buttonwithicon";
 import { ParseReferenceLink } from "../../helper/ParseReferenceLink";
 import ShareModal from "./shareModal";
@@ -119,7 +120,7 @@ const HeaderRow = (props: Props): JSX.Element => {
 
       {props.resultItem.description ? (
         <div className="flex flex-col sm:flex-row items-center">
-          <p className="text-base">{props.resultItem.description}</p>
+          <div className="text-base" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(props.resultItem.description) }} />
         </div>
       ) : null}
     </div>

--- a/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
+++ b/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
@@ -1,5 +1,6 @@
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
+import DOMPurify from "dompurify";
 import tailwindConfig from "../../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import { displayNotesIcons } from "./displayNotesIcons";
@@ -43,7 +44,10 @@ const DisplayNote = ({ title, value }) => {
         />
       )}
       <b>{title ? title : "Notes"}:</b>
-      <span className={classes.paragraphCard}>{value}</span>
+      <span
+        className={classes.paragraphCard}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(value) }}
+      />
     </div>
   );
 };
@@ -53,7 +57,10 @@ const UsageTip = ({ value }) => {
   return (
     <div className={`container`}>
       &#128161; <b>Usage Tip:</b>
-      <span className={classes.paragraphCard}>{value}</span>
+      <span
+        className={classes.paragraphCard}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(value) }}
+      />
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,6 +3789,11 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
+dompurify@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.6.tgz#43c714a94c6a7b8801850f82e756685300a027e2"
+  integrity sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==
+
 domutils@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"


### PR DESCRIPTION
This PR is for #181. I changed the description, usage tips, and display notes for the HTML rendering style.

Currently, I haven't found any result items to test, but you can modify the code to replace the props value with some HTML code, and the result should be rendered in HTML style.

Please let me know if we want other fields to follow this pattern.