### PR TITLE
feat: register a custom editor component named Toggle Section

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -29,6 +29,91 @@
         "https://fonts.googleapis.com/css2?family=Nunito:wght@300;400&display=swap"
       );
       CMS.registerPreviewStyle("/styles/posts.module.css");
+      // Register custom Editor Components
+      CMS.registerEditorComponent({
+        // Internal id of the component
+        id: "toggle-section",
+        // Visible label
+        label: "Toggle Section",
+        // Fields the user need to fill out when adding an instance of the component
+        fields: [
+          {
+            name: 'title',
+            label: 'Title',
+            widget: 'string'
+          },
+          {
+            name: 'content',
+            label: 'Content',
+            widget: 'markdown'
+          },
+          {
+            name: 'group',
+            label: 'Group',
+            widget: 'string'
+          }
+        ],
+
+        // Regex pattern used to search for instances of this block in the markdown document.
+        // Patterns are run in a multiline environment (against the entire markdown document),
+        // and so generally should make use of the multiline flag (`m`). If you need to capture
+        // newlines in your capturing groups, you can either use something like
+        // `([\S\s]*)`, or you can additionally enable the "dot all" flag (`s`),
+        // which will cause `(.*)` to match newlines as well.
+        //
+        // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
+        // `(.*?)` vs `(.*)`), especially if matching against newline characters.
+        pattern: /^<details( name="(.*)?")?><summary>(.*?)<\/summary>(.*?)<\/details>$/m,
+        // Given a RegExp Match object
+        // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
+        // return an object with one property for each field defined in `fields`.
+        //
+        // This is used to populate the custom widget in the markdown editor in the CMS.
+        fromBlock: function(match) {
+          console.log('Matches: ', match);
+          return {
+            title: match[3],
+            content: match[4],
+            group: match[2]
+          };
+        },
+
+        // Given an object with one property for each field defined in `fields`,
+        // return the string you wish to be inserted into your markdown.
+        //
+        // This is used to serialize the data from the custom widget to the
+        // markdown document
+        toBlock: function(data) {
+          if (data.group) {
+            return `<details name="${data.group}"><summary>${data.title}</summary>${data.content}</details>`;
+          } else {
+            return `<details><summary>${data.title}</summary>${data.content}</details>`;
+          }
+        },
+        // Preview output for this component. Can either be a string or a React component
+        // (component gives better render performance)
+        toPreview: function(data) {
+          if (data.group) {return `
+<details name="${data.group}">
+  <summary>${data.title}</summary>
+
+  ${data.content}
+
+</details>
+`;
+          } else {
+            return `
+<details>
+  <summary>${data.title}</summary>
+
+  ${data.content}
+
+</details>
+`;
+          }
+
+        }
+      });
       // this preview generally mimics the structure of the actual post page, but it is not
       // actually derived from that component (tried for a long time to get that to work, no luck.)
       var PostPreview = createClass({

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -63,7 +63,7 @@
         //
         // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
         // `(.*?)` vs `(.*)`), especially if matching against newline characters.
-        pattern: /^<details( name="(.*)?")?><summary>(.*?)<\/summary>(.*?)<\/details>$/m,
+        pattern: /^<details( name="(.*)?")?>\n*<summary>\n*(.*?)\n*<\/summary>\n*(.*?)\n*<\/details>\n*$/ms,
         // Given a RegExp Match object
         // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
         // return an object with one property for each field defined in `fields`.

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -48,6 +48,8 @@
             name: 'content',
             label: 'Content',
             widget: 'markdown',
+            // exclude toggle-section from being nested inside of another toggle-section
+            editor_components: [ "image", "code-block" ],
             required: true
           },
           {

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -63,7 +63,7 @@
         //
         // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
         // `(.*?)` vs `(.*)`), especially if matching against newline characters.
-        pattern: /^<details( name="(.*)?")?>\n*<summary>\n*(.*?)\n*<\/summary>\n*(.*?)\n*<\/details>\n*$/ms,
+        pattern: /^<details( name="(.*)?")?>\n*<summary>\n*(.*?)\n*<\/summary>\n*(.*?)\n*<\/details>$/ms,
         // Given a RegExp Match object
         // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
         // return an object with one property for each field defined in `fields`.

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -17,6 +17,7 @@
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script>
       // Register fonts so they can be used in the preview styles
       CMS.registerPreviewStyle(
@@ -40,12 +41,14 @@
           {
             name: 'title',
             label: 'Title',
-            widget: 'string'
+            widget: 'string',
+            required: true
           },
           {
             name: 'content',
             label: 'Content',
-            widget: 'markdown'
+            widget: 'markdown',
+            required: true
           },
           {
             name: 'group',
@@ -63,7 +66,7 @@
         //
         // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
         // `(.*?)` vs `(.*)`), especially if matching against newline characters.
-        pattern: /^<details( name="(.*)?")?>\n*<summary>\n*(.*?)\n*<\/summary>\n*(.*?)\n*<\/details>$/ms,
+        pattern: /<details(\sname='([^']+)?')?>\n*<summary>\n*(.*?)\n*<\/summary>\n*(.*?)\n*<\/details>/ms,
         // Given a RegExp Match object
         // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
         // return an object with one property for each field defined in `fields`.
@@ -85,29 +88,37 @@
         // markdown document
         toBlock: function(data) {
           if (data.group) {
-            return `<details name="${data.group}"><summary>${data.title}</summary>${data.content}</details>`;
+            return `
+<details name='${data.group}'>
+<summary>${data.title}</summary>
+
+${data.content}
+</details>`;
           } else {
-            return `<details><summary>${data.title}</summary>${data.content}</details>`;
+            return `
+<details>
+<summary>${data.title}</summary>
+
+${data.content}
+</details>`;
           }
         },
         // Preview output for this component. Can either be a string or a React component
         // (component gives better render performance)
         toPreview: function(data) {
           if (data.group) {return `
-<details name="${data.group}">
-  <summary>${data.title}</summary>
+<details name='${data.group}'>
+<summary>${data.title}</summary>
 
-  ${data.content}
-
+${marked.parse(data.content)}
 </details>
 `;
           } else {
             return `
 <details>
-  <summary>${data.title}</summary>
+<summary>${data.title}</summary>
 
-  ${data.content}
-
+${marked.parse(data.content)}
 </details>
 `;
           }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -215,6 +215,7 @@ article details {
 
 article summary::marker {
   color: #ff9c77;
+  cursor: pointer;
 }
 
 article summary strong {


### PR DESCRIPTION
## Problem
DecapCMS allows us to create custom editor components to render complex Markdown

Fixes #342 

## Approach
* feat: create a custom editor component that will produce standard `<details>`/`<summary>` toggles as HTML
    * Prevent nesting one Toggle Section within another Toggle Section

Example:
![Screenshot 2024-10-24 at 1 26 29 PM](https://github.com/user-attachments/assets/dae13448-be75-49ec-b3de-4ddc41e40fc9)

Which produces the following HTML:
```html
<details name="example"><summary>1. Access varies depending on where you are (origin)</summary><p>Imagine living in downtown Chicago, where it is easy to catch a bus or hop on the subway to get to work, visit friends, or run errands. If the transit system is well-connected, and stops are just a short walk from your home, this could make it convenient for you to rely on public transportation. Now, if someone lives in a small rural town where public transit might be limited to a few bus routes that only run a couple of times a day. The nearest bus stop could be several miles away, making it inconvenient to rely on public transportation. At the same time, some individuals may find it convenient to obtain services near their work or shopping locations, indicating that daily activity spaces other than residential locations can be more representative of origin in measuring public transit calculations. This highlights the importance of origin (location) in accessibility decision making.</p></details>
```

### TODOs
* ~~Newline characters within `content` are not well-supported. This will be problematic for less technical users (supporting which is the whole point of using a CMS system to begin with)~~ regex has been adjusted to allow newline characters within collapsible content :+1:
* ~~Images embedded in `content` do not play well with the editor - this may be because of the newline support mentioned above~~ with the corrected newline behavior (see above), this problem appears to have gone away and we can now embed images within collapsible content :+1:

## How to Test
1. Navigate to https://deploy-preview-350--cheerful-treacle-913a24.netlify.app/admin/index.html
2. Click on Guides on the left, and choose the "Public Transit Equity" guide from the list
    * You should see an Editor on the left, and a preview of the contents on the right
3. Ensure that the editor is set to "Rich-text" mode
4. Expand the "+" dropdown on the editor
    * You should see "Toggle Section" listed here - this is our newly-added component
5. Choose "Toggle Section" from the list
    * You should see a new widget named "Toggle Section" appear in the editor below
    * You should see that this widget has 3 separate inputs: `title`, `content`, `group`
6. Enter a value for `Title` - this will be the clickable header when the section is collapsed
7. Enter a value for `Content` - this will be Markdown that becomes the main content for when the section is expanded
    * Expand the "+" button here - you should see that Toggle Section is not listed as an option within a Toggle Section
8. (optional) Enter a value for `Group` - if specified, only a single section from the same group can be expanded at once
9. Change between the "Rich-text" and "Markdown" modes in the editor
    * You should see the widget is converted to its raw HTML format (see above) and then back again
10. Try to come up with weird edge cases that might break this widget
    * NOTE: The HTML form must be a produced as a single line, or else we have trouble detecting the end of one Toggle Section and the start of another