### PR TITLE
#306, #307: add pagination and remove suppressed objects

### DIFF
--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -9,7 +9,7 @@ import { schemaMatch } from "./util";
  * @returns
  */
 const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
-  if (rawSolrObject.gbl_suppress_b === false) {
+  if (!rawSolrObject.gbl_suppressed_b) {
     let result = {} as SolrObject;
     result.score = rawSolrObject.score;
     result.id = rawSolrObject.id;

--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -9,51 +9,54 @@ import { schemaMatch } from "./util";
  * @returns
  */
 const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
-  let result = {} as SolrObject;
-  result.score = rawSolrObject.score;
-  result.id = rawSolrObject.id;
-  result.title = rawSolrObject.dct_title_s;
-  result.metadata_version = rawSolrObject.gbl_mdVersion_s;
-  result.modified = rawSolrObject.gbl_mdModified_dt;
-  result.access_rights = rawSolrObject.dct_accessRights_s;
-  result.resource_class = rawSolrObject.gbl_resourceClass_sm;
-  result.description = rawSolrObject.dct_description_sm
-    ? rawSolrObject.dct_description_sm
-    : [];
-  result.creator = rawSolrObject.dct_creator_sm
-    ? typeof rawSolrObject.dct_creator_sm === "string"
-      ? [rawSolrObject.dct_creator_sm]
-      : rawSolrObject.dct_creator_sm
-    : [];
-  result.index_year = rawSolrObject.gbl_indexYear_im
-    ? typeof rawSolrObject.gbl_indexYear_im === "string"
-      ? [rawSolrObject.gbl_indexYear_im]
-      : rawSolrObject.gbl_indexYear_im.map((year) => {
-          return year.toString();
-        })
-    : [];
-  result.meta = {};
-  result.years = new Set();
-  if (rawSolrObject.dct_isVersionOf_sm)
-    // child object only
-    result.parents = rawSolrObject.dct_isVersionOf_sm;
-  Object.keys(rawSolrObject).forEach((key) => {
-    if (
-      key !== "id" &&
-      key !== "dct_title_s" &&
-      key !== "gbl_mdVersion_s" &&
-      key !== "gbl_mdModified_dt" &&
-      key !== "dct_accessRights_s" &&
-      key !== "gbl_resourceClass_sm" &&
-      key !== "dct_description_sm" &&
-      key !== "dct_creator_sm" &&
-      key !== "gbl_indexYear_im" &&
-      key !== "dct_isVersionOf_sm"
-    ) {
-      result.meta[schemaMatch(key, schema)] = rawSolrObject[key];
-    }
-  });
-  return result;
+  if (!rawSolrObject.gbl_suppress_b) {
+    let result = {} as SolrObject;
+    result.score = rawSolrObject.score;
+    result.id = rawSolrObject.id;
+    result.title = rawSolrObject.dct_title_s;
+    result.metadata_version = rawSolrObject.gbl_mdVersion_s;
+    result.modified = rawSolrObject.gbl_mdModified_dt;
+    result.access_rights = rawSolrObject.dct_accessRights_s;
+    result.resource_class = rawSolrObject.gbl_resourceClass_sm;
+    result.description = rawSolrObject.dct_description_sm
+      ? rawSolrObject.dct_description_sm
+      : [];
+    result.creator = rawSolrObject.dct_creator_sm
+      ? typeof rawSolrObject.dct_creator_sm === "string"
+        ? [rawSolrObject.dct_creator_sm]
+        : rawSolrObject.dct_creator_sm
+      : [];
+    result.index_year = rawSolrObject.gbl_indexYear_im
+      ? typeof rawSolrObject.gbl_indexYear_im === "string"
+        ? [rawSolrObject.gbl_indexYear_im]
+        : rawSolrObject.gbl_indexYear_im.map((year) => {
+            return year.toString();
+          })
+      : [];
+    result.meta = {};
+    result.years = new Set();
+    if (rawSolrObject.dct_isVersionOf_sm)
+      // child object only
+      result.parents = rawSolrObject.dct_isVersionOf_sm;
+    Object.keys(rawSolrObject).forEach((key) => {
+      if (
+        key !== "id" &&
+        key !== "dct_title_s" &&
+        key !== "gbl_mdVersion_s" &&
+        key !== "gbl_mdModified_dt" &&
+        key !== "dct_accessRights_s" &&
+        key !== "gbl_resourceClass_sm" &&
+        key !== "dct_description_sm" &&
+        key !== "dct_creator_sm" &&
+        key !== "gbl_indexYear_im" &&
+        key !== "dct_isVersionOf_sm"
+      ) {
+        result.meta[schemaMatch(key, schema)] = rawSolrObject[key];
+      }
+    });
+    return result;
+  }
+  return undefined;
 };
 
 /**
@@ -61,43 +64,12 @@ const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
  * @param solrObjects a list of transformed solr objects using initSolrObject
  * @returns a list of solrParent objects to create parent resource list
  */
-const generateSolrParentList = (
+const generateSolrObjectList = (
   solrObjects: SolrObject[],
   sortBy?: string,
   sortOrder?: string
 ): SolrObject[] => {
-  let result = new Set<SolrObject>();
-  solrObjects
-    .filter((solrObject) => solrObject.parents)
-    .forEach((childObject) => {
-      childObject.parents.forEach((parentTitle) => {
-        // only if the object has parents, add the parent to the result
-        if (
-          solrObjects.filter((solrParent) => parentTitle === solrParent.id)
-            .length > 0
-        ) {
-          solrObjects
-            .filter((solrParent) => parentTitle === solrParent.id)
-            .forEach((solrParent) => {
-              childObject.meta["date_issued"]
-                ? solrParent.years.add(
-                    typeof childObject.meta["date_issued"] === "string"
-                      ? childObject.meta["date_issued"]
-                      : childObject.meta["date_issued"][0]
-                  )
-                : null;
-              result.add(solrParent);
-            });
-        } else {
-          result.add(childObject);
-        }
-      });
-    });
-  solrObjects
-    .filter((solrObject) => !solrObject.parents)
-    .forEach((solrObject) => {
-      result.add(solrObject);
-    });
+  let result = new Set<SolrObject>(solrObjects);
   //For now, only handle the case when both sortBy and sortOrder are provided and they are modified
   const finalArray = Array.from(result);
   if (sortBy && sortOrder && sortBy === "modified") {
@@ -118,7 +90,7 @@ const generateSolrParentList = (
 
 /**
  * Use this function to derive the parent object from a list of solr objects.
- * Note this is not equal to generateSolrParentList, thus won't have 'years' accumulated from child object.
+ * Note this is not equal to generateSolrObjectList, thus won't have 'years' accumulated from child object.
  *
  * This function should be called to derive the parent result from Solr response.
  */
@@ -126,4 +98,4 @@ const filterParentList = (solrObjects: SolrObject[]): SolrObject[] => {
   return solrObjects.filter((solrObject) => !solrObject.parents);
 };
 
-export { initSolrObject, generateSolrParentList, filterParentList };
+export { initSolrObject, generateSolrObjectList, filterParentList };

--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -9,7 +9,7 @@ import { schemaMatch } from "./util";
  * @returns
  */
 const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
-  if (!rawSolrObject.gbl_suppress_b) {
+  if (rawSolrObject.gbl_suppress_b === false) {
     let result = {} as SolrObject;
     result.score = rawSolrObject.score;
     result.id = rawSolrObject.id;
@@ -55,8 +55,7 @@ const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
       }
     });
     return result;
-  }
-  return undefined;
+  };
 };
 
 /**
@@ -69,6 +68,8 @@ const generateSolrObjectList = (
   sortBy?: string,
   sortOrder?: string
 ): SolrObject[] => {
+  //remove undefined objects
+  solrObjects = solrObjects.filter((solrObject) => solrObject !== undefined);
   let result = new Set<SolrObject>(solrObjects);
   //For now, only handle the case when both sortBy and sortOrder are provided and they are modified
   const finalArray = Array.from(result);

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -4,7 +4,7 @@ import { SolrObject } from "meta/interface/SolrObject";
 import { Grid } from "@mui/material";
 import SolrQueryBuilder from "./helper/SolrQueryBuilder";
 import SuggestedResult from "./helper/SuggestedResultBuilder";
-import { generateSolrParentList } from "meta/helper/solrObjects";
+import { generateSolrObjectList } from "meta/helper/solrObjects";
 import DetailPanel from "./detailPanel/detailPanel";
 import SearchRow from "./searchArea/searchRow";
 import ResultsPanel from "./resultsPanel/resultsPanel";
@@ -64,7 +64,7 @@ export default function DiscoveryArea({
           returnedTerms.forEach((term) => {
             searchQueryBuilder.combineQueries(term, filterQueries);
             searchQueryBuilder.fetchResult().then((result) => {
-              generateSolrParentList(
+              generateSolrObjectList(
                 result,
                 params.sortBy,
                 params.sortOrder
@@ -87,9 +87,10 @@ export default function DiscoveryArea({
             });
           });
         } else {
+          console.log("No suggestions found, fetching results for the query");
           searchQueryBuilder.combineQueries(value, filterQueries);
           searchQueryBuilder.fetchResult().then((result) => {
-            let newResults = generateSolrParentList(
+            let newResults = generateSolrObjectList(
               result,
               params.sortBy,
               params.sortOrder
@@ -128,7 +129,7 @@ export default function DiscoveryArea({
   );
   const isQuery = params.query.length > 0;
   const filterQueries = reGetFilterQueries(params);
-  const originalResults = generateSolrParentList(
+  const originalResults = generateSolrObjectList(
     results,
     params.sortBy,
     params.sortOrder

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -87,7 +87,6 @@ export default function DiscoveryArea({
             });
           });
         } else {
-          console.log("No suggestions found, fetching results for the query");
           searchQueryBuilder.combineQueries(value, filterQueries);
           searchQueryBuilder.fetchResult().then((result) => {
             let newResults = generateSolrObjectList(

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -253,8 +253,9 @@ export default function DiscoveryArea({
           }}
         >
           <DetailPanel
-            resultItem={fetchResults.find(
-              (r) => r.id === params.showDetailPanel
+            resultItem={
+              fetchResults.find(
+              (r) => r? r.id === params.showDetailPanel : null
             )}
             setShowDetailPanel={params.setShowDetailPanel}
             showSharedLink={params.showSharedLink}

--- a/src/components/search/helper/FilterHelpMethods.tsx
+++ b/src/components/search/helper/FilterHelpMethods.tsx
@@ -1,3 +1,5 @@
+// NOTE: most methods in this file are not used in the search component now. Still save them here for future possible filter implementation.
+
 import FilterObject from "../interface/FilterObject";
 import CheckBoxObject from "../interface/CheckboxObject";
 import SolrQueryBuilder from "./SolrQueryBuilder";

--- a/src/components/search/helper/SolrQueryBuilder.tsx
+++ b/src/components/search/helper/SolrQueryBuilder.tsx
@@ -2,7 +2,7 @@ import { initSolrObject } from "meta/helper/solrObjects";
 import { SolrObject } from "meta/interface/SolrObject";
 import { findSolrAttribute } from "meta/helper/util";
 import SRMatch from "../../search/helper/SpatialResolutionMatch.json";
-import { f } from "nuqs/dist/serializer-C_l8WgvO";
+
 export default class SolrQueryBuilder {
   private query: QueryObject = {
     solrUrl: process.env.NEXT_PUBLIC_SOLR_URL || "",
@@ -143,7 +143,7 @@ export default class SolrQueryBuilder {
     let sortQuery = `select?sort=${encodeURIComponent(
       findSolrAttribute(searchTerm.attribute, this.query.schema_json)
     )}${encodeURIComponent(" ")}${searchTerm.order}`;
-    sortQuery = sortQuery += "&rows=1000"; //add rows to remove pagination
+    sortQuery = sortQuery; //add rows to remove pagination
     return this.setQuery(sortQuery);
   }
 
@@ -158,6 +158,7 @@ export default class SolrQueryBuilder {
         ).length > 0
       ) {
         let filterQuery = `*`;
+        filterQuery += `dct_subject_count_i:[2 TO *]`;
         combinedQuery += filterQuery;
       } else {
         let filterQuery = `&fq=`;
@@ -183,8 +184,8 @@ export default class SolrQueryBuilder {
         filterQuery += attributeQueries.join(" AND ");
         combinedQuery += filterQuery;
       }
-      combinedQuery += "&rows=1000";
     }
+    combinedQuery += "&rows=1000";
     return this.setQuery(combinedQuery.replace(this.getSolrUrl() + "/", ""));
   };
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -32,7 +32,7 @@ const Search: NextPage<SearchPageProps> = ({ schema }) => {
   );
   const [isLoading, setLoading] = useState(true);
   useEffect(() => {
-    fetch(solrUrl + "/select?q=*:*&rows=100")
+    fetch(solrUrl + "/select?q=*:*")
       .then((res) => res.json())
       .then((data) => {
         const solrObjectResults = data.response.docs.map((doc) =>


### PR DESCRIPTION
This PR addresses #306 and #307. It adds pagination (row=1000) to ensure all objects are returned, except those with gbl_suppress_b set to true.

## How to Test

1. Navigate to the search page, where all objects should now be returned, except those excluded (For now you will see the "No result" view, but once the data get updated, you should see the correct output).

2. Test the filters and search functionality to confirm that everything works as expected.