### PR TITLE
feat: create popover for glossary items

### DIFF
--- a/meta/glossary.json
+++ b/meta/glossary.json
@@ -1,0 +1,3 @@
+{
+    "health equity": "short description of health equity"
+}

--- a/src/components/GlossaryPopover.tsx
+++ b/src/components/GlossaryPopover.tsx
@@ -22,7 +22,7 @@ export default function GlossaryPopover({ entry }) {
     return (
       <>
         <button
-          className={"underline decoration-wavy"}
+          className={"underline decoration-dotted"}
           aria-describedby={id}
           onClick={handleClick}
         >

--- a/src/components/GlossaryPopover.tsx
+++ b/src/components/GlossaryPopover.tsx
@@ -1,0 +1,58 @@
+import glossaryEntries from "../../meta/glossary.json";
+import * as React from "react";
+import Popover from "@mui/material/Popover";
+
+export default function GlossaryPopover({ entry }) {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? `${entry}-popover` : undefined;
+
+  if (glossaryEntries[entry]) {
+    return (
+      <>
+        <button
+          className={"underline decoration-wavy"}
+          aria-describedby={id}
+          onClick={handleClick}
+        >
+          {entry}
+        </button>
+        <Popover
+          id={id}
+          open={open}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          anchorOrigin={{
+            vertical: "top",
+            horizontal: "center",
+          }}
+          transformOrigin={{
+            vertical: "bottom",
+            horizontal: "center",
+          }}
+        >
+          <div
+            className={
+              "text-almostblack py-1 px-2 border-strongorange rounded border font-sans text-sm bg-lightbisque"
+            }
+          >
+            {glossaryEntries[entry]}
+          </div>
+        </Popover>
+      </>
+    );
+  } else {
+    return <>{entry}</>;
+  }
+}

--- a/src/components/GlossaryPopover.tsx
+++ b/src/components/GlossaryPopover.tsx
@@ -2,7 +2,7 @@ import glossaryEntries from "../../meta/glossary.json";
 import * as React from "react";
 import Popover from "@mui/material/Popover";
 
-export default function GlossaryPopover({ entry }) {
+export default function GlossaryPopover({ entry, display = null }) {
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
     null
   );
@@ -18,7 +18,9 @@ export default function GlossaryPopover({ entry }) {
   const open = Boolean(anchorEl);
   const id = open ? `${entry}-popover` : undefined;
 
-  if (glossaryEntries[entry]) {
+  const content = display ? display : glossaryEntries[entry];
+
+  if (content) {
     return (
       <>
         <button
@@ -47,7 +49,7 @@ export default function GlossaryPopover({ entry }) {
               "text-almostblack py-1 px-2 border-strongorange rounded border font-sans text-sm bg-lightbisque"
             }
           >
-            {glossaryEntries[entry]}
+            {content}
           </div>
         </Popover>
       </>

--- a/src/components/search/searchArea/searchRow.tsx
+++ b/src/components/search/searchArea/searchRow.tsx
@@ -6,6 +6,7 @@ import SpatialResolutionCheck from "./spatialResolutionCheck";
 import SearchBox from "./searchBox";
 import { Box, Grid, Typography } from "@mui/material";
 import { SearchUIConfig } from "@/components/searchUIConfig";
+import GlossaryPopover from "@/components/GlossaryPopover";
 
 interface Props {
   header: string;
@@ -35,9 +36,7 @@ const SearchRow = (props: Props): JSX.Element => {
   const classes = useStyles();
   return (
     // The mt for top nav is 8, therefore set the row mt to 32
-    <Box
-      className="w-full mt-8 sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet"
-    >
+    <Box className="w-full mt-8 sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
       <Grid container className="sm:mb-7">
         <Grid
           item
@@ -53,7 +52,9 @@ const SearchRow = (props: Props): JSX.Element => {
               {props.header}
             </div>
             <div className={`text-s text-center sm:text-left sm:mt-[1em]`}>
-              {props.description}
+              Our data discovery platform provides access to spatially indexed
+              and curated databases, specifically designed for conducting{" "}
+              <GlossaryPopover entry={"health equity"} /> research.
             </div>
           </Box>
         </Grid>
@@ -73,7 +74,10 @@ const SearchRow = (props: Props): JSX.Element => {
               src={SearchUIConfig.search.searchBox.spatialResOptions}
             />
           </Box>
-          <Box width="100%" className="mt-[2em] sm:mt-0 3xl:max-w-[1203px] pr-[1em] md:pr-[3.375em]">
+          <Box
+            width="100%"
+            className="mt-[2em] sm:mt-0 3xl:max-w-[1203px] pr-[1em] md:pr-[3.375em]"
+          >
             <SearchBox
               schema={props.schema}
               autocompleteKey={props.autocompleteKey}


### PR DESCRIPTION
Initial implementation of #257, a "glossary" that can power extra definitions for key terms. It is implemented with a simple MUI popover that has a style matching the buttons within the map interface. The popover appears on click (not on hover) so it should work fine on mobile as well. 

![image](https://github.com/user-attachments/assets/b5137028-2f6d-4a38-88ac-37bd4913dc7d)

![image](https://github.com/user-attachments/assets/274c0811-5a69-4411-a8a2-d998648f5996)

By default, it looks for a predefined entry in the `meta/glossary.json` file, but any content can be passed to it, if there are context-specific definitions we want to display.

To test:

1. go to: https://deploy-preview-270--cheerful-treacle-913a24.netlify.app/search
2. click on the underlined term "health equity" in the text description

We could implement this anywhere within the website, besides news posts and showcase pages (though, it would be possible to set that up). For button labels, we could use this same style but make the popover [appear on hover](https://mui.com/material-ui/react-popover/#mouse-hover-interaction) (so as not to interfere with existing click events).