### PR TITLE
252 better slug handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,38 +18,7 @@ Or
 
 - Switch to the `publish` branch and make direct edits to the `.mdx` files in `content/news`
 
-### Tips for Writing Blog Posts
-
-- Each post should have at least one tag.
-- Don't use `<` or `>` in the text of a post. If you need those characters, use `&lt;` (lt = "less than") and `&gt;` (gt = "greater than").
-  - The reason for this is that markdown can support inclusion of HTML elements, which look like `<element-name>`. If `<>` are found outside of a valid HTML element, they will cause an error.
-- Do not include raw links directly in the post text, always make normal text, highlight, and then add a link to it.
-  - For example, make a link that looks like [sdohplace.org](https://sdohplace.org) instead of putting `https://sdohplace.org` directly in the post body
-- To add a caption under an image, use these three steps:
-
-  1. First, add the image as usual, using the + button in the **Rich Text** editor.
-  2. Next, switch the editor mode to **Markdown** and find the line for the image. It should look something like
-     ```
-     ![](/images/sdoh_place.png)
-     ```
-  3. Now, copy the following code block and place it below the image line:
-     ```
-     <figure>
-       <img src="">
-       <figcaption>add your caption here</figcaption>
-     </figure>
-     ```
-  4. Take the path from the original image tag and put it into the new `src` attribute, and then update your caption as desired. For example:
-     ```
-     <figure>
-       <img src="/images/sdoh_place.png">
-       <figcaption>"SDOH model" by Skbanergt is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0">CC BY-SA 4.0</a></figcaption>
-     </figure>
-     ```
-     Note that to place a link in the caption, you need to use a full `<a>` element.
-  5. Finally, you should see the figure and caption looking good in the post preview, and you can remove the original image line.
-
-- If you need to change the slug of the post after it has been created, you will also need to manually change the file name to match the new slug.
+A full guide to using the CMS is available internally on our Notion workspace.
 
 ## Branch Configuration
 

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -296,7 +296,7 @@ collections:
     extension: "mdx"
     format: "frontmatter"
     create: true
-    slug: "{{slug}}"
+    slug: "{{field.slug}}"
     identifier_field: slug
     summary: "{{title}}"
     fields:
@@ -306,6 +306,7 @@ collections:
       - label: "Slug"
         name: "slug"
         widget: "string"
+        hint: "The slug must contain only lowercase letters, numbers, and hyphens. It will name the file and be used in the URL for this entry. It shouldn't be changed after this entry is saved."
       - label: "Publish Date"
         name: "date"
         widget: "datetime"
@@ -356,7 +357,7 @@ collections:
     extension: "mdx"
     format: "frontmatter"
     create: true # Allow users to create new documents in this collection
-    slug: "{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
+    slug: "{{field.slug}}"
     fields: # The fields for each document, usually in front matter
       - label: "Project Title"
         name: "title"
@@ -364,6 +365,7 @@ collections:
       - label: "Slug"
         name: "slug"
         widget: "string"
+        hint: "The slug must contain only lowercase letters, numbers, and hyphens. It will name the file and be used in the URL for this entry. It shouldn't be changed after this entry is saved."
       - label: "Featured Image"
         name: "image"
         widget: "image"

--- a/public/styles/posts.module.css
+++ b/public/styles/posts.module.css
@@ -47,7 +47,9 @@
 
 .content p,
 .content ul,
-.content ol {
+.content ol,
+.content details,
+.content details > summary {
   font-size: 1.25rem;
 }
 .content p {

--- a/src/components/showcase/ShowcaseItem.tsx
+++ b/src/components/showcase/ShowcaseItem.tsx
@@ -6,7 +6,6 @@ type Props = {
   item: ShowcaseContent;
 };
 export default function ShowcaseItem({ item }: Props) {
-  console.log(item);
   return (
     <Link href={"/showcase/" + item.slug} legacyBehavior>
       <a className={"no-underline"}>

--- a/src/components/showcase/ShowcaseLayout.tsx
+++ b/src/components/showcase/ShowcaseLayout.tsx
@@ -74,19 +74,6 @@ export default function ShowcaseLayout({
           <header>
             <h1>{title}</h1>
           </header>
-          <div className={"text-smokegray font-light italic text-base"}>
-            <p>
-              Earlier this year, we invited{" "}
-              <Link href="/fellows">fifteen fellows</Link> to develop their own
-              web mapping applications, centered on equity and designed with
-              communities in mind, using the{" "}
-              <Link href="https://toolkit.sdohplace.org">
-                SDOH &amp; Place Toolkit
-              </Link>
-              . From July to September, we&apos;ll feature final fellow
-              applications each week.
-            </p>
-          </div>
           <div className="relative">
             <Image
               src={image}

--- a/src/pages/showcase/[showcase].tsx
+++ b/src/pages/showcase/[showcase].tsx
@@ -20,7 +20,7 @@ export type Props = {
   link: string;
   tags: string[];
   fellowName: string;
-  techUsed: string;
+  techUsed?: string;
   description?: string;
   source: MDXRemoteSerializeResult;
 };
@@ -44,7 +44,7 @@ export default function Post({
   link,
   tags,
   fellowName,
-  techUsed,
+  techUsed = "",
   description = "",
   source,
 }: Props) {
@@ -91,7 +91,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       title: data.title,
       slug: data.slug,
       image: data.image,
-      techUsed: data.tech_used,
+      techUsed: data.tech_used ? data.tech_used : "",
       link: data.link,
       fellowName: data.fellow,
       source: mdxSource,


### PR DESCRIPTION
Adds a bit of help text around the slug field in posts/showcase entries in the CMS. Also a few small style updates, and removing the intro text from the top of showcase pages.