### PR TITLE
#180: create the search component based on the new UI design

### DIFF
--- a/src/components/map/mapArea.tsx
+++ b/src/components/map/mapArea.tsx
@@ -144,7 +144,7 @@ export default function MapArea({
       const map = mapRef.current.getMap();
 
       let selectDisplayLayers = new Array<LayerDef>();
-      // get all needed interactive layers based on current presented results's spacial resolution
+      // get all needed interactive layers based on current presented results's spatial resolution
       searchResult.forEach((result) => {
         if (result.meta["spatial_resolution"]) {
           const spatial_res =
@@ -349,7 +349,7 @@ export default function MapArea({
   };
 
   //   let testDisplayLayers = currentDisplayLayers;
-  //   // get all needed interactive layers based on current presented results's spacial resolution
+  //   // get all needed interactive layers based on current presented results's spatial resolution
   //   searchResult.forEach((result) => {
   //     if (result.meta["spatial_resolution"]) {
   //       const spatial_res =

--- a/src/components/search/detailPanel/headerRow/headerRow.tsx
+++ b/src/components/search/detailPanel/headerRow/headerRow.tsx
@@ -6,7 +6,7 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import { SolrObject } from "../../../../../meta/interface/SolrObject";
 import { updateSearchParams } from "../../helper/ManageURLParams";
 import Image from "next/image";
-import { Box, Button, IconButton, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 import ButtonWithIcon from "@/components/homepage/buttonwithicon";
 import { ParseReferenceLink } from "../../helper/ParseReferenceLink";
 import ShareModal from "./shareModal";

--- a/src/components/search/parentList.tsx
+++ b/src/components/search/parentList.tsx
@@ -125,7 +125,7 @@ export default function ParentList({
             </Link>
           )}
           {selectedRecord && selectedRecord.meta["spatial_resolution"] && (
-            // test only: show spacial resolution
+            // test only: show spatial resolution
             <List>
               <ListItem>
                 Spatial Resolution: {selectedRecord.meta["spatial_resolution"]}

--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -30,7 +30,7 @@ import ResultCard from "./resultCard";
 import DetailPanel from "./detailPanel/detailPanel";
 
 import { updateSearchParams } from "@/components/search/helper/ManageURLParams";
-import IconMatch from "./helper/IconMatch";
+import SearchRow from "./searchArea/searchRow";
 
 export default function SearchArea({
   results,
@@ -408,15 +408,21 @@ export default function SearchArea({
 
   return (
     <Grid container height={"calc(100vh - 172px)"}>
+      <Grid item xs={12}>
+        <SearchRow
+          header={"Data Discovery"}
+          description="Our data discovery platform provides access to spatially indexed and curated databases,specifically designed for conducting health equity research."
+          spatial_resolution_list={["City", "Zip", "County", "Tract"]}
+          schema={schema}
+        />
+      </Grid>
       <Grid item height={"100%"} sx={{ overflow: "scroll" }} xs={3}>
         <Grid item xs={12} sx={{ background: "#ECE6F0" }}>
           {/* ViewOnly's width is set to 499px, same to design as example */}
           {/* Result Card's width is set to fill its container's width */}
-          {
-            fetchResults.map((result) => (
-              <ResultCard key={result.id} resultItem={result} />
-            ))
-          }
+          {fetchResults.map((result) => (
+            <ResultCard key={result.id} resultItem={result} />
+          ))}
           <h5>Spatial Resolution</h5>
           {Array.from(sRCheckboxes).map((checkbox, index) => (
             <span key={index}>

--- a/src/components/search/searchArea.tsx
+++ b/src/components/search/searchArea.tsx
@@ -412,7 +412,6 @@ export default function SearchArea({
         <SearchRow
           header={"Data Discovery"}
           description="Our data discovery platform provides access to spatially indexed and curated databases,specifically designed for conducting health equity research."
-          spatial_resolution_list={["City", "Zip", "County", "Tract"]}
           schema={schema}
         />
       </Grid>

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -1,0 +1,231 @@
+import * as React from "react";
+import SearchIcon from "@mui/icons-material/Search";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Checkbox,
+  Grid,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Popper,
+  TextField,
+} from "@mui/material";
+import tailwindConfig from "../../../../tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+import { updateSearchParams } from "@/components/search/helper/ManageURLParams";
+import { useSearchParams, usePathname } from "next/navigation";
+import { useRouter } from "next/router";
+import { makeStyles } from "@mui/styles";
+import { SearchObject } from "../interface/SearchObject";
+import SolrQueryBuilder from "../helper/SolrQueryBuilder";
+import SuggestedResult from "../helper/SuggestedResultBuilder";
+
+interface Props {
+  schema: any;
+}
+const fullConfig = resolveConfig(tailwindConfig);
+const useStyles = makeStyles((theme) => ({
+  searchBox: {
+    fontFamily: `${fullConfig.theme.fontFamily["sans"]} !important`,
+    // remove the button border and 'x' sign in the input field and other default hover settings
+    "& input": {
+      "&:focus": {
+        outline: "none",
+        borderColor: "transparent",
+        boxShadow: "none",
+      },
+      "&::-webkit-search-cancel-button": {
+        display: "none",
+      },
+    },
+    "& .MuiOutlinedInput-root": {
+      "&:hover .MuiOutlinedInput-notchedOutline": {
+        borderColor: "transparent",
+      },
+      "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+        borderColor: "transparent",
+      },
+    },
+  },
+  popper: {
+    borderRadius: "1em !important",
+  },
+  paper: {
+    fontFamily: `${fullConfig.theme.fontFamily["sans"]} !important`,
+    fontColor: `${fullConfig.theme.colors["smokegray"]}`,
+    fontSize: "0.875em",
+    marginTop: "0.1em",
+    width: "60%",
+    transform: "translateX(10%)",
+  },
+}));
+const CustomPopper = (props) => {
+  const classes = useStyles();
+  return (
+    <Popper {...props} className={classes.popper} placement="bottom-start" />
+  );
+};
+
+const CustomPaper = (props) => {
+  const classes = useStyles();
+  return <Paper {...props} className={classes.paper} />;
+};
+
+const SearchBox = (props: Props): JSX.Element => {
+  const classes = useStyles();
+  const searchParams = useSearchParams();
+  const currentPath = usePathname();
+  const router = useRouter();
+  const [autocompleteKey, setAutocompleteKey] = React.useState(0);
+  const [userInput, setUserInput] = React.useState("");
+  const [options, setOptions] = React.useState([]);
+  const [queryData, setQueryData] = React.useState<SearchObject>({
+    userInput: "",
+  });
+  let searchQueryBuilder = new SolrQueryBuilder();
+  searchQueryBuilder.setSchema(props.schema);
+  const processResults = (results, value) => {
+    suggestResultBuilder.setSuggester("mySuggester"); //this could be changed to a different suggester
+    suggestResultBuilder.setSuggestInput(value);
+    suggestResultBuilder.setResultTerms(JSON.stringify(results));
+  };
+  let suggestResultBuilder = new SuggestedResult();
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    updateSearchParams(
+      router,
+      searchParams,
+      currentPath,
+      "query",
+      userInput,
+      "overwrite"
+    );
+  };
+  const handleDropdownSelect = (event, value) => {
+    updateSearchParams(
+      router,
+      searchParams,
+      currentPath,
+      "query",
+      value,
+      "overwrite"
+    );
+  };
+  // This needs to be updated after switching to the new method
+  const handleReset = () => {
+    setAutocompleteKey(autocompleteKey + 1);
+  };
+  const handleUserInputChange = async (event, value) => {
+    setQueryData({
+      ...queryData,
+      userInput: value,
+    });
+    if (value !== "") {
+      searchQueryBuilder.suggestQuery(value);
+      searchQueryBuilder
+        .fetchResult()
+        .then((result) => {
+          processResults(result, value);
+          setOptions(suggestResultBuilder.getTerms());
+        })
+        .catch((error) => {
+          console.error("Error fetching result:", error);
+        });
+    } else {
+      handleReset();
+    }
+  };
+  return (
+    <div className={`sm:mt-6 sm:mb-12 sm:ml-[2em]`}>
+      <form id="search-form" onSubmit={handleSubmit}>
+        <Autocomplete
+          PopperComponent={CustomPopper}
+          PaperComponent={CustomPaper}
+          key={autocompleteKey}
+          freeSolo
+          options={options}
+          defaultValue={searchParams.get("query")?.toString() || ""}
+          onInputChange={(event, value, reason) => {
+            if (event && event.type === "change") {
+              setUserInput(value);
+              handleUserInputChange(event, value);
+            }
+          }}
+          onChange={(event, value) => {
+            setUserInput(value);
+            handleDropdownSelect(event, value);
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              variant="outlined"
+              fullWidth
+              placeholder="Search"
+              className={`${classes.searchBox} bg-white`}
+              sx={{
+                borderRadius: "1.75em",
+                border: `1px solid ${fullConfig.theme.colors["frenchviolet"]}`,
+                "& .MuiOutlinedInput-root": {
+                  borderRadius: "1.75em",
+                  color: fullConfig.theme.colors["smokegray"],
+                  "&:hover .MuiOutlinedInput-notchedOutline": {
+                    borderColor: "transparent",
+                  },
+                },
+                "& .MuiOutlinedInput-notchedOutline": {
+                  borderColor: "transparent",
+                },
+              }}
+              InputProps={{
+                ...params.InputProps,
+                startAdornment: (
+                  <InputAdornment position="start" className="mr-2">
+                    <SearchIcon className="text-2xl" />
+                  </InputAdornment>
+                ),
+                endAdornment: (
+                  <Box display="flex" alignItems="center">
+                    <Box component="span" className="mr-2">
+                      <a
+                        href="#" // This needs to be updated after decide the advanced search page
+                        className={`text-frenchviolet no-underline ${classes.searchBox}`}
+                      >
+                        Advanced
+                      </a>
+                    </Box>
+                    <InputAdornment position="end">
+                      <Button
+                        type="submit"
+                        variant="contained"
+                        color="primary"
+                        sx={{
+                          minWidth: "auto",
+                          padding: 0,
+                          borderRadius: "50%",
+                          width: "2.25em",
+                          height: "2.25em",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          backgroundColor:
+                            fullConfig.theme.colors["frenchviolet"],
+                        }}
+                      >
+                        <ArrowForwardIcon />
+                      </Button>
+                    </InputAdornment>
+                  </Box>
+                ),
+                type: "search",
+              }}
+            />
+          )}
+        />
+      </form>
+    </div>
+  );
+};
+export default SearchBox;

--- a/src/components/search/searchArea/searchRow.tsx
+++ b/src/components/search/searchArea/searchRow.tsx
@@ -1,0 +1,91 @@
+import { makeStyles } from "@mui/styles";
+import * as React from "react";
+import tailwindConfig from "../../../../tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+import SpatialResolutionCheck from "./spatialResolutionCheck";
+import SearchBox from "./searchBox";
+import { Box, Grid, Typography } from "@mui/material";
+
+interface Props {
+  spatial_resolution_list: {};
+  header: string;
+  description: string;
+  schema: any;
+}
+const fullConfig = resolveConfig(tailwindConfig);
+const useStyles = makeStyles((theme) => ({
+  searchRow: {
+    color: `${fullConfig.theme.colors["almostblack"]}`,
+    fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+  },
+}));
+const SearchRow = (props: Props): JSX.Element => {
+  const classes = useStyles();
+  const spatialResOptions = [
+    {
+      value: "state",
+      display_name: "State",
+    },
+    {
+      value: "county",
+      display_name: "County",
+    },
+    {
+      value: "zcta",
+      display_name: "Zip Code",
+    },
+    {
+      value: "tract",
+      display_name: "Tract",
+    },
+    {
+      value: "bg",
+      display_name: "Block Group",
+    },
+    {
+      value: "place",
+      display_name: "City",
+    },
+  ];
+  return (
+    <Box className={`w-full shadow-none aspect-ratio bg-lightviolet`}>
+      <Grid container className="sm:mb-7">
+        <Grid
+          item
+          xs={12}
+          sm={4}
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          className="py-[2em] px-[2em] sm:pt-[3em] sm:pl-[2em]"
+        >
+          <Box width="100%">
+            <SpatialResolutionCheck src={spatialResOptions} />
+          </Box>
+          <Box width="100%" className="mt-[2em] sm:mt-0 sm:mb-5xl ">
+            <SearchBox schema={props.schema} />
+          </Box>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          sm={8}
+          display="flex"
+          flexDirection="column"
+          justifyContent={{ xs: "center", sm: "flex-start" }}
+          alignItems={{ xs: "center", sm: "flex-start" }}
+          order={{ xs: 1, sm: 0 }}
+          className={`py-[1em] pb-[2em] sm:pt-[3em] sm:pl-[4em] ${classes.searchRow}`}
+        >
+          <div className="text-3xl sm:text-4xl text-center sm:text-left">
+            {props.header}
+          </div>
+          <div className="text-s lg:pr-[20em] text-center sm:text-left">
+            {props.description}
+          </div>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+export default SearchRow;

--- a/src/components/search/searchArea/searchRow.tsx
+++ b/src/components/search/searchArea/searchRow.tsx
@@ -7,7 +7,6 @@ import SearchBox from "./searchBox";
 import { Box, Grid, Typography } from "@mui/material";
 
 interface Props {
-  spatial_resolution_list: {};
   header: string;
   description: string;
   schema: any;

--- a/src/components/search/searchArea/spatialResolutionCheck.tsx
+++ b/src/components/search/searchArea/spatialResolutionCheck.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import CheckBoxObject from "../interface/CheckboxObject";
+import { Checkbox } from "@mui/material";
+import { updateSearchParams } from "@/components/search/helper/ManageURLParams";
+import { useSearchParams, usePathname } from "next/navigation";
+import { useRouter } from "next/router";
+import { styled } from "@mui/material/styles";
+
+interface SpatialResolutionCheck {
+  value: string;
+  display_name: string;
+}
+interface Props {
+  src: SpatialResolutionCheck[];
+}
+
+const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
+  "&.Mui-checked": {
+    color: "transparent",
+    "& .MuiSvgIcon-root": {
+      backgroundColor: "#7E1CC4",
+      borderRadius: "4px",
+      border: "1px solid #7E1CC4",
+      padding: "0px",
+    },
+    "& .MuiSvgIcon-root path": {
+      display: "none",
+    },
+  },
+  "& .MuiSvgIcon-root": {
+    borderRadius: "4px",
+    border: "1px solid #7E1CC4",
+  },
+  color: "transparent",
+}));
+
+const SpatialResolutionCheck = (props: Props): JSX.Element => {
+  const searchParams = useSearchParams();
+  const currentPath = usePathname();
+  const router = useRouter();
+  const [resetStatus, setResetStatus] = React.useState(true);
+  let tempSRChecboxes = new Set<CheckBoxObject>();
+  props.src.forEach((option) => {
+    tempSRChecboxes.add({
+      attribute: "special_resolution",
+      value: option.value,
+      checked: searchParams.get("layers")
+        ? searchParams.get("layers").toString().includes(option.value)
+        : false,
+      displayName: option.display_name,
+    });
+  });
+  const [sRCheckboxes, setSRCheckboxes] = React.useState(
+    new Set<CheckBoxObject>(tempSRChecboxes)
+  );
+  const handleSRSelectionChange = (event) => {
+    const { value, checked } = event.target;
+    updateSearchParams(
+      router,
+      searchParams,
+      currentPath,
+      "layers",
+      value,
+      checked ? "add" : "remove"
+    );
+    const updatedSet = new Set(
+      Array.from(sRCheckboxes).map((obj) => {
+        if (obj.value === value) {
+          return { ...obj, checked: checked };
+        }
+        return obj;
+      })
+    );
+    setSRCheckboxes(updatedSet);
+    setResetStatus(!resetStatus);
+  };
+  return (
+    // <div style={{ minWidth: props.minWidth }} className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4"> 
+   <div className="flex flex-row flex-wrap justify-evenly">
+      {Array.from(sRCheckboxes).map((checkbox, index) => (
+        <div key={index}>
+          <div className="flex flex-col items-center justify-center flex-grow">
+            <CustomCheckbox
+              checked={
+                checkbox.value === "county" ||
+                checkbox.value === "state" ||
+                checkbox.checked
+              }
+              value={checkbox.value}
+              onChange={handleSRSelectionChange}
+              disabled={
+                checkbox.value === "county" || checkbox.value === "state"
+              }
+            />
+            <div className="text-center text-l" style={{ letterSpacing: 0.5 }}>
+              {checkbox.displayName}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+export default SpatialResolutionCheck;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -117,7 +117,6 @@ const Search: NextPage<SearchPageProps> = ({ schema }) => {
 
   return (
     <>
-      <Header title={"Data Discovery"} />
       <NavBar />
       <TopLines />
       <Modal
@@ -195,7 +194,7 @@ const Search: NextPage<SearchPageProps> = ({ schema }) => {
                   attribute: "provider",
                   displayName: "Provider",
                 },
-                // Move the Spacial Resolution to the top as a distinct filter
+                // Move the Spatial Resolution to the top as a distinct filter
                 // {
                 //   attribute: "spatial_resolution",
                 //   displayName: "Spatial Resolution",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,10 +21,15 @@ module.exports = {
         black: "#000",
         salmonpink: "#ff9c77",
         frenchviolet: "#7e1cc4",
+        lightviolet: "#ECE6F0",
         lightbisque: "#ffe5c4",
-        strongorange: "#FF9C77"
+        strongorange: "#FF9C77",
       },
       spacing: {},
+      flexGrow: {
+        1: 1,
+        2: 2,
+      },
       fontFamily: {
         // sans is the default font applied by tailwind, so alias
         // it to our custom font
@@ -50,6 +55,7 @@ module.exports = {
       "4xl": "2.441rem",
       "5xl": "3.052rem",
       "6xl": "5rem",
+      4: "4rem",
       inherit: "inherit",
       "2xl-rfs": "clamp(1.125rem, 0.8vw + 0.5rem, 1.5rem)",
       "xl-rfs": "clamp(0.875rem, 0.8vw + 0.3rem, 1.125rem)",


### PR DESCRIPTION
This PR is for #180. It creates the search panel at the top of the search page based on the new design. This PR still uses the previous methods of handling parameters. After creating the frame page to include all components, the method will be reviewed and updated. Some width ratios in the search area may also be adjusted after including other components on the page.

## How to Test

1. Navigate to the search page. The search area is placed at the top of the screen.

2. For spatial resolution checkboxes, I used the original list of spatial resolutions. Among them, the State and County checkboxes are set to be checked by default and uneditable (we can remove them as well). Other checkboxes can be turned on and off. The map will reflect the changes.

<img width="619" alt="Screenshot 2024-07-19 at 11 56 40 AM" src="https://github.com/user-attachments/assets/b7294fb6-d23b-48dc-9575-9d17e297e68e">


3. The search input field has been modified to reflect the new UI design. The 'Advanced' button is currently not functional; I placed it there as a placeholder.

4. Begin to type and search. The autocomplete dropdown appears when the user begins to type, and the user can click the pre-populated data or the search button to see the result, as before.

5. After submitting a query and getting the result, copy and paste the current URL into another browser. The state of the page should be maintained in the new window.