### PR TITLE
#311: Filter object from the solr side and add info section

### DIFF
--- a/meta/helper/solrObjects.ts
+++ b/meta/helper/solrObjects.ts
@@ -9,53 +9,51 @@ import { schemaMatch } from "./util";
  * @returns
  */
 const initSolrObject = (rawSolrObject: any, schema: {}): SolrObject => {
-  if (!rawSolrObject.gbl_suppressed_b) {
-    let result = {} as SolrObject;
-    result.score = rawSolrObject.score;
-    result.id = rawSolrObject.id;
-    result.title = rawSolrObject.dct_title_s;
-    result.metadata_version = rawSolrObject.gbl_mdVersion_s;
-    result.modified = rawSolrObject.gbl_mdModified_dt;
-    result.access_rights = rawSolrObject.dct_accessRights_s;
-    result.resource_class = rawSolrObject.gbl_resourceClass_sm;
-    result.description = rawSolrObject.dct_description_sm
-      ? rawSolrObject.dct_description_sm
-      : [];
-    result.creator = rawSolrObject.dct_creator_sm
-      ? typeof rawSolrObject.dct_creator_sm === "string"
-        ? [rawSolrObject.dct_creator_sm]
-        : rawSolrObject.dct_creator_sm
-      : [];
-    result.index_year = rawSolrObject.gbl_indexYear_im
-      ? typeof rawSolrObject.gbl_indexYear_im === "string"
-        ? [rawSolrObject.gbl_indexYear_im]
-        : rawSolrObject.gbl_indexYear_im.map((year) => {
-            return year.toString();
-          })
-      : [];
-    result.meta = {};
-    result.years = new Set();
-    if (rawSolrObject.dct_isVersionOf_sm)
-      // child object only
-      result.parents = rawSolrObject.dct_isVersionOf_sm;
-    Object.keys(rawSolrObject).forEach((key) => {
-      if (
-        key !== "id" &&
-        key !== "dct_title_s" &&
-        key !== "gbl_mdVersion_s" &&
-        key !== "gbl_mdModified_dt" &&
-        key !== "dct_accessRights_s" &&
-        key !== "gbl_resourceClass_sm" &&
-        key !== "dct_description_sm" &&
-        key !== "dct_creator_sm" &&
-        key !== "gbl_indexYear_im" &&
-        key !== "dct_isVersionOf_sm"
-      ) {
-        result.meta[schemaMatch(key, schema)] = rawSolrObject[key];
-      }
-    });
-    return result;
-  };
+  let result = {} as SolrObject;
+  result.score = rawSolrObject.score;
+  result.id = rawSolrObject.id;
+  result.title = rawSolrObject.dct_title_s;
+  result.metadata_version = rawSolrObject.gbl_mdVersion_s;
+  result.modified = rawSolrObject.gbl_mdModified_dt;
+  result.access_rights = rawSolrObject.dct_accessRights_s;
+  result.resource_class = rawSolrObject.gbl_resourceClass_sm;
+  result.description = rawSolrObject.dct_description_sm
+    ? rawSolrObject.dct_description_sm
+    : [];
+  result.creator = rawSolrObject.dct_creator_sm
+    ? typeof rawSolrObject.dct_creator_sm === "string"
+      ? [rawSolrObject.dct_creator_sm]
+      : rawSolrObject.dct_creator_sm
+    : [];
+  result.index_year = rawSolrObject.gbl_indexYear_im
+    ? typeof rawSolrObject.gbl_indexYear_im === "string"
+      ? [rawSolrObject.gbl_indexYear_im]
+      : rawSolrObject.gbl_indexYear_im.map((year) => {
+          return year.toString();
+        })
+    : [];
+  result.meta = {};
+  result.years = new Set();
+  if (rawSolrObject.dct_isVersionOf_sm)
+    // child object only
+    result.parents = rawSolrObject.dct_isVersionOf_sm;
+  Object.keys(rawSolrObject).forEach((key) => {
+    if (
+      key !== "id" &&
+      key !== "dct_title_s" &&
+      key !== "gbl_mdVersion_s" &&
+      key !== "gbl_mdModified_dt" &&
+      key !== "dct_accessRights_s" &&
+      key !== "gbl_resourceClass_sm" &&
+      key !== "dct_description_sm" &&
+      key !== "dct_creator_sm" &&
+      key !== "gbl_indexYear_im" &&
+      key !== "dct_isVersionOf_sm"
+    ) {
+      result.meta[schemaMatch(key, schema)] = rawSolrObject[key];
+    }
+  });
+  return result;
 };
 
 /**

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -252,9 +252,8 @@ export default function DiscoveryArea({
           }}
         >
           <DetailPanel
-            resultItem={
-              fetchResults.find(
-              (r) => r? r.id === params.showDetailPanel : null
+            resultItem={fetchResults.find((r) =>
+              r ? r.id === params.showDetailPanel : null
             )}
             setShowDetailPanel={params.setShowDetailPanel}
             showSharedLink={params.showSharedLink}

--- a/src/components/search/helper/ParameterList.tsx
+++ b/src/components/search/helper/ParameterList.tsx
@@ -43,7 +43,10 @@ export const GetAllParams = () => {
     "showSharedLink",
     parseAsString.withDefault("")
   );
-
+  const [showInfoPanel, setInfoPanel] = useQueryState(
+    "showInfoPanel",
+    parseAsString.withDefault("")
+  );
   // showFilter: if it is not empty, show the filter
   const [showFilter, setShowFilter] = useQueryState(
     "showFilter",
@@ -124,6 +127,8 @@ export const GetAllParams = () => {
       setShowDetailPanel,
       showSharedLink,
       setShowSharedLink,
+      showInfoPanel,
+      setInfoPanel,
       showFilter,
       setShowFilter,
       sortOrder,

--- a/src/components/search/helper/SolrQueryBuilder.tsx
+++ b/src/components/search/helper/SolrQueryBuilder.tsx
@@ -129,7 +129,7 @@ export default class SolrQueryBuilder {
       )}:"${encodeURIComponent(term.value)}" AND `;
     });
     filterQuery = filterQuery.slice(0, -5); //remove the last AND
-    filterQuery = filterQuery += "&rows=1000";
+    filterQuery = filterQuery += "&fq=(gbl_suppressed_b:false)&rows=1000";
     return this.setQuery(filterQuery);
   }
 
@@ -185,7 +185,7 @@ export default class SolrQueryBuilder {
         combinedQuery += filterQuery;
       }
     }
-    combinedQuery += "&rows=1000";
+    combinedQuery += "&fq=(gbl_suppressed_b:false)&rows=1000";
     return this.setQuery(combinedQuery.replace(this.getSolrUrl() + "/", ""));
   };
 }

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -21,7 +21,6 @@ const useStyles = makeStyles((theme) => ({
 }));
 function CustomTabPanel(props: Props) {
   const { children, value, index, ...other } = props;
-
   return (
     <div
       role="tabpanel"
@@ -44,12 +43,24 @@ export default function InfoPanel() {
   let params = GetAllParams();
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
+  const [maxHeight, setMaxHeight] = React.useState(0);
+  const tabPanelRef = React.useRef(null);
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
   const handleClosePanel = () => {
     params.setInfoPanel(null);
   };
+  React.useEffect(() => {
+    if (tabPanelRef.current) {
+      const panels = Array.from(tabPanelRef.current.children) as HTMLElement[];
+      const maxContentHeight = panels.reduce(
+        (maxHeight, panel) => Math.max(maxHeight, panel.scrollHeight),
+        0
+      );
+      setMaxHeight(maxContentHeight);
+    }
+  }, []);
   return (
     <div className={`${classes.infoPanel}`}>
       <Box
@@ -139,18 +150,26 @@ export default function InfoPanel() {
           <CloseIcon />
         </IconButton>
       </Box>
-      <CustomTabPanel value={value} index={0}>
-        Spatial resolution determines how detailed your data is. A higher
-        resolution means you can see data for smaller areas, like individual
-        census tracts or zip codes. Low resolution shows data for larger areas,
-        like states or counties. Lorem ipsum ipsum ipsum ipsum ipsum ipsum ipsum
-        ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum.
-      </CustomTabPanel>
-      <CustomTabPanel value={value} index={1}>
-        Search keywords. Low resolution shows data for larger areas, like states
-        or counties. Lorem ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum
-        ipsum ipsum ipsum ipsum ipsum ipsum ipsum.
-      </CustomTabPanel>
+      <Box
+        sx={{
+          minHeight: maxHeight,
+          transition: "height 0.3s ease",
+        }}
+        ref={tabPanelRef}
+      >
+        <CustomTabPanel value={value} index={0}>
+          Spatial resolution determines how detailed your data is. A higher
+          resolution means you can see data for smaller areas, like individual
+          census tracts or zip codes. Low resolution shows data for larger
+          areas, like states or counties. Lorem ipsum ipsum ipsum ipsum ipsum
+          ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum.
+        </CustomTabPanel>
+        <CustomTabPanel value={value} index={1}>
+          Search keywords. Low resolution shows data for larger areas, like
+          states or counties. Lorem ipsum ipsum ipsum ipsum ipsum ipsum ipsum
+          ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum.
+        </CustomTabPanel>
+      </Box>
     </div>
   );
 }

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -1,0 +1,156 @@
+import * as React from "react";
+import { makeStyles } from "@mui/styles";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import CloseIcon from "@mui/icons-material/Close";
+import { GetAllParams, reGetFilterQueries } from "../helper/ParameterList";
+import tailwindConfig from "tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+import { Box, Tabs, Tab, IconButton, Typography } from "@mui/material";
+
+interface Props {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+const fullConfig = resolveConfig(tailwindConfig);
+const useStyles = makeStyles((theme) => ({
+  infoPanel: {
+    color: `${fullConfig.theme.colors["almostblack"]}`,
+    fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+  },
+}));
+function CustomTabPanel(props: Props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3, pl: 0 }}>{children}</Box>}
+    </div>
+  );
+}
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    "aria-controls": `simple-tabpanel-${index}`,
+  };
+}
+export default function InfoPanel() {
+  let params = GetAllParams();
+  const classes = useStyles();
+  const [value, setValue] = React.useState(0);
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+  const handleClosePanel = () => {
+    params.setInfoPanel(null);
+  };
+  return (
+    <div className={`${classes.infoPanel}`}>
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: "divider",
+          position: "relative",
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <IconButton
+          onClick={handleClosePanel}
+          style={{
+            position: "absolute",
+            left: -72,
+            top: 4,
+            color: fullConfig.theme.colors["frenchviolet"],
+          }}
+        >
+          <InfoOutlinedIcon />
+        </IconButton>
+
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          sx={{
+            paddingLeft: "2em",
+            minWidth: "fit-content",
+          }}
+          TabIndicatorProps={{
+            style: {
+              backgroundColor: fullConfig.theme.colors["frenchviolet"],
+              height: "0.2em",
+            },
+          }}
+        >
+          <Tab
+            sx={{ paddingRight: "2em" }}
+            label={
+              <Typography
+                sx={{
+                  textTransform: "none",
+                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                  fontWeight: 500,
+                  color:
+                    value === 0
+                      ? fullConfig.theme.colors["frenchviolet"]
+                      : fullConfig.theme.colors["almostblack"],
+                }}
+              >
+                Spatial resolution
+              </Typography>
+            }
+            {...a11yProps(0)}
+          />
+          <Tab
+            sx={{ paddingRight: "2em" }}
+            label={
+              <Typography
+                sx={{
+                  textTransform: "none",
+                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                  fontWeight: 500,
+                  color:
+                    value === 1
+                      ? fullConfig.theme.colors["frenchviolet"]
+                      : fullConfig.theme.colors["almostblack"],
+                }}
+              >
+                Search keywords
+              </Typography>
+            }
+            {...a11yProps(1)}
+          />
+        </Tabs>
+
+        <IconButton
+          onClick={handleClosePanel}
+          style={{
+            position: "absolute",
+            right: 0,
+            top: 4,
+            color: fullConfig.theme.colors["frenchviolet"],
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <CustomTabPanel value={value} index={0}>
+        Spatial resolution determines how detailed your data is. A higher
+        resolution means you can see data for smaller areas, like individual
+        census tracts or zip codes. Low resolution shows data for larger areas,
+        like states or counties. Lorem ipsum ipsum ipsum ipsum ipsum ipsum ipsum
+        ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum.
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={1}>
+        Search keywords. Low resolution shows data for larger areas, like states
+        or counties. Lorem ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum
+        ipsum ipsum ipsum ipsum ipsum ipsum ipsum.
+      </CustomTabPanel>
+    </div>
+  );
+}

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -21,6 +21,7 @@ import SolrQueryBuilder from "../helper/SolrQueryBuilder";
 import SuggestedResult from "../helper/SuggestedResultBuilder";
 import { useEffect } from "react";
 import { GetAllParams, reGetFilterQueries } from "../helper/ParameterList";
+import { url } from "inspector";
 
 interface Props {
   schema: any;
@@ -199,7 +200,9 @@ const SearchBox = (props: Props): JSX.Element => {
                     <SearchIcon className="text-2xl mr-2 ml-10 text-frenchviolet" />
                     <Box component="span" className="mx-2">
                       <a
-                        href="#" // This needs to be updated after decide the advanced search page
+                        onClick={() => {
+                          urlParams.setInfoPanel("Yes");
+                        }}
                         className={`no-underline text-frenchviolet `}
                       >
                         <InfoOutlinedIcon />

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -21,7 +21,6 @@ import SolrQueryBuilder from "../helper/SolrQueryBuilder";
 import SuggestedResult from "../helper/SuggestedResultBuilder";
 import { useEffect } from "react";
 import { GetAllParams, reGetFilterQueries } from "../helper/ParameterList";
-import { url } from "inspector";
 
 interface Props {
   schema: any;

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -202,6 +202,7 @@ const SearchBox = (props: Props): JSX.Element => {
                         onClick={() => {
                           urlParams.setInfoPanel("Yes");
                         }}
+                        style={{ cursor: "pointer" }}
                         className={`no-underline text-frenchviolet `}
                       >
                         <InfoOutlinedIcon />

--- a/src/components/search/searchArea/searchRow.tsx
+++ b/src/components/search/searchArea/searchRow.tsx
@@ -7,6 +7,8 @@ import SearchBox from "./searchBox";
 import { Box, Grid, Typography } from "@mui/material";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import GlossaryPopover from "@/components/GlossaryPopover";
+import { GetAllParams } from "../helper/ParameterList";
+import InfoPanel from "./infoPanel";
 
 interface Props {
   header: string;
@@ -35,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 const SearchRow = (props: Props): JSX.Element => {
   const classes = useStyles();
+  let params = GetAllParams();
   return (
     // The mt for top nav is 8, therefore set the row mt to 32
     <Box className="w-full mt-8 sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
@@ -70,33 +73,46 @@ const SearchRow = (props: Props): JSX.Element => {
           order={{ xs: 1, sm: 0 }}
           className={`pt-[2.1825em] pb-[2.875em] ${classes.searchRow}`}
         >
-          <Box width="100%">
-            <SpatialResolutionCheck
-              src={SearchUIConfig.search.searchBox.spatialResOptions}
-              handleSearch={props.handleSearch}
-              filterQueries={props.filterQueries}
-            />
-          </Box>
-          <Box
-            width="100%"
-            className="mt-[2em] sm:mt-0 3xl:max-w-[1203px] pr-[1em] md:pr-[3.375em]"
-          >
-            <SearchBox
-              schema={props.schema}
-              autocompleteKey={props.autocompleteKey}
-              options={props.options}
-              processResults={props.processResults}
-              setOptions={props.setOptions}
-              handleInputReset={props.handleInputReset}
-              inputValue={props.inputValue}
-              setInputValue={props.setInputValue}
-              value={props.value}
-              setValue={props.setValue}
-              inputRef={props.inputRef}
-              handleSearch={props.handleSearch}
-              setQuery={props.setQuery}
-            />
-          </Box>
+          {!params.showInfoPanel && (
+            <Box width="100%">
+              <Box width="100%">
+                <SpatialResolutionCheck
+                  src={SearchUIConfig.search.searchBox.spatialResOptions}
+                  handleSearch={props.handleSearch}
+                  filterQueries={props.filterQueries}
+                />
+              </Box>
+              <Box
+                width="100%"
+                className="mt-[2em] sm:mt-0 3xl:max-w-[1203px] pr-[1em] md:pr-[3.375em]"
+              >
+                <SearchBox
+                  schema={props.schema}
+                  autocompleteKey={props.autocompleteKey}
+                  options={props.options}
+                  processResults={props.processResults}
+                  setOptions={props.setOptions}
+                  handleInputReset={props.handleInputReset}
+                  inputValue={props.inputValue}
+                  setInputValue={props.setInputValue}
+                  value={props.value}
+                  setValue={props.setValue}
+                  inputRef={props.inputRef}
+                  handleSearch={props.handleSearch}
+                  setQuery={props.setQuery}
+                />
+              </Box>
+            </Box>
+          )}
+          {params.showInfoPanel && (
+            <div>
+              <div
+                className={`flex items-center space-x-10 md:ml-[6em] md:mr-[5.3125em]`}
+              >
+                <InfoPanel />
+              </div>
+            </div>
+          )}
         </Grid>
       </Grid>
     </Box>


### PR DESCRIPTION
This PR addresses #314. It also moves the judgment of unsuppressed documents to the query side.

## How to Test

1. Navigate to the search page and click the info icon in the search box. You should see the information panel appear:

<img width="1222" alt="Screenshot 2024-10-01 at 9 16 34 AM" src="https://github.com/user-attachments/assets/4a02e02c-0b9e-4947-97ae-d70d559c31fc">

2. Switch tabs, and different content should appear. I have added placeholders for now.

3. Click on the info icon or the close icon. This tab should be replaced by the original search box.

