### PR TITLE
style: update tooltip and other popover styles #257

### DIFF
--- a/src/components/GlossaryPopover.tsx
+++ b/src/components/GlossaryPopover.tsx
@@ -46,7 +46,7 @@ export default function GlossaryPopover({ entry, display = null }) {
         >
           <div
             className={
-              "text-almostblack py-1 px-2 border-strongorange rounded border font-sans text-sm bg-lightbisque"
+              "text-almostblack py-1 px-2 rounded font-sans text-sm bg-lightbisque"
             }
           >
             {content}

--- a/src/components/search/mapPanel/mapPanel.tsx
+++ b/src/components/search/mapPanel/mapPanel.tsx
@@ -123,20 +123,24 @@ const MapPanel = (props: Props): JSX.Element => {
               horizontal: "left",
             }}
           >
-            <p style={{ padding: "1em" }}>
-              Overlays created from{" "}
-              <Link
-                href="https://docs.overturemaps.org/guides/places/"
-                target="_blank"
-              >
-                Places
-              </Link>{" "}
-              theme,{" "}
-              <Link href="https://overturemaps.org" target="_blank">
-                Overture Maps Foundation
-              </Link>
-              .
-            </p>
+            <Box className="py-2 px-4 rounded bg-lightbisque">
+              <p className="text-almostblack font-sans text-sm">
+                Overlays created from{" "}
+                <Link
+                  href="https://docs.overturemaps.org/guides/places/"
+                  target="_blank"
+                >
+                  Places
+                </Link>{" "}
+                theme,{" "}
+                <Link href="https://overturemaps.org" target="_blank">
+                  Overture Maps Foundation
+                </Link>
+                .
+              </p>
+            </Box>
+            {/* <p style={{ padding: "1em" }}>
+            </p> */}
           </Popover>
           <Menu
             id="basic-menu"
@@ -147,8 +151,10 @@ const MapPanel = (props: Props): JSX.Element => {
             onClose={closeOverlaysMenu}
             MenuListProps={{
               "aria-labelledby": "overlays-button",
+              className: "rounded bg-lightbisque",
             }}
           >
+            {/* <Box className="py-1 px-2 rounded border bg-lightbisque"> */}
             {Object.keys(overlayRegistry).map((overlay) => (
               <MenuItem
                 // selected={params.visOverlays.includes(overlay)}
@@ -169,6 +175,8 @@ const MapPanel = (props: Props): JSX.Element => {
                 {overlay}
               </MenuItem>
             ))}
+
+            {/* </Box> */}
           </Menu>
         </div>
       </Box>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -80,6 +80,8 @@ ul.navbar > li > ul {
   padding: 1rem 2rem;
   background-color: #ffe5c4;
   border-radius: 4px;
+  box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2),
+    0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12);
   @apply absolute;
 }
 


### PR DESCRIPTION
Unifies the style of a few similar components. I tried a much more comprehensive style overhaul, but that turned out to be really challenging across these MUI components within our current setup (and my understanding of it) so this is mostly just done with tailwind classes.

![image](https://github.com/user-attachments/assets/312598cd-a2bb-45f4-a207-0551b7992b6c)
![image](https://github.com/user-attachments/assets/f1ad17ae-0dd9-42df-bcfb-920bbdb2b423)
![image](https://github.com/user-attachments/assets/fddb87cb-032b-4d7d-a2ba-01faded6f155)
![image](https://github.com/user-attachments/assets/dd120330-dcd3-47dd-b47e-4c4fb252616a)

