### PR TITLE
#238: Update the search box to match the new design

### DIFF
--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -87,7 +87,9 @@ const CustomPaper = (props) => {
 };
 
 const SearchBox = (props: Props): JSX.Element => {
-  const [showClearButton, setShowClearButton] = React.useState(false);
+  const [showClearButton, setShowClearButton] = React.useState(
+    props.value ? true : false
+  );
   const classes = useStyles();
   const params = GetAllParams();
   const [userInput, setUserInput] = React.useState(

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
 import SearchIcon from "@mui/icons-material/Search";
-import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import {
   Autocomplete,
   Box,
   Button,
-  Checkbox,
-  Grid,
   IconButton,
   InputAdornment,
   Paper,
@@ -15,14 +14,12 @@ import {
 } from "@mui/material";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
-import { useSearchParams, usePathname } from "next/navigation";
-import { useRouter } from "next/router";
+import CloseIcon from "@mui/icons-material/Close";
 import { makeStyles } from "@mui/styles";
 import { SearchObject } from "../interface/SearchObject";
 import SolrQueryBuilder from "../helper/SolrQueryBuilder";
 import SuggestedResult from "../helper/SuggestedResultBuilder";
 import { useEffect } from "react";
-import { get } from "http";
 import { GetAllParams, reGetFilterQueries } from "../helper/ParameterList";
 
 interface Props {
@@ -90,6 +87,7 @@ const CustomPaper = (props) => {
 };
 
 const SearchBox = (props: Props): JSX.Element => {
+  const [showClearButton, setShowClearButton] = React.useState(false);
   const classes = useStyles();
   const params = GetAllParams();
   const [userInput, setUserInput] = React.useState(
@@ -163,6 +161,7 @@ const SearchBox = (props: Props): JSX.Element => {
           onInputChange={(event, value, reason) => {
             if (event && event.type === "change") {
               handleUserInputChange(event, value);
+              setShowClearButton(value !== "");
             }
           }}
           onChange={(event, value) => {
@@ -193,39 +192,53 @@ const SearchBox = (props: Props): JSX.Element => {
               InputProps={{
                 ...params.InputProps,
                 startAdornment: (
-                  <InputAdornment position="start" className="mr-2">
-                    <SearchIcon className="text-2xl" />
+                  <InputAdornment position="start">
+                    <SearchIcon className="text-2xl mr-2 ml-10 text-frenchviolet" />
+                    <Box component="span" className="mx-2">
+                      <a
+                        href="#" // This needs to be updated after decide the advanced search page
+                        className={`no-underline text-frenchviolet `}
+                      >
+                        <InfoOutlinedIcon />
+                      </a>
+                    </Box>
                   </InputAdornment>
                 ),
                 endAdornment: (
                   <Box display="flex" alignItems="center">
-                    <Box component="span" className="mr-2">
-                      <a
-                        href="#" // This needs to be updated after decide the advanced search page
-                        className={`text-frenchviolet no-underline ${classes.searchBox}`}
-                      >
-                        Help
-                      </a>
-                    </Box>
+                    {showClearButton && (
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={() => {
+                            setUserInput("");
+                            props.handleInputReset();
+                            setShowClearButton(false);
+                          }}
+                        >
+                          <CloseIcon className="text-2xl text-frenchviolet" />
+                        </IconButton>
+                      </InputAdornment>
+                    )}
                     <InputAdornment position="end">
                       <Button
+                        className=""
                         type="submit"
                         variant="contained"
                         color="primary"
                         sx={{
-                          minWidth: "auto",
-                          padding: 0,
-                          borderRadius: "50%",
-                          width: "2.25em",
-                          height: "2.25em",
                           display: "flex",
                           alignItems: "center",
                           justifyContent: "center",
-                          backgroundColor:
-                            fullConfig.theme.colors["frenchviolet"],
+                          backgroundColor: "transparent",
+                          color: fullConfig.theme.colors["frenchviolet"],
+                          boxShadow: "none",
+                          "&:hover": {
+                            backgroundColor: "transparent",
+                            boxShadow: "none",
+                          },
                         }}
                       >
-                        <ArrowForwardIcon />
+                        <ArrowCircleRightIcon className="text-2xl mr-10" />
                       </Button>
                     </InputAdornment>
                   </Box>

--- a/src/components/search/searchArea/searchRow.tsx
+++ b/src/components/search/searchArea/searchRow.tsx
@@ -7,7 +7,6 @@ import SearchBox from "./searchBox";
 import { Box, Grid, Typography } from "@mui/material";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import GlossaryPopover from "@/components/GlossaryPopover";
-import { set } from "date-fns";
 
 interface Props {
   header: string;


### PR DESCRIPTION
This PR is for #238. It updates the search box to match the new design and adds a "close" button that allows users to reset the search while typing. Note that the auto-complete is not working because `/suggest?` does not return any results at the moment. The Info icon is currently kept as a "/#" link until the corresponding page is designed.

## How to Test
1. Navigate to the search page and type anything in the search box.

2. You should notice an "X" button appears:
<img width="1107" alt="Screenshot 2024-09-04 at 9 58 03 AM" src="https://github.com/user-attachments/assets/674d5159-734a-4067-9fee-57dbec73f7ab">

3. Click this button, and you should see all search input cleared.

4. Try adding a few spatial resolution filters and then perform a search.
<img width="1666" alt="Screenshot 2024-09-04 at 9 58 42 AM" src="https://github.com/user-attachments/assets/0481443b-01b7-4d4c-abc0-b552a8f27284">

5. Now click the "X" button again. You should see that the filters are maintained, but the result list is refreshed by removing the query.
<img width="1679" alt="Screenshot 2024-09-04 at 9 58 55 AM" src="https://github.com/user-attachments/assets/34d1a3f4-849a-4d2a-b28d-f74bef488c79">

6. Enter something in the search box, perform the search, and then paste the URL into another window. You should see the close button is still present in the search box in the new window.
