### PR TITLE
#265: fix the auto suggestor

### DIFF
--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -1,3 +1,4 @@
+import { c } from "nuqs/dist/serializer-C_l8WgvO";
 import { SolrObject } from "../interface/SolrObject";
 // import { SolrParent } from "../interface/SolrParent";
 import { findFirstSentence, schemaMatch } from "./util";
@@ -71,6 +72,8 @@ const generateSolrParentList = (
     .filter((solrObject) => solrObject.parents)
     .forEach((childObject) => {
       childObject.parents.forEach((parentTitle) => {
+        // only if the object has parents, add the parent to the result
+        if(solrObjects.filter((solrParent) => parentTitle === solrParent.id).length >0 ) {
         solrObjects
           .filter((solrParent) => parentTitle === solrParent.id)
           .forEach((solrParent) => {
@@ -83,6 +86,10 @@ const generateSolrParentList = (
               : null;
             result.add(solrParent);
           });
+        }
+        else {
+          result.add(childObject);
+        }
       });
     });
   solrObjects

--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -1,7 +1,6 @@
-import { c } from "nuqs/dist/serializer-C_l8WgvO";
 import { SolrObject } from "../interface/SolrObject";
 // import { SolrParent } from "../interface/SolrParent";
-import { findFirstSentence, schemaMatch } from "./util";
+import {schemaMatch } from "./util";
 
 /**
  *

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, use, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { SolrObject } from "meta/interface/SolrObject";
-import { Grid, Typography } from "@mui/material";
+import { Grid } from "@mui/material";
 import SolrQueryBuilder from "./helper/SolrQueryBuilder";
 import SuggestedResult from "./helper/SuggestedResultBuilder";
 import { generateSolrParentList } from "meta/helper/solrObjects";
@@ -14,8 +14,7 @@ import {
   GetAllParams,
   reGetFilterQueries,
 } from "./helper/ParameterList";
-import FilterPanel, { grouped } from "./filterPanel/filterPanel";
-import { c } from "nuqs/dist/serializer-C_l8WgvO";
+import FilterPanel from "./filterPanel/filterPanel";
 
 export default function DiscoveryArea({
   results,

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -15,6 +15,7 @@ import {
   reGetFilterQueries,
 } from "./helper/ParameterList";
 import FilterPanel, { grouped } from "./filterPanel/filterPanel";
+import { c } from "nuqs/dist/serializer-C_l8WgvO";
 
 export default function DiscoveryArea({
   results,
@@ -60,11 +61,11 @@ export default function DiscoveryArea({
     searchQueryBuilder
       .fetchResult()
       .then((result) => {
-        processResults(result, value);
+        let returnedTerms = processResults(result, value);
         // if multiple terms are returned, we get all weight = 1 terms (this is done in SuggestionsResultBuilder), then aggregate the results for all terms
-        if (suggestResultBuilder.getTerms().length > 0) {
+        if (returnedTerms.length > 0) {
           const multipleResults = [] as SolrObject[];
-          suggestResultBuilder.getTerms().forEach((term) => {
+          returnedTerms.forEach((term) => {
             searchQueryBuilder.combineQueries(term, filterQueries);
             searchQueryBuilder.fetchResult().then((result) => {
               generateSolrParentList(
@@ -84,7 +85,6 @@ export default function DiscoveryArea({
             });
           });
         } else {
-          console.log("no suggestions, just one term", value, filterQueries);
           searchQueryBuilder.combineQueries(value, filterQueries);
           searchQueryBuilder.fetchResult().then((result) => {
             const newResults = generateSolrParentList(
@@ -104,6 +104,7 @@ export default function DiscoveryArea({
     suggestResultBuilder.setSuggester("mySuggester"); //this could be changed to a different suggester
     suggestResultBuilder.setSuggestInput(value);
     suggestResultBuilder.setResultTerms(JSON.stringify(results));
+    return suggestResultBuilder.getTerms();
   };
 
   /**

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -13,8 +13,6 @@ import MapPanel from "./mapPanel/mapPanel";
 import {
   GetAllParams,
   reGetFilterQueries,
-  resetAllFilters,
-  updateAll,
 } from "./helper/ParameterList";
 import FilterPanel, { grouped } from "./filterPanel/filterPanel";
 

--- a/src/components/search/helper/ParameterList.tsx
+++ b/src/components/search/helper/ParameterList.tsx
@@ -260,5 +260,14 @@ export const resetAllFilters = (params) => {
   params.setVisLyrs(null);
   params.setIndexYear(null);
   params.setSubject(null);
-  params.setQuery(null);
+  params.setSortOrder(null);
+};
+
+export const isFiltersOn = (params) => {
+  return (
+    params.spatialResolution.length > 0 ||
+    params.visLyrs.length > 0 ||
+    params.indexYear.length > 0 ||
+    params.subject.length > 0
+  );
 };

--- a/src/components/search/resultsPanel/resultsPanel.tsx
+++ b/src/components/search/resultsPanel/resultsPanel.tsx
@@ -5,12 +5,17 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import SearchIcon from "@mui/icons-material/Search";
 import { SolrObject } from "meta/interface/SolrObject";
 import ResultCard from "./resultCard";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, IconButton, Typography } from "@mui/material";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import { SvgIcon } from "@mui/material";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import IconTag from "../detailPanel/iconTag";
 import IconMatch from "../helper/IconMatch";
+import {
+  GetAllParams,
+  isFiltersOn,
+  resetAllFilters,
+} from "../helper/ParameterList";
 
 interface Props {
   resultsList: SolrObject[];
@@ -34,6 +39,7 @@ const useStyles = makeStyles((theme) => ({
 
 const ResultsPanel = (props: Props): JSX.Element => {
   const classes = useStyles();
+  const params = GetAllParams();
   return (
     <div
       className="results-panel"
@@ -72,6 +78,28 @@ const ResultsPanel = (props: Props): JSX.Element => {
               <div>Sort & Filter</div>
             </div>
           </div>
+          {isFiltersOn(params) && (
+            <div className="flex flex-col sm:mb-[1.5em] sm:ml-[1.1em] sm:flex-row items-center justify-center">
+              <Button
+                className="sm:my-[0.5em]"
+                sx={{
+                  color: "white",
+                  backgroundColor: fullConfig.theme.colors["frenchviolet"],
+                  "&:hover": {
+                    boxShadow: "none",
+                    backgroundColor: fullConfig.theme.colors["frenchviolet"],
+                    color: "white",
+                  },
+                }}
+                onClick={() => {
+                  resetAllFilters(params);
+                  props.handleSearch(params, params.query, []);
+                }}
+              >
+                Clear All Filters
+              </Button>
+            </div>
+          )}
         </Box>
         {props.showFilter.length > 0 && props.filterComponent}
         <Box
@@ -108,7 +136,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
                 <div className="text-s">Search for themes instead?</div>
               </Box>
               <Box className="flex flex-col sm:flex-row flex-wrap gap-4">
-                {/* This part will be changed to the list at https://github.com/healthyregions/SDOHPlace/issues/287 once the subject data is updated */}
                 <IconTag
                   svgIcon={IconMatch("Community Health")}
                   label="Community Health"

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -28,7 +28,7 @@ interface Props {
   options: any[];
   setOptions: React.Dispatch<React.SetStateAction<any[]>>;
   handleInputReset: () => void;
-  processResults: (results, value) => void;
+  processResults: (results, value) => string[];
   inputRef: React.RefObject<HTMLInputElement>;
   value: string | null;
   setValue: React.Dispatch<React.SetStateAction<string | null>>;
@@ -113,8 +113,8 @@ const SearchBox = (props: Props): JSX.Element => {
   const handleDropdownSelect = (event, value) => {
     const filterQueries = reGetFilterQueries(urlParams);
     props.setInputValue(value);
-    props.setQuery(props.inputValue);
-    props.handleSearch(urlParams, props.inputValue, filterQueries);
+    props.setQuery(value);
+    props.handleSearch(urlParams, value, filterQueries);
   };
   const handleUserInputChange = async (
     event: React.ChangeEvent<{}>,
@@ -131,8 +131,8 @@ const SearchBox = (props: Props): JSX.Element => {
       searchQueryBuilder
         .fetchResult()
         .then((result) => {
-          props.processResults(result, newInputValue);
-          props.setOptions(suggestResultBuilder.getTerms());
+          let returnedTerms = props.processResults(result, newInputValue);
+          props.setOptions(returnedTerms);
         })
         .catch((error) => {
           console.error("Error fetching result:", error);
@@ -142,7 +142,6 @@ const SearchBox = (props: Props): JSX.Element => {
     }
   };
   useEffect(() => {
-    console.log("props.value in searchBox", props.value, urlParams.query);
     if (!urlParams.query) {
       setUserInput("");
     } else if (urlParams.query !== userInput) {

--- a/src/components/search/searchArea/searchRow.tsx
+++ b/src/components/search/searchArea/searchRow.tsx
@@ -7,7 +7,6 @@ import SearchBox from "./searchBox";
 import { Box, Grid, Typography } from "@mui/material";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import GlossaryPopover from "@/components/GlossaryPopover";
-import { set } from "date-fns";
 
 interface Props {
   header: string;
@@ -16,7 +15,7 @@ interface Props {
   autocompleteKey: number;
   options: any[];
   handleInputReset: () => void;
-  processResults: (results: any, value: string) => void;
+  processResults: (results: any, value: string) => string[];
   setOptions: React.Dispatch<React.SetStateAction<any[]>>;
   inputRef: React.RefObject<HTMLInputElement>;
   value: string | null;


### PR DESCRIPTION
This PR is for #265. It enables the auto-suggest feature after the user inputs anything in the search box.

## How to Test
1. Go to the search page and type anything in the search box. You should see the auto-suggestion feature enabled again:
<img width="709" alt="Screenshot 2024-09-19 at 11 06 05 AM" src="https://github.com/user-attachments/assets/ab2aa1bd-593f-476d-a4e2-b9c433f36824">

2. Click on one of the results (for example, southwest coastal alaska). You should see the result list appear after the query:
<img width="1330" alt="Screenshot 2024-09-19 at 11 08 14 AM" src="https://github.com/user-attachments/assets/f6b7b0c2-182d-48ae-b377-712896a22733">

3. Run a sort or filter, and the result list should adjust as expected:
<img width="1094" alt="Screenshot 2024-09-19 at 11 08 24 AM" src="https://github.com/user-attachments/assets/c3882a8f-a5a8-4af2-ac1b-e224dc0a9b1e">


## NOTE
@mradamcox : while fixing the suggestion feature, I noticed an issue that I want to confirm with you. One example is "southeast coastal Alaska," which was suggested by Solr. Our existing rule for generating the parent object from the child object resulted in no results.

When I checked the query (https://solr.sdohplace.org/solr/blacklight-core-dev/select?q=southeast%20coastal%20alaska&fq=&rows=1000), it appears that all the results have a parent of "tree-canopy-cover." However, the returned result doesn't include a "tree-canopy-cover" item. Instead, we only have items like "tree-canopy-cover-alaska2013" and "tree-canopy-cover-alaska2014."

On the other hand, we do have a "Tree Canopy Cover" object in the database. If a user enters "Tree Canopy Cover" directly and then selects any of the returned results from the drop-down or directly searches this term, it will appear. However, this item doesn't include "southeast coastal Alaska," so it doesn't show up in the above search.

To address this, I changed the rule so that if the parent item is not in the returned list, all the child objects are shown instead. Please let me know if this change makes sense. We can also update the Solr rule to ensure that if all child items are returned, the parent item must also be included.