### PR TITLE
#292: Add a reset button to reset filters, including subject

### DIFF
--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -13,8 +13,6 @@ import MapPanel from "./mapPanel/mapPanel";
 import {
   GetAllParams,
   reGetFilterQueries,
-  resetAllFilters,
-  updateAll,
 } from "./helper/ParameterList";
 import FilterPanel, { grouped } from "./filterPanel/filterPanel";
 

--- a/src/components/search/helper/ParameterList.tsx
+++ b/src/components/search/helper/ParameterList.tsx
@@ -260,5 +260,14 @@ export const resetAllFilters = (params) => {
   params.setVisLyrs(null);
   params.setIndexYear(null);
   params.setSubject(null);
-  params.setQuery(null);
+  params.setSortOrder(null);
+};
+
+export const isFiltersOn = (params) => {
+  return (
+    params.spatialResolution.length > 0 ||
+    params.visLyrs.length > 0 ||
+    params.indexYear.length > 0 ||
+    params.subject.length > 0
+  );
 };

--- a/src/components/search/resultsPanel/resultsPanel.tsx
+++ b/src/components/search/resultsPanel/resultsPanel.tsx
@@ -5,12 +5,17 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import SearchIcon from "@mui/icons-material/Search";
 import { SolrObject } from "meta/interface/SolrObject";
 import ResultCard from "./resultCard";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, IconButton, Typography } from "@mui/material";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import { SvgIcon } from "@mui/material";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import IconTag from "../detailPanel/iconTag";
 import IconMatch from "../helper/IconMatch";
+import {
+  GetAllParams,
+  isFiltersOn,
+  resetAllFilters,
+} from "../helper/ParameterList";
 
 interface Props {
   resultsList: SolrObject[];
@@ -34,6 +39,7 @@ const useStyles = makeStyles((theme) => ({
 
 const ResultsPanel = (props: Props): JSX.Element => {
   const classes = useStyles();
+  const params = GetAllParams();
   return (
     <div
       className="results-panel"
@@ -72,6 +78,28 @@ const ResultsPanel = (props: Props): JSX.Element => {
               <div>Sort & Filter</div>
             </div>
           </div>
+          {isFiltersOn(params) && (
+            <div className="flex flex-col sm:mb-[1.5em] sm:ml-[1.1em] sm:flex-row items-center justify-center">
+              <Button
+                className="sm:my-[0.5em]"
+                sx={{
+                  color: "white",
+                  backgroundColor: fullConfig.theme.colors["frenchviolet"],
+                  "&:hover": {
+                    boxShadow: "none",
+                    backgroundColor: fullConfig.theme.colors["frenchviolet"],
+                    color: "white",
+                  },
+                }}
+                onClick={() => {
+                  resetAllFilters(params);
+                  props.handleSearch(params, params.query, []);
+                }}
+              >
+                Clear All Filters
+              </Button>
+            </div>
+          )}
         </Box>
         {props.showFilter.length > 0 && props.filterComponent}
         <Box
@@ -108,7 +136,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
                 <div className="text-s">Search for themes instead?</div>
               </Box>
               <Box className="flex flex-col sm:flex-row flex-wrap gap-4">
-                {/* This part will be changed to the list at https://github.com/healthyregions/SDOHPlace/issues/287 once the subject data is updated */}
                 <IconTag
                   svgIcon={IconMatch("Community Health")}
                   label="Community Health"


### PR DESCRIPTION
This PR addresses issue #292. It adds a "Clear All Filters" button to reset all applied filters.

## How to Test
1. Apply any filter. You should see a "Clear All Filters" button appear: <img width="1673" alt="Screenshot 2024-09-19 at 4 38 37 PM" src="https://github.com/user-attachments/assets/157cdb71-34e1-479d-acd8-d3ca952d650d">

2. Click the button, and all filters should be cleared: <img width="1849" alt="Screenshot 2024-09-19 at 4 39 36 PM" src="https://github.com/user-attachments/assets/b3b587f8-41da-4de7-8fea-aa032a3ce3d5">

3. Apply filters until you see a "No results" view. Then, click "Community Health" to navigate to the subject view (Note: no results will be displayed at this time, as I will address the subject icons in a future PR). Afterward, click the "Clear All Filters" button: <img width="1211" alt="Screenshot 2024-09-19 at 4 43 03 PM" src="https://github.com/user-attachments/assets/498e780c-fe17-4349-8c23-43c33f6a772b">

4. Click the button again, and the results should be reset.

5. Enter a query in the search box with some filters applied (e.g., "social"): <img width="1929" alt="Screenshot 2024-09-19 at 4 49 54 PM" src="https://github.com/user-attachments/assets/9dcb8b5f-6d88-4dda-be50-a9d885dca66b">

6. Click the button, and you should see that the query results are maintained while all filters are no longer applied: <img width="1464" alt="Screenshot 2024-09-19 at 4 50 43 PM" src="https://github.com/user-attachments/assets/45c3752a-d439-45be-a463-a6c242f8a661">
