### PR TITLE
Fix the infinitely re-rendering of DiscoverArea and its subcomponents

### DIFF
--- a/src/components/search/resultsPanel/resultsPanel.tsx
+++ b/src/components/search/resultsPanel/resultsPanel.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
 
 const ResultsPanel = (props: Props): JSX.Element => {
   const classes = useStyles();
-  
+  console.log("ResultsPanel", props.resultsList);
   return (
     <div className="results-panel" style={{ flex: '1 1 auto', overflow: 'hidden' }}>
     <span className={`${classes.resultsPanel}`}>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -4,9 +4,6 @@ import { GetStaticProps } from "next";
 import NavBar from "@/components/NavBar";
 import * as React from "react";
 import { useState, useEffect } from "react";
-
-import resolveConfig from "tailwindcss/resolveConfig";
-import tailwindConfig from "tailwind.config.js";
 import { initSolrObject } from "meta/helper/solrObjects";
 import { SolrObject } from "meta/interface/SolrObject";
 import { getSchema, SchemaObject } from "@/components/search/helper/GetSchema";
@@ -15,28 +12,7 @@ import { SearchUIConfig } from "@/components/searchUIConfig";
 import DiscoveryArea from "@/components/search/discoveryArea";
 import SearchTopLines from "@/components/search/SearchTopLines";
 
-const fullConfig = resolveConfig(tailwindConfig);
-
 const solrUrl = process.env.NEXT_PUBLIC_SOLR_URL;
-
-const modalBoxStyle = {
-  position: "absolute" as "absolute",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  width: "90%",
-  maxWidth: "1068px",
-  maxHeight: "100vh",
-  color: "white",
-  bgcolor: `${fullConfig.theme.colors["darkgray"]}`,
-  border: "2px solid #000",
-  boxShadow: 24,
-  p: 4,
-  paddingTop: "10px",
-  overflowY: "auto",
-};
-const sideBarStyle = {};
-
 interface SearchPageProps {
   schema: SchemaObject;
 }
@@ -51,7 +27,6 @@ export const getStaticProps: GetStaticProps<SearchPageProps> = async () => {
 };
 
 const Search: NextPage<SearchPageProps> = ({ schema }) => {
-  const [open, setOpen] = React.useState(true);
   const [solrObjectResults, setSolrObjectResults] = useState(
     [] as SolrObject[]
   );

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,18 +1,15 @@
 "use client";
 import type { NextPage } from "next";
 import { GetStaticProps } from "next";
-import { usePathname, useSearchParams } from "next/navigation";
 import NavBar from "@/components/NavBar";
 import * as React from "react";
-import { useState, useEffect, useMemo } from "react";
-import { useRouter } from "next/router";
+import { useState, useEffect } from "react";
 
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "tailwind.config.js";
 import { initSolrObject } from "meta/helper/solrObjects";
 import { SolrObject } from "meta/interface/SolrObject";
 import { getSchema, SchemaObject } from "@/components/search/helper/GetSchema";
-import { updateSearchParams } from "@/components/search/helper/ManageURLParams";
 import Footer from "@/components/homepage/footer";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import DiscoveryArea from "@/components/search/discoveryArea";
@@ -55,10 +52,6 @@ export const getStaticProps: GetStaticProps<SearchPageProps> = async () => {
 
 const Search: NextPage<SearchPageProps> = ({ schema }) => {
   const [open, setOpen] = React.useState(true);
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
-  const [data, setData] = useState(null);
-  const [allResults, setAllResults] = useState([]);
   const [solrObjectResults, setSolrObjectResults] = useState(
     [] as SolrObject[]
   );
@@ -74,10 +67,6 @@ const Search: NextPage<SearchPageProps> = ({ schema }) => {
         setLoading(false);
       });
   }, [solrUrl, schema]);
-  const memoizedSolrObjectResults = useMemo(
-    () => solrObjectResults,
-    [solrObjectResults]
-  );
   return (
     <>
       <NavBar />

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -4,7 +4,7 @@ import { GetStaticProps } from "next";
 import { usePathname, useSearchParams } from "next/navigation";
 import NavBar from "@/components/NavBar";
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 
 import resolveConfig from "tailwindcss/resolveConfig";
@@ -63,21 +63,21 @@ const Search: NextPage<SearchPageProps> = ({ schema }) => {
     [] as SolrObject[]
   );
   const [isLoading, setLoading] = useState(true);
-
   useEffect(() => {
     fetch(solrUrl + "/select?q=*:*&rows=100")
       .then((res) => res.json())
       .then((data) => {
-        setData(data);
-        const solrObjectResults = [];
-        data.response.docs.map((doc, index) => {
-          solrObjectResults.push(initSolrObject(doc, schema));
-        });
+        const solrObjectResults = data.response.docs.map((doc) =>
+          initSolrObject(doc, schema)
+        );
         setSolrObjectResults(solrObjectResults);
         setLoading(false);
       });
-  });
-
+  }, [solrUrl, schema]);
+  const memoizedSolrObjectResults = useMemo(
+    () => solrObjectResults,
+    [solrObjectResults]
+  );
   return (
     <>
       <NavBar />


### PR DESCRIPTION
This PR addresses the issue of infinite re-rendering in `DiscoverArea` and its subcomponents, which can be observed by adding a console log in the component. The root cause was the `useEffect` in `index.tsx`, which is responsible for providing `solrObjectResults` to all components in `DiscoverArea`. Without dependencies, the `useEffect` was running on every render, causing `setSolrObjectResults` and other state setters to trigger additional renders, leading to the infinite loop.

I've added solrUrl and schema as dependencies, ensuring that `<DiscoverArea>` and its subcomponents only re-render when these two variables change. I also cleaned up some unused code in `index.tsx` after making this change.

## How to Test
Run the app and navigate to the search page. You should observe only two render cycles, as indicated by the console message in the `ResultPanel` component. The two renders are expected in development; in production, it should render only once.
<img width="1560" alt="Screenshot 2024-08-16 at 12 32 36 PM" src="https://github.com/user-attachments/assets/bdeb5a6d-6f88-4192-bbdd-223f87155c3a">


Please let me know if this makes sense to you. Please feel free to add more test messages to confirm the fix.