### PR TITLE
fix: address bug with HTML display in description field #181

### DIFF
--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -18,8 +18,8 @@ const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
   result.access_rights = rawSolrObject.dct_accessRights_s;
   result.resource_class = rawSolrObject.gbl_resourceClass_sm;
   result.description = rawSolrObject.dct_description_sm
-    ? findFirstSentence(rawSolrObject.dct_description_sm[0])
-    : "";
+    ? rawSolrObject.dct_description_sm
+    : [];
   result.creator = rawSolrObject.dct_creator_sm
     ? typeof rawSolrObject.dct_creator_sm === "string"
       ? [rawSolrObject.dct_creator_sm]

--- a/src/components/search/detailPanel/headerRow/headerRow.tsx
+++ b/src/components/search/detailPanel/headerRow/headerRow.tsx
@@ -48,10 +48,6 @@ const HeaderRow = (props: Props): JSX.Element => {
     alert("The shared link has been copied to the clipboard successfully!");
   };
 
-  // handle description
-  if (props.resultItem.description.endsWith("<a href='https://www.")) {
-    props.resultItem.description += "'>link</a>"; // Completing the <a> tag for dev only. Delete this after confirming all links are complete
-  }
   const sanitizedDescription = DOMPurify.sanitize(
     props.resultItem.description,
     {


### PR DESCRIPTION
Closes #181. The description was being truncated, probably leftover from an earlier implementation where we just wanted to show a snippet of the description. Now fixed.