### PR TITLE
#293: change the reference link content

### DIFF
--- a/meta/interface/SolrObject.ts
+++ b/meta/interface/SolrObject.ts
@@ -24,7 +24,7 @@ export interface SolrObject {
     theme?: string;
     issued?: string;
     temporal?: string;
-    references?: any;
+    references?: any; // json object. Value should be displayed
     rights?: string;
     md_modified?: string;
     md_version?: string;

--- a/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
+++ b/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
@@ -75,7 +75,7 @@ const Link = ({ value }) => {
         href={String(url)}
         className={`${classes.paragraphCard} ${classes.link}`}
       >
-        {String(key)}
+        {String(url)}
       </a>
     </div>
   );


### PR DESCRIPTION
This PR addresses #293. It switches the reference link to display its content.

## How to Test
1. Go to the search page and click one of the result items.
2. The reference link should now display the correct content:
<img width="1074" alt="Screenshot 2024-09-18 at 9 09 41 AM" src="https://github.com/user-attachments/assets/fb51555d-71f8-4e51-8420-237897ffce4e">
