### PR TITLE
Update map component nuqs

### DIFF
--- a/src/components/map/mapArea.tsx
+++ b/src/components/map/mapArea.tsx
@@ -36,6 +36,8 @@ import {
 } from "../../components/map/helper/layers";
 import { sources } from "../../components/map/helper/sources";
 
+import { ZoomButton, EnableBboxSearchButton } from "./mapButtons";
+
 import getCountyGeo from "./helper/countyLocation";
 import CheckBoxObject from "../search/interface/CheckboxObject";
 
@@ -44,66 +46,15 @@ interface CustomMap extends maplibregl.Map {
   _popup?: maplibregl.Popup | null;
 }
 
-const statesBounds: LngLatBoundsLike = [-125.3321, 23.8991, -65.7421, 49.4325];
+const contiguousBounds: LngLatBoundsLike = [
+  -125.3321, 23.8991, -65.7421, 49.4325,
+];
 const alaskaBounds: LngLatBoundsLike = [
   -180, 50.5134265, -128.3203125, 71.3604977,
 ];
 const hawaiiBounds: LngLatBoundsLike = [
   -163.0371094, 16.5098328, -152.1826172, 25.9580447,
 ];
-const bounds = {
-  states: statesBounds,
-  alaska: alaskaBounds,
-  hawaii: hawaiiBounds,
-};
-// {
-//     results,
-//     isLoading,
-//     filterAttributeList,
-//   }: {
-//     results: SolrObject[];
-//     isLoading: boolean;
-//     filterAttributeList: {
-//       attribute: string;
-//       displayName: string;
-//     }[];
-//   }
-// just an example construction (see upper left corner of map)
-function NavigateButton({
-  label,
-  bounds,
-}: {
-  label: string;
-  bounds: LngLatBoundsLike;
-}) {
-  const { current: map } = useMap();
-
-  const onClick = () => {
-    if (map.getMap().getLayer(poiLayer.spec.id)) {
-      map.getMap().removeLayer(poiLayer.spec.id);
-    } else {
-      map.getMap().addLayer(poiLayer.spec, poiLayer.addBefore);
-    }
-    map.fitBounds(bounds);
-  };
-
-  return (
-    <button
-      onClick={onClick}
-      style={{
-        backgroundColor: "black",
-        margin: "15px",
-        fontSize: "1.5em",
-        padding: "5px",
-        color: "white",
-        zIndex: 1,
-        position: "relative",
-      }}
-    >
-      {label}
-    </button>
-  );
-}
 
 const parseAsLngLatBoundsLike = createParser({
   parse(queryValue) {
@@ -488,7 +439,7 @@ export default function MapArea({
       ref={mapRef}
       mapLib={maplibregl}
       initialViewState={{
-        bounds: bboxParam ? bboxParam : bounds.states,
+        bounds: bboxParam ? bboxParam : contiguousBounds,
       }}
       style={{
         width: "100%",
@@ -513,9 +464,10 @@ export default function MapArea({
           Id: {selectedState}
         </Popup>
       )} */}
-      <NavigateButton label="Con. US" bounds={bounds.states} />
-      <NavigateButton label="AK" bounds={bounds.alaska} />
-      <NavigateButton label="HI" bounds={bounds.hawaii} />
+      <ZoomButton label="Contiguous" bounds={contiguousBounds} />
+      <ZoomButton label="AK" bounds={alaskaBounds} />
+      <ZoomButton label="HI" bounds={hawaiiBounds} />
+      <EnableBboxSearchButton />
     </Map>
   );
 }

--- a/src/components/map/mapArea.tsx
+++ b/src/components/map/mapArea.tsx
@@ -444,40 +444,38 @@ export default function MapArea({
   }, [visLyrs, mapLoaded]);
 
   return (
-    <div style={{ height: "calc(100vh - 172px" }}>
-      <Map
-        id="discoveryMap"
-        ref={mapRef}
-        mapLib={maplibregl}
-        initialViewState={{
-          bounds: bounds.states,
-        }}
-        style={{
-          width: "100%",
-          height: "100%",
-        }}
-        mapStyle="https://api.maptiler.com/maps/3d4a663a-95c3-42d0-9ee6-6a4cce2ba220/style.json?key=bnAOhGDLHGeqBRkYSg8l"
-        onMouseMove={onHover}
-        onClick={onClick}
-        onLoad={() => setMapLoaded(true)}
-        interactiveLayerIds={["state-interactive"]}
-      >
-        {/* adding highlight layer here, to aquire the dynamic filter (maybe this can be done in a more similar pattern to the other layers) */}
-        <Layer {...hlStateLyr} filter={filterState} />
-        {/* {selectedState && (
-          <Popup
-            longitude={hoverInfo.longitude}
-            latitude={hoverInfo.latitude}
-            closeButton={false}
-            className="county-info"
-          >
-            Id: {selectedState}
-          </Popup>
-        )} */}
-        <NavigateButton label="Con. US" bounds={bounds.states} />
-        <NavigateButton label="AK" bounds={bounds.alaska} />
-        <NavigateButton label="HI" bounds={bounds.hawaii} />
-      </Map>
-    </div>
+    <Map
+      id="discoveryMap"
+      ref={mapRef}
+      mapLib={maplibregl}
+      initialViewState={{
+        bounds: bounds.states,
+      }}
+      style={{
+        width: "100%",
+        height: "100%",
+      }}
+      mapStyle="https://api.maptiler.com/maps/3d4a663a-95c3-42d0-9ee6-6a4cce2ba220/style.json?key=bnAOhGDLHGeqBRkYSg8l"
+      onMouseMove={onHover}
+      onClick={onClick}
+      onLoad={() => setMapLoaded(true)}
+      interactiveLayerIds={["state-interactive"]}
+    >
+      {/* adding highlight layer here, to aquire the dynamic filter (maybe this can be done in a more similar pattern to the other layers) */}
+      <Layer {...hlStateLyr} filter={filterState} />
+      {/* {selectedState && (
+        <Popup
+          longitude={hoverInfo.longitude}
+          latitude={hoverInfo.latitude}
+          closeButton={false}
+          className="county-info"
+        >
+          Id: {selectedState}
+        </Popup>
+      )} */}
+      <NavigateButton label="Con. US" bounds={bounds.states} />
+      <NavigateButton label="AK" bounds={bounds.alaska} />
+      <NavigateButton label="HI" bounds={bounds.hawaii} />
+    </Map>
   );
 }

--- a/src/components/map/mapButtons.tsx
+++ b/src/components/map/mapButtons.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useMap, LngLatBoundsLike } from "react-map-gl/maplibre";
+import { poiLayer } from "./helper/layers";
+import { parseAsBoolean, useQueryState } from "nuqs";
+
+const mapButtonStyle =
+  "mt-4 ml-4 text-almostblack py-1 px-2 border-strongorange rounded border relative z-1 font-sans text-base bg-lightbisque";
+
+export function ZoomButton({
+  label,
+  bounds,
+}: {
+  label: string;
+  bounds: LngLatBoundsLike;
+}) {
+  const { current: map } = useMap();
+
+  const onClick = () => {
+    if (map.getMap().getLayer(poiLayer.spec.id)) {
+      map.getMap().removeLayer(poiLayer.spec.id);
+    } else {
+      map.getMap().addLayer(poiLayer.spec, poiLayer.addBefore);
+    }
+    map.fitBounds(bounds);
+  };
+
+  return (
+    <button onClick={onClick} className={mapButtonStyle}>
+      {label}
+    </button>
+  );
+}
+
+export function EnableBboxSearchButton() {
+  const [bboxSearch, setBboxSearch] = useQueryState(
+    "bboxSearch",
+    parseAsBoolean.withDefault(false)
+  );
+
+  return (
+    <div className={`${mapButtonStyle} inline`}>
+      <label>
+        <input
+          type="checkbox"
+          checked={bboxSearch}
+          onChange={(e) => {
+            e.target.checked ? setBboxSearch(true) : setBboxSearch(null);
+          }}
+        />
+        &nbsp;Search this area
+      </label>
+    </div>
+  );
+}

--- a/src/components/search/mapPanel/mapPanel.tsx
+++ b/src/components/search/mapPanel/mapPanel.tsx
@@ -53,9 +53,7 @@ const MapPanel = (props: Props): JSX.Element => {
           height: `${SearchUIConfig.search.searchResults.resultListHeight}`,
         }}
       >
-        <div className="mb-[0.75em]">
-          <MapArea searchResult={props.resultsList} />
-        </div>
+        <MapArea searchResult={props.resultsList} />
       </Box>
       <Box className="sm:my-[1.68em]">
         <div className="sm:mb-[1.5em] sm:flex-col">


### PR DESCRIPTION
Some updates to the map component, still more work to do but it's a start.

- Replace layers param handling with `nuqs` per #235
- Add a `bbox` url param to track map panning, and use this param for initial load of map (if present)
- Style zoom to region buttons per mockups
- Add a "Search this area" checkbox and corresponding url param `bboxSearch=true`

@pengyin-shan For future reference, the idea is that if `bboxSearch=true`, then an additional filter will be applied to the search query that casts the value of the `bbox` param (i.e. the current extent of the map view) into a Solr-friendly query and runs against one of the geometry-related fields in the index, like `geometry` or `bounding_box`. In other words, every time the map is moved, the search results will update based on the bbox param, if that box is checked. We don't have metadata ready to really implement this yet, so I see it as a task that I'll come back to a couple weeks from now. Also, this feature isn't in the mockups, it's just something that I wanted to stub out because I have a feeling it will ultimately be desirable.