### PR TITLE
fix: refactored Post + Showcase to cut down on duplicated code

### DIFF
--- a/src/components/news/PostItem.tsx
+++ b/src/components/news/PostItem.tsx
@@ -32,11 +32,13 @@ export default function PostItem({
   `;
 
   return (
-    <Link href={slugPrefix + item.slug} legacyBehavior>
+    <>
       <style>{css}</style>
-      <a className={"no-underline item-link"}>
-        {getContent(item)}
-      </a>
-    </Link>
+      <Link href={slugPrefix + item.slug} legacyBehavior>
+        <a className={"no-underline item-link"}>
+          {getContent(item)}
+        </a>
+      </Link>
+    </>
   );
 }

--- a/src/components/news/PostItem.tsx
+++ b/src/components/news/PostItem.tsx
@@ -2,28 +2,40 @@ import { PostContent } from "../../lib/posts";
 import Date from "./Date";
 import Link from "next/link";
 import { parseISO } from "date-fns";
+import {ShowcaseContent} from "../../lib/showcases";
 
-type Props = {
-  post: PostContent;
+const getPostContent = (post: PostContent) => <>
+    <Date date={parseISO(post.date)} />
+    <h2 className={"item-title"}>{post.title}</h2>
+</>;
+
+export type ItemProps = {
+  item: PostContent | ShowcaseContent;
+  slugPrefix?: string;
+  getContent?: Function;
 };
-export default function PostItem({ post }: Props) {
+export default function PostItem({
+    item,
+    slugPrefix = '/news/',
+    getContent = getPostContent
+}: ItemProps) {
+
+  const css: string = `
+      .item-link {
+        color: #222;
+        display: inline-block;
+      }
+      .item-title {
+        margin: 0;
+        font-size: 2rem;
+      }
+  `;
+
   return (
-    <Link href={"/news/" + post.slug} legacyBehavior>
-      <a className={"no-underline"}>
-        <Date date={parseISO(post.date)} />
-        <h2>{post.title}</h2>
-        <style jsx>
-          {`
-            a {
-              color: #222;
-              display: inline-block;
-            }
-            h2 {
-              margin: 0;
-              font-size: 2rem;
-            }
-          `}
-        </style>
+    <Link href={slugPrefix + item.slug} legacyBehavior>
+      <style>{css}</style>
+      <a className={"no-underline item-link"}>
+        {getContent(item)}
       </a>
     </Link>
   );

--- a/src/components/news/PostLayout.tsx
+++ b/src/components/news/PostLayout.tsx
@@ -42,7 +42,7 @@ export default function PostLayout({
   date,
   slug,
   author,
-  tags,
+  tags = [],
   link,
   image,
   fellowName,
@@ -54,8 +54,8 @@ export default function PostLayout({
   pathPrefix = '/news',
   backButtonText = 'Back to all posts'
 }: PostLayoutProps) {
-  const keywords = tags ? tags.map((it) => getTag(it).name) : [];
-  const authorName = getAuthor(author).name;
+  const keywords = tags?.length ? tags.map((it) => getTag(it)?.name) : [];
+  const authorName = getAuthor(author)?.name;
   const fellow = getFellow(fellowName);
   return (
     <Layout>

--- a/src/components/news/PostLayout.tsx
+++ b/src/components/news/PostLayout.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import styles from "@/public/styles/posts.module.css";
 import Author from "./Author";
 import Copyright from "./Copyright";
-import Date from "./Date";
+import DateComponent from "./Date";
 import Layout from "./Layout";
 import BasicMeta from "./meta/BasicMeta";
 import JsonLdMeta from "./meta/JsonLdMeta";
@@ -12,17 +12,30 @@ import TwitterCardMeta from "./meta/TwitterCardMeta";
 import TagButton from "./TagButton";
 import { getAuthor } from "../../lib/authors";
 import { getTag } from "../../lib/tags";
-import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
-import Footer from "../homepage/footer";
+import { getFellow } from "../../lib/people";
+import Image from "next/image";
 
-type Props = {
+export type PostLayoutProps = {
+  // Shared
   title: string;
   date: Date;
   slug: string;
   tags: string[];
-  author: string;
   description?: string;
   children: React.ReactNode;
+
+  // PostLayout
+  author?: string;
+  showJsonLd: boolean;
+  showMetadata: boolean;
+
+  // ShowcaseLayout
+  fellowName: string;
+  image: string;
+  link: string;
+  techUsed: string;
+  pathPrefix: string;
+  backButtonText: string;
 };
 export default function PostLayout({
   title,
@@ -30,37 +43,48 @@ export default function PostLayout({
   slug,
   author,
   tags,
+  link,
+  image,
+  fellowName,
+  techUsed,
   description = "",
   children,
-}: Props) {
+  showJsonLd = true,
+  showMetadata = true,
+  pathPrefix = '/news',
+  backButtonText = 'Back to all posts'
+}: PostLayoutProps) {
   const keywords = tags ? tags.map((it) => getTag(it).name) : [];
   const authorName = getAuthor(author).name;
+  const fellow = getFellow(fellowName);
   return (
     <Layout>
       <BasicMeta
-        url={`/news/${slug}`}
+        url={`${pathPrefix}/${slug}`}
         title={title}
         keywords={keywords}
         description={description}
       />
       <TwitterCardMeta
-        url={`/news/${slug}`}
+        url={`${pathPrefix}/${slug}`}
         title={title}
         description={description}
       />
       <OpenGraphMeta
-        url={`/news/${slug}`}
+        url={`${pathPrefix}/${slug}`}
         title={title}
         description={description}
       />
-      <JsonLdMeta
-        url={`/news/${slug}`}
-        title={title}
-        keywords={keywords}
-        date={date}
-        author={authorName}
-        description={description}
-      />
+        {
+            showJsonLd && <JsonLdMeta
+                url={`${pathPrefix}/${slug}`}
+                title={title}
+                keywords={keywords}
+                date={date}
+                author={authorName}
+                description={description}
+              />
+        }
       <div className={styles.container}>
         <article
           className={
@@ -68,30 +92,59 @@ export default function PostLayout({
           }
         >
           <div className={"backlink"}>
-            <Link href="/news" className={"no-underline"}>
-              &larr; Back to all posts
+            <Link href={pathPrefix} className={"no-underline"}>
+              &larr; {backButtonText}
             </Link>
           </div>
           <header>
             <h1>{title}</h1>
-            <div className={"metadata"}>
-              <div>
-                <Date date={date} />
-              </div>
-              <div>
-                <Author author={getAuthor(author)} />
-              </div>
-            </div>
+              {
+                  showMetadata && <div className={"metadata"}>
+                      <div>
+                        <DateComponent date={date} />
+                      </div>
+                      <div>
+                        <Author author={getAuthor(author)} />
+                      </div>
+                    </div>
+              }
           </header>
+            {
+                image && <div className="relative">
+                    <Image
+                        src={image}
+                        alt="ad"
+                        width={0}
+                        height={0}
+                        sizes="100vw"
+                        style={{ width: "100%", height: "auto" }} // optional
+                    />
+                </div>
+            }
+            { fellowName && fellow && link && <div className={styles.metadata}>
+                    <p style={{ marginTop: "0.5rem" }}>Tech used: {techUsed}</p>
+                    <p>
+                        By: <Link href={fellow.link}>{fellow.name}</Link>
+                    </p>
+                    <p>Fellow cohort: Spring 2024</p>
+                    <button
+                        onClick={() => {
+                            window.open(link, "_blank");
+                        }}
+                    >
+                        Explore App &rarr;
+                    </button>
+                </div>
+            }
           <div className={styles.content}>{children}</div>
-          <ul className={"tag-list"}>
-            {tags &&
-              tags.map((it, i) => (
-                <li key={i}>
-                  <TagButton tag={getTag(it)} />
-                </li>
-              ))}
-          </ul>
+            { tags && <ul className={"tag-list"}>
+                {tags.map((it, i) => (
+                    <li key={i}>
+                      <TagButton tag={getTag(it)} />
+                    </li>
+                  ))}
+                </ul>
+            }
         </article>
         <footer>
           <Copyright />

--- a/src/components/news/PostLayout.tsx
+++ b/src/components/news/PostLayout.tsx
@@ -26,16 +26,16 @@ export type PostLayoutProps = {
 
   // PostLayout
   author?: string;
-  showJsonLd: boolean;
-  showMetadata: boolean;
+  showJsonLd?: boolean;
+  showMetadata?: boolean;
 
   // ShowcaseLayout
-  fellowName: string;
-  image: string;
-  link: string;
-  techUsed: string;
-  pathPrefix: string;
-  backButtonText: string;
+  fellowName?: string;
+  image?: string;
+  link?: string;
+  techUsed?: string;
+  pathPrefix?: string;
+  backButtonText?: string;
 };
 export default function PostLayout({
   title,

--- a/src/components/news/PostList.tsx
+++ b/src/components/news/PostList.tsx
@@ -7,17 +7,18 @@ import { TagContent } from "../../lib/tags";
 import {ShowcaseContent} from "../../lib/showcases";
 import ShowcaseItem from "@/components/showcase/ShowcaseItem";
 
-const getContent = (item) => <PostItem item={item} />
+const getPostContent = (item) => <PostItem item={item} />
 
 export type ListProps = {
   posts: PostContent[] | ShowcaseContent[];
   tags?: TagContent[];
+  getContent?: Function;
   pagination: {
     current: number;
     pages: number;
   };
 };
-export default function PostList({ posts, tags, pagination }: ListProps) {
+export default function PostList({ posts, tags, pagination, getContent=getPostContent }: ListProps) {
   return (
     <>
       <div className={"post-list"}>
@@ -37,7 +38,7 @@ export default function PostList({ posts, tags, pagination }: ListProps) {
           }}
         />}
       </div>
-        { tags && <ul className={"categories"}>
+        { tags?.length && <ul className={"categories"}>
             <li>
               <strong>Tags</strong>
             </li>

--- a/src/components/news/PostList.tsx
+++ b/src/components/news/PostList.tsx
@@ -4,45 +4,49 @@ import PostItem from "./PostItem";
 import TagLink from "./TagLink";
 import Pagination from "./Pagination";
 import { TagContent } from "../../lib/tags";
+import {ShowcaseContent} from "../../lib/showcases";
+import ShowcaseItem from "@/components/showcase/ShowcaseItem";
 
-type Props = {
-  posts: PostContent[];
-  tags: TagContent[];
+const getContent = (item) => <PostItem item={item} />
+
+export type ListProps = {
+  posts: PostContent[] | ShowcaseContent[];
+  tags?: TagContent[];
   pagination: {
     current: number;
     pages: number;
   };
 };
-export default function PostList({ posts, tags, pagination }: Props) {
+export default function PostList({ posts, tags, pagination }: ListProps) {
   return (
     <>
       <div className={"post-list"}>
         <ul className={""}>
           {posts.map((it, i) => (
             <li key={i}>
-              <PostItem post={it} />
+                {getContent(it)}
             </li>
           ))}
         </ul>
-        <Pagination
+          { pagination && <Pagination
           current={pagination.current}
           pages={pagination.pages}
           link={{
             href: (page) => (page === 1 ? "/news" : "/news/page/[page]"),
             as: (page) => (page === 1 ? null : "/news/page/" + page),
           }}
-        />
+        />}
       </div>
-      <ul className={"categories"}>
-        <li>
-          <strong>Tags</strong>
-        </li>
-        {tags.map((it, i) => (
-          <li key={i}>
-            <TagLink tag={it} />
-          </li>
-        ))}
-      </ul>
+        { tags && <ul className={"categories"}>
+            <li>
+              <strong>Tags</strong>
+            </li>
+            {tags.map((it, i) => (
+              <li key={i}>
+                <TagLink tag={it} />
+              </li>
+            ))}
+      </ul>}
     </>
   );
 }

--- a/src/components/news/TagPostList.tsx
+++ b/src/components/news/TagPostList.tsx
@@ -25,7 +25,7 @@ export default function TagPostList({ posts, tag, pagination }: Props) {
       <ul>
         {posts.map((it, i) => (
           <li key={i}>
-            <PostItem post={it} />
+            <PostItem item={it} />
           </li>
         ))}
       </ul>

--- a/src/components/showcase/ShowcaseItem.tsx
+++ b/src/components/showcase/ShowcaseItem.tsx
@@ -1,36 +1,27 @@
 import { ShowcaseContent } from "../../lib/showcases";
 import Image from "next/image";
-import Link from "next/link";
+import PostItem, {ItemProps} from "@/components/news/PostItem";
 
-type Props = {
-  item: ShowcaseContent;
-};
-export default function ShowcaseItem({ item }: Props) {
-  return (
-    <Link href={"/showcase/" + item.slug} legacyBehavior>
-      <a className={"no-underline"}>
-        <div style={{ display: "flex" }}>
-          <div>
+const getShowcaseContent = (item: ShowcaseContent) => <>
+    <div style={{ display: "flex" }}>
+        <div>
             <Image src={item.image} alt={item.title} width={200} height={25} />
-          </div>
-          <div style={{ paddingLeft: "2rem" }}>
+        </div>
+        <div style={{ paddingLeft: "2rem" }}>
             <h2>{item.title}</h2>
             <p>{item.fellow}</p>
-          </div>
         </div>
-        <style jsx>
-          {`
-            a {
-              color: #222;
-              display: inline-block;
-            }
-            h2 {
-              margin: 0;
-              font-size: 2rem;
-            }
-          `}
-        </style>
-      </a>
-    </Link>
+    </div>
+</>;
+
+export default function ShowcaseItem({
+    item,
+    slugPrefix = '/showcase/',
+    getContent = getShowcaseContent,
+}: ItemProps) {
+  return (
+    <PostItem item={item}
+              slugPrefix={slugPrefix}
+              getContent={getContent}></PostItem>
   );
 }

--- a/src/components/showcase/ShowcaseItem.tsx
+++ b/src/components/showcase/ShowcaseItem.tsx
@@ -4,11 +4,9 @@ import PostItem, {ItemProps} from "@/components/news/PostItem";
 
 const getShowcaseContent = (item: ShowcaseContent) => <>
     <div style={{ display: "flex" }}>
-        <div>
-            <Image src={item.image} alt={item.title} width={200} height={25} />
-        </div>
+        <Image src={item.image} alt={item.title} width={200} height={25} />
         <div style={{ paddingLeft: "2rem" }}>
-            <h2>{item.title}</h2>
+            <h2 className={"item-title"}>{item.title}</h2>
             <p>{item.fellow}</p>
         </div>
     </div>

--- a/src/components/showcase/ShowcaseLayout.tsx
+++ b/src/components/showcase/ShowcaseLayout.tsx
@@ -1,35 +1,9 @@
 import React from "react";
-import Link from "next/link";
-import Image from "next/image";
-import styles from "@/public/styles/posts.module.css";
-import Author from "../news/Author";
-import Copyright from "../news/Copyright";
-import Date from "../news/Date";
-import Layout from "../news/Layout";
-import BasicMeta from "../news/meta/BasicMeta";
-import JsonLdMeta from "../news/meta/JsonLdMeta";
-import OpenGraphMeta from "../news/meta/OpenGraphMeta";
-import TwitterCardMeta from "../news/meta/TwitterCardMeta";
-import TagButton from "../news/TagButton";
-import { getFellow } from "../../lib/people";
-import { getTag } from "../../lib/tags";
-import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
-import Footer from "../homepage/footer";
+import PostLayout, { PostLayoutProps } from "../news/PostLayout";
 
-type Props = {
-  title: string;
-  date: Date;
-  slug: string;
-  image: string;
-  link: string;
-  tags: string[];
-  fellowName: string;
-  techUsed: string;
-  description?: string;
-  children: React.ReactNode;
-};
 export default function ShowcaseLayout({
   title,
+  date,
   image,
   link,
   slug,
@@ -38,212 +12,19 @@ export default function ShowcaseLayout({
   tags,
   description = "",
   children,
-}: Props) {
-  const keywords = tags ? tags.map((it) => getTag(it).name) : [];
-  // const authorName = getAuthor(author).name;
-  const fellow = getFellow(fellowName);
+  showJsonLd = false,
+  showMetadata = false,
+  pathPrefix = '/showcase',
+  backButtonText = 'Back to showcases',
+}: PostLayoutProps) {
   return (
-    <Layout>
-      <BasicMeta
-        url={`/showcase/${slug}`}
-        title={title}
-        keywords={keywords}
-        description={description}
-      />
-      <TwitterCardMeta
-        url={`/showcase/${slug}`}
-        title={title}
-        description={description}
-      />
-      <OpenGraphMeta
-        url={`/showcase/${slug}`}
-        title={title}
-        description={description}
-      />
-      <div className={styles.container}>
-        <article
-          className={
-            "text-stone-900 text-xl w-[1068px] max-w-[1068px] max-md:max-w-full max-md:mt-10"
-          }
-        >
-          <div className={"backlink"}>
-            <Link href="/showcase" className={"no-underline"}>
-              &larr; Back to showcase
-            </Link>
-          </div>
-          <header>
-            <h1>{title}</h1>
-          </header>
-          <div className="relative">
-            <Image
-              src={image}
-              alt="ad"
-              width={0}
-              height={0}
-              sizes="100vw"
-              style={{ width: "100%", height: "auto" }} // optional
-            />
-          </div>
-          <div className={styles.metadata}>
-            <p style={{ marginTop: "0.5rem" }}>Tech used: {techUsed}</p>
-            <p>
-              By: <Link href={fellow.link}>{fellow.name}</Link>
-            </p>
-            <p>Fellow cohort: Spring 2024</p>
-            <button
-              onClick={() => {
-                window.open(link, "_blank");
-              }}
-            >
-              Explore App &rarr;
-            </button>
-          </div>
-          <div className={styles.content}>{children}</div>
-        </article>
-        <footer>
-          <Copyright />
-        </footer>
-      </div>
-      <style jsx>
-        {`
-          .metadata div {
-            display: inline-block;
-            margin-right: 0.5rem;
-          }
-          article {
-            flex: 1 0 auto;
-          }
-          h1 {
-            margin: 0 0 0.5rem;
-            font-size: 2.3rem;
-          }
-          .backlink {
-            color: grey;
-            margin-bottom: 1em;
-          }
-          .tag-list {
-            list-style: none;
-            text-align: right;
-            margin: 1.75rem 0 0 0;
-            padding: 0;
-          }
-          .tag-list li {
-            display: inline-block;
-            margin-left: 0.5rem;
-          }
-          .social-list {
-            margin-top: 3rem;
-            text-align: center;
-          }
-
-          @media (min-width: 769px) {
-            .container {
-              display: flex;
-              flex-direction: column;
-            }
-          }
-        `}
-      </style>
-      <style global jsx>
-        {`
-          /* Syntax highlighting */
-          .token.comment,
-          .token.prolog,
-          .token.doctype,
-          .token.cdata,
-          .token.plain-text {
-            color: #6a737d;
-          }
-
-          .token.atrule,
-          .token.attr-value,
-          .token.keyword,
-          .token.operator {
-            color: #d73a49;
-          }
-
-          .token.property,
-          .token.tag,
-          .token.boolean,
-          .token.number,
-          .token.constant,
-          .token.symbol,
-          .token.deleted {
-            color: #22863a;
-          }
-
-          .token.selector,
-          .token.attr-name,
-          .token.string,
-          .token.char,
-          .token.builtin,
-          .token.inserted {
-            color: #032f62;
-          }
-
-          .token.function,
-          .token.class-name {
-            color: #6f42c1;
-          }
-
-          /* language-specific */
-
-          /* JSX */
-          .language-jsx .token.punctuation,
-          .language-jsx .token.tag .token.punctuation,
-          .language-jsx .token.tag .token.script,
-          .language-jsx .token.plain-text {
-            color: #24292e;
-          }
-
-          .language-jsx .token.tag .token.attr-name {
-            color: #6f42c1;
-          }
-
-          .language-jsx .token.tag .token.class-name {
-            color: #005cc5;
-          }
-
-          .language-jsx .token.tag .token.script-punctuation,
-          .language-jsx .token.attr-value .token.punctuation:first-child {
-            color: #d73a49;
-          }
-
-          .language-jsx .token.attr-value {
-            color: #032f62;
-          }
-
-          .language-jsx span[class="comment"] {
-            color: pink;
-          }
-
-          /* HTML */
-          .language-html .token.tag .token.punctuation {
-            color: #24292e;
-          }
-
-          .language-html .token.tag .token.attr-name {
-            color: #6f42c1;
-          }
-
-          .language-html .token.tag .token.attr-value,
-          .language-html
-            .token.tag
-            .token.attr-value
-            .token.punctuation:not(:first-child) {
-            color: #032f62;
-          }
-
-          /* CSS */
-          .language-css .token.selector {
-            color: #6f42c1;
-          }
-
-          .language-css .token.property {
-            color: #005cc5;
-          }
-        `}
-      </style>
-    </Layout>
+    <PostLayout title={title} image={image} link={link} slug={slug}
+                date={date} fellowName={fellowName} techUsed={techUsed}
+                tags={tags} description={description} showJsonLd={showJsonLd}
+                showMetadata={showMetadata} pathPrefix={pathPrefix}
+                backButtonText={backButtonText}
+    >
+        {children}
+    </PostLayout>
   );
 }

--- a/src/components/showcase/ShowcaseList.tsx
+++ b/src/components/showcase/ShowcaseList.tsx
@@ -2,22 +2,18 @@ import React from "react";
 import { ShowcaseContent } from "../../lib/showcases";
 import ShowcaseItem from "./ShowcaseItem";
 import Pagination from "../news/Pagination";
+import {ListProps} from "@/components/news/PostList";
 
-type Props = {
-  posts: ShowcaseContent[];
-  pagination: {
-    current: number;
-    pages: number;
-  };
-};
-export default function PostList({ posts, pagination }: Props) {
+const getContent = (item) => <ShowcaseItem item={item} />
+
+export default function ShowcaseList({ posts, pagination }: ListProps) {
   return (
     <>
       <div className={"post-list"}>
         <ul className={""}>
           {posts.map((it, i) => (
             <li key={i}>
-              <ShowcaseItem item={it} />
+              {getContent(it)}
             </li>
           ))}
         </ul>

--- a/src/components/showcase/ShowcaseList.tsx
+++ b/src/components/showcase/ShowcaseList.tsx
@@ -2,30 +2,12 @@ import React from "react";
 import { ShowcaseContent } from "../../lib/showcases";
 import ShowcaseItem from "./ShowcaseItem";
 import Pagination from "../news/Pagination";
-import {ListProps} from "@/components/news/PostList";
+import PostList, {ListProps} from "@/components/news/PostList";
 
-const getContent = (item) => <ShowcaseItem item={item} />
+const getShowcaseContent = (item) => <ShowcaseItem item={item} />
 
-export default function ShowcaseList({ posts, pagination }: ListProps) {
+export default function ShowcaseList({ posts, pagination, getContent=getShowcaseContent }: ListProps) {
   return (
-    <>
-      <div className={"post-list"}>
-        <ul className={""}>
-          {posts.map((it, i) => (
-            <li key={i}>
-              {getContent(it)}
-            </li>
-          ))}
-        </ul>
-        {/* <Pagination
-          current={pagination.current}
-          pages={pagination.pages}
-          link={{
-            href: (page) => (page === 1 ? "/news" : "/news/page/[page]"),
-            as: (page) => (page === 1 ? null : "/news/page/" + page),
-          }}
-        /> */}
-      </div>
-    </>
+    <PostList posts={posts} pagination={pagination} tags={[]} getContent={getContent}></PostList>
   );
 }


### PR DESCRIPTION
## Problem
News (Post) + Showcase contain a lot of copy-pasted / duplicated code between them

We would like to consolidate this into a set of shared components that can be used for both contexts

## Approach
* Refactor `PostItem`, `PostList`, and `PostLayout` into reusable components
    * Replace copy-pasted code within `ShowcaseItem`, `ShowcaseList`, and `ShowcaseLayout` to use these newly-refactored components

## How to Test
TBD
