### PR TITLE
Fix heading style in MDX content

### DIFF
--- a/content/posts/finding-healthy-food-connecticut.mdx
+++ b/content/posts/finding-healthy-food-connecticut.mdx
@@ -16,7 +16,7 @@ excerpt: "Next up in the Fellow Showcase Series: The Windham Connecticut, Food
 
 **By:** [Peter Chen, PhD,](https://www.linkedin.com/in/xiang-%E2%80%9Cpeter%E2%80%9D-chen-0429ab19/) University of Connecticut
 
-### **App Motivations**
+### App Motivations
 
 I created this app because I have always been intrigued by the idea of putting my GIS expertise into community practice, aiming to help those deprived of resources or experiencing health inequities to live healthy and sustainable lives. In the past few years, I have been doing fieldwork in Windham, CT (a low-income community in CT), to understand the various barriers to food access for low-income individuals, especially those utilizing a food pantry. This SDOH fellowship incentivized this project, allowing me to develop a GIS tool to promote information delivery and health education for these socially vulnerable populations.
 
@@ -24,7 +24,7 @@ This map is aimed at helping members of the Windham and Willimantic community, a
 
 Target users of this application include those that are low-income, those receiving federal assistance programs, or those utilizing food pantries.
 
-### **Features**
+### Features
 
 1. Transportation-oriented design: All bus stops and routes are included, as some target users will take buses to access food. Additionally, each bus stop has a Google Street View showing its surroundings, helping users find the stop easily. Each food place has a link called 'How To Get Here,' which directs users to Google Maps for route information. 
 
@@ -38,7 +38,7 @@ Target users of this application include those that are low-income, those receiv
 
 This project is completed and ready for all Windham and Willimantic community members to use. 
 
-### **Acknowledgements**
+### Acknowledgements
 
 The project is also sponsored by a USDA National Institute of Food and Agriculture grant (PI: Ock Chun).
 

--- a/content/posts/introducing-the-sdoh-place-project.mdx
+++ b/content/posts/introducing-the-sdoh-place-project.mdx
@@ -37,7 +37,7 @@ In addition, for those who can find and use this place-based data, there exists 
 
 To ensure easier access, and to make SDOH data more accessible to all who would like to work with such data, the SDOH & Place project will act as a one stop shop for finding SDOH and place-based data; as well as, working with it.
 
-### **Data Discover Tool**
+### Data Discover Tool
 
 This search engine will act as a one stop shop for finding free high quality SDOH data. This tool will allow you to search for data by topic and/or location within rural, urban, and suburban U.S. spaces.
 

--- a/content/posts/mapping-montgomery.mdx
+++ b/content/posts/mapping-montgomery.mdx
@@ -33,7 +33,7 @@ By: [Amy Kryston, MS, MPH,](https://www.linkedin.com/in/amy-kryston) UNC Gilling
 
 - - -
 
-### **App Motivations**
+### App Motivations
 
 Amy, on behalf of her colleagues, wanted to highlight the many available resources in Montgomery, Alabama, especially those directly related to physical wellness, emotional and community wellness, and public safety. They also wanted to create a central hub where residents could locate and learn about resources.
 
@@ -49,7 +49,7 @@ Community members and CHWs can utilize this map to find organizations or locatio
 
 ![](/images/screenshot-amy-kryston.png "Asset map view of all services available: recreation and food")<span style={{fontSize:'.8em', fontStyle:'italic'}}>Asset map view of all services available: recreation and food.</span>
 
-### **Features**
+### Features
 
 The current map provides information about various food resources, from farmers markets to cultural grocery stores to food pantries. 
 
@@ -61,7 +61,7 @@ Also, recreation resources, like public parks and private gyms.
 
 This is a very user-friendly map, and they've taken care to ensure it's accessible for most forms of color blindness and used other design knowledge. They are most proud, of course, of how they were able to engage the community and learn about what resources they were most interested in learning about.
 
-### **Upcoming Features**
+### Upcoming Features
 
 There is still much work they would like to do, including:
 
@@ -75,7 +75,7 @@ While there is ongoing work, this is a working draft that can still be accessed 
 
 - - -
 
-### **Acknowledgements**
+### Acknowledgements
 
 Thank you to the community and City of Montgomery, Alabama, and the many wonderful partners and colleagues who aided in this project. And much thanks to this program. This work would not have been possible without the support of the SDOH & Place Fellowship!
 

--- a/content/posts/place-project-cohort.mdx
+++ b/content/posts/place-project-cohort.mdx
@@ -22,13 +22,13 @@ The anticipation has been building, and now the moment has arrived to unveil the
 
 ![](/images/screen-shot-2024-04-22-at-8.24.04-pm.png)
 
-## **Meet the Fellows**
+## Meet the Fellows
 
 Fellows will share the final project prototypes at the upcoming [SDOH & Place Symposium](https://sdohplace.org/news/symposium2024) in Chicago on June 14-15th, 2024. Learn more and apply for one of the spots available at [go.illinois.edu/SDOHPlace-Symposium](go.illinois.edu/SDOHPlace-Symposium). If accepted, registration and conference meals are free. Some travel stipends may be available for visitors.\
 \
 Let's dive into the projects that our cohort members will be spearheading:
 
-## **[Beth Beyer](https://www.linkedin.com/in/beth-beyer-08602347/)**
+## [Beth Beyer](https://www.linkedin.com/in/beth-beyer-08602347/)
 
 #### *The Technology Alliance*
 
@@ -38,7 +38,7 @@ Beth's project focuses on identifying spaces where communities gather through ar
 
 *Potential App Type: Asset Map*
 
-### **[Joseph Asumah Braimah](https://www.linkedin.com/in/braimah-joseph-asumah-75a6852b/)**
+### [Joseph Asumah Braimah](https://www.linkedin.com/in/braimah-joseph-asumah-75a6852b/)
 
 #### *Lawrence University; Department of Public Health*
 
@@ -48,7 +48,7 @@ Joseph's project will highlight the home maintenance service needs of older indi
 
 *Potential App Type: To Be Determined (TBD)*
 
-### **[Peter Chen](https://www.linkedin.com/in/xiang-%E2%80%9Cpeter%E2%80%9D-chen-0429ab19/)**
+### [Peter Chen](https://www.linkedin.com/in/xiang-%E2%80%9Cpeter%E2%80%9D-chen-0429ab19/)
 
 #### *University of Connecticut; Department of GIScience*
 
@@ -58,7 +58,7 @@ Peter's project involves mapping an innovative mobility-based retail food enviro
 
 *Potential App Type: Data Dashboard*
 
-### **[Jessica Ann Davis](https://www.linkedin.com/in/jessica-a-davis-85a241204/)**
+### [Jessica Ann Davis](https://www.linkedin.com/in/jessica-a-davis-85a241204/)
 
 #### *University of Pittsburgh; School of Medicine*
 
@@ -68,7 +68,7 @@ Jessica's project aims to create healthy food and lactation support resource map
 
 *Potential App Type: Asset/Story Map*
 
-### **[Tyler Gorham](https://www.linkedin.com/in/tyler-gorham/)**
+### [Tyler Gorham](https://www.linkedin.com/in/tyler-gorham/)
 
 #### *Nationwide Children’s Hospital*
 
@@ -78,7 +78,7 @@ Tyler's project involves conducting a historic policy inventory and Opportunity 
 
 *Potential App Type: Story Map*
 
-### **[Amy Kryston](https://www.linkedin.com/in/amy-kryston/)**
+### [Amy Kryston](https://www.linkedin.com/in/amy-kryston/)
 
 #### *Partners in Health*
 
@@ -88,7 +88,7 @@ Amy's project involves creating a resource map for Montgomery, AL, outlining ava
 
 *Potential App Type: Asset Map*
 
-### **[Latrice Landry](https://www.linkedin.com/in/latrice-landry-ab217a145/)**
+### [Latrice Landry](https://www.linkedin.com/in/latrice-landry-ab217a145/)
 
 #### *University of Pennsylvania; Department of Genetics*
 
@@ -98,7 +98,7 @@ Latrice aims to build a place-based visualization demonstrating the relationship
 
 *Potential App Type: Asset/Thematic Map*
 
-### **[Alexander Michels](https://www.linkedin.com/in/alexmichels/)**
+### [Alexander Michels](https://www.linkedin.com/in/alexmichels/)
 
 #### *University of Illinois Urbana-Champaign*
 
@@ -108,7 +108,7 @@ Alexander's project aims to leverage machine learning techniques and Uber Moveme
 
 *Potential App Type: Data Dashboard*
 
-### **[Sarah Nelson](https://www.linkedin.com/in/sarah-nelson-04a46a19/)**
+### [Sarah Nelson](https://www.linkedin.com/in/sarah-nelson-04a46a19/)
 
 #### *University of Nebraska at Omaha; Department of Geography & Geology*
 
@@ -118,7 +118,7 @@ Sarah's project aims to develop a public website and interactive map that NUIHC 
 
 *Potential App Type: Asset Map*
 
-### **[Kennedy Patterson](https://www.linkedin.com/in/kennedy-patterson123/)**
+### [Kennedy Patterson](https://www.linkedin.com/in/kennedy-patterson123/)
 
 #### *University of Chicago; Division of Social Sciences*
 
@@ -128,7 +128,7 @@ Kennedy's project will synthesize unhoused death records in King County (Seattle
 
 *Potential App Type: To Be Determined (TBD)*
 
-### **[Sonia Monet Saxon](https://www.linkedin.com/in/sonia-monet-saxon-8bb6a4257/)**
+### [Sonia Monet Saxon](https://www.linkedin.com/in/sonia-monet-saxon-8bb6a4257/)
 
 #### *University of Illinois Chicago*
 
@@ -138,7 +138,7 @@ Sonia's project utilizes story maps to bring visibility to the lived experiences
 
 *Potential App Type: Story Map*
 
-### **[Sarah Scott](https://www.linkedin.com/in/sarah-scott-mph-cph-387b56148/)**
+### [Sarah Scott](https://www.linkedin.com/in/sarah-scott-mph-cph-387b56148/)
 
 #### *University of Pittsburgh*
 
@@ -148,7 +148,7 @@ Sarah's project involves creating an interactive asset map detailing resources f
 
 *Potential App Type: Asset Map*
 
-### **[Madeline Smith-Johnson](https://www.linkedin.com/in/msj1/)**
+### [Madeline Smith-Johnson](https://www.linkedin.com/in/msj1/)
 
 #### *Rice University; Department of Sociology*
 
@@ -158,7 +158,7 @@ Madeline's project involves creating an interactive map of the U.S. that allows 
 
 *Potential App Type: Data Dashboard*
 
-### **[Makiya Thomas](https://www.linkedin.com/in/makiya-thomas-m-a-mdiv-9160331aa/)**
+### [Makiya Thomas](https://www.linkedin.com/in/makiya-thomas-m-a-mdiv-9160331aa/)
 
 #### *Champaign Urbana Public Health District*
 
@@ -168,7 +168,7 @@ Makiya's project aims to educate women on the alarming rates of maternal morbidi
 
 *Potential App Type: Story/Asset Map*
 
-### **[Wei Tu](https://www.linkedin.com/in/wei-tu-a8116122/)**
+### [Wei Tu](https://www.linkedin.com/in/wei-tu-a8116122/)
 
 #### *Georgia Southern University; School of Earth, Environment, and Sustainability*
 

--- a/content/posts/symposium2024.mdx
+++ b/content/posts/symposium2024.mdx
@@ -19,7 +19,7 @@ The SDOH & Place Project works to build a community of practice around defining 
 
 At the **first SDOH & Place Symposium this June**, the community will meet to share progress, break bread, celebrate achievements, and learn from each other. Join us! 
 
-### **Schedule**
+### Schedule
 
 **Friday, June 14th**
 

--- a/content/showcase/sharing-birth-stories-in-the-motherhood-project.mdx
+++ b/content/showcase/sharing-birth-stories-in-the-motherhood-project.mdx
@@ -8,13 +8,13 @@ fellow: Makiya Thomas
 ---
 ##### *Earlier this year, we invited [fifteen fellows](https://sdohplace.org/fellows) to develop their own web mapping applications, centered on equity and designed with communities in mind, using the [SDOH & Place Toolkit](https://toolkit.sdohplace.org/). From July to September, we'll feature final fellow applications each week.*
 
-### **App Motivations**
+### App Motivations
 
 This project is called C-Ur Experience—which is a play on the city name Champaign-Urbana—The Motherhood Project. Makiya created this data application to shed light on the fatal infant and maternal mortalities in the United States and the state of Illinois. Also, to provide a platform for minority mothers to share and unite. This project has a special focus on Black mothers within the community because of the rising birth mortality rate within Illinois. This project specifically centers on the local Champaign-Urbana area. 
 
 The target audience for this application is mothers, healthcare providers, community members, and advocates of the Champaign-Urbana area. 
 
-### **Features**
+### Features
 
 This project is a story map focusing on the alarming rates of Black maternal health and infant maternity rates. Additionally, this project shares stories from members of the community about their experiences giving birth in the Champaign-Urbana area. These stories are snippets of interviews with mothers of the community. 
 
@@ -38,7 +38,7 @@ Viewers of the website can also view facts from the CDC regarding infant mortali
 
 Also, through the project's instagram page, members of the community can be a part of a community of mothers to support each other. The Motherhood Project will be working to bring all the mothers and their children involved in this project to get together in the Fall to celebrate their community and further solidify a network of support. If you are a mother in the Champaign-Urbana area and have given birth in the last 5 years, consider contacting Makiya to be interviewed about your experience giving birth in Champaign-Urbana (information provided in the link below). 
 
-### **Acknowledgements**
+### Acknowledgements
 
 Makiya would like to thank the Champign-Urbana Public Health district for their help in the project and Carle Foundation Hospital for their open communication.
 

--- a/content/showcase/structural-inequality-health-by-gender-sexuality-in-the-u-s.mdx
+++ b/content/showcase/structural-inequality-health-by-gender-sexuality-in-the-u-s.mdx
@@ -8,13 +8,13 @@ fellow: Madeline Smith-Johnson
 ---
 ##### *Earlier this year, we invited [fifteen fellows](https://sdohplace.org/fellows) to develop their own web mapping applications, centered on equity and designed with communities in mind, using the [SDOH & Place Toolkit](https://toolkit.sdohplace.org/). From July to September, we'll feature final fellow applications each week.*
 
-### **App Motivations**
+### App Motivations
 
 Madeline created this dashboard to connect gender, sexuality, and health in a way that highlighted the importance of state context. Inequality based on gender and sexuality is increasingly different across states in the U.S. For example, in some states, abortion access is restricted, laws make it more difficult for same-sex couples to build families, and transgender people are banned from using public facilities that align with their gender identity. There is growing academic evidence that living in more unequal state contexts is associated with poorer population health outcomes. Madeline's dashboard allows the user to explore these associations – the changes in state context over time, across states, and their associations with mental and physical health outcomes for specific gender and sexuality groups. 
 
 The target audience of this dashboard is diverse - it includes researchers, policy makers, students, and individuals who are interested in or personally affected by these state contexts. For instance, LGBTQ+ users might use this dashboard to explore what types of non-discrimination protections are available in their state or users moving to a new state might explore whether health disparities are more pronounced in that state.   
 
-### **Features**
+### Features
 
 The dashboard includes a panel of health data from the Behavioral Risk Factor Surveillance System – a large national health survey that includes information about diverse gender and sexuality. 
 
@@ -34,7 +34,7 @@ Bar charts display weighted proportions of five health outcomes (frequent mental
 
 Clicking on a specific state on the structural inequality map will filter the health data to display health information for only that state. There are some interesting associations between high-inequality states and poorer health outcomes for sexual and gender minorities. However, this is not a universal pattern, suggesting that there are other important structural factors at play here.
 
-### **Upcoming Features**
+### Upcoming Features
 
 The dashboard is complete and functional. However, analyses of the best way to capture structural inequality are ongoing. Madeline expects to complete these analyses by the end of 2024 and may update the dashboard in 2025 to display new measures of structural inequality.
 

--- a/content/showcase/the-montgomery-alabama-asset-map.mdx
+++ b/content/showcase/the-montgomery-alabama-asset-map.mdx
@@ -6,7 +6,7 @@ link: https://akryston.shinyapps.io/final_map/
 tech_used: R, R-Shiny
 fellow: Amy Kryston
 ---
-### **App Motivations**
+### App Motivations
 
 Amy, on behalf of her colleagues, wanted to highlight the many available resources in Montgomery, Alabama, especially those directly related to physical wellness, emotional and community wellness, and public safety. They also wanted to create a central hub where residents could locate and learn about resources.
 
@@ -26,7 +26,7 @@ Community members and CHWs can utilize this map to find organizations or locatio
 </figure>
 
 
-### **Features**
+### Features
 
 The current map provides information about various food resources, from farmers markets to cultural grocery stores to food pantries.
 
@@ -44,7 +44,7 @@ Also, recreation resources, like public parks and private gyms.
 
 This is a very user-friendly map, and they've taken care to ensure it's accessible for most forms of color blindness and used other design knowledge. They are most proud, of course, of how they were able to engage the community and learn about what resources they were most interested in learning about.
 
-### **Upcoming Features**
+### Upcoming Features
 
 There is still much work they would like to do, including:
 
@@ -58,7 +58,7 @@ While there is ongoing work, this is a working draft that can still be accessed 
 
 - - -
 
-### **Acknowledgements**
+### Acknowledgements
 
 Thank you to the community and City of Montgomery, Alabama, and the many wonderful partners and colleagues who aided in this project. And much thanks to this program. This work would not have been possible without the support of the SDOH & Place Fellowship!
 

--- a/content/showcase/windham-willmantic-conn-food-access-map.mdx
+++ b/content/showcase/windham-willmantic-conn-food-access-map.mdx
@@ -6,7 +6,7 @@ link: https://experience.arcgis.com/experience/8c7230430b6f4e92ab7c6353fe0e94a0
 tech_used: ArcGIS Online
 fellow: Peter Chen
 ---
-### **App Motivations**
+### App Motivations
 
 I created this app because I have always been intrigued by the idea of putting my GIS expertise into community practice, aiming to help those deprived of resources or experiencing health inequities to live healthy and sustainable lives. In the past few years, I have been doing fieldwork in Windham, CT (a low-income community in CT), to understand the various barriers to food access for low-income individuals, especially those utilizing a food pantry. This SDOH fellowship incentivized this project, allowing me to develop a GIS tool to promote information delivery and health education for these socially vulnerable populations.
 
@@ -14,7 +14,7 @@ This map is aimed at helping members of the Windham and Willimantic community, a
 
 Target users of this application include those that are low-income, those receiving federal assistance programs, or those utilizing food pantries.
 
-### **Features**
+### Features
 
 1. Transportation-oriented design: All bus stops and routes are included, as some target users will take buses to access food. Additionally, each bus stop has a Google Street View showing its surroundings, helping users find the stop easily. Each food place has a link called 'How To Get Here,' which directs users to Google Maps for route information. 
 
@@ -28,7 +28,7 @@ Target users of this application include those that are low-income, those receiv
 
 This project is completed and ready for all Windham and Willimantic community members to use. 
 
-### **Acknowledgements**
+### Acknowledgements
 
 The project is also sponsored by a USDA National Institute of Food and Agriculture grant (PI: Ock Chun).
 

--- a/public/styles/posts.module.css
+++ b/public/styles/posts.module.css
@@ -31,7 +31,7 @@
 .content h3,
 .content h4,
 .content h5 {
-  font-family: Nunito;
+  font-family: Fredoka;
   margin: 2rem 0 0 0;
 }
 
@@ -39,10 +39,10 @@
   font-size: 1.75rem;
 }
 .content h3 {
-  font-size: 1.5rem;
+  font-size: 1.6rem;
 }
 .content h4 {
-  font-size: 1.3rem;
+  font-size: 1.4rem;
 }
 
 .content p,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -144,39 +144,14 @@ article {
 /* Headers */
 
 article h1 {
-  font-family: "Fredoka", sans-serif;
   color: #7e1cc4;
-  font-weight: 400;
-  font-size: 48px;
   letter-spacing: 0.2px;
 }
 
 article h2 {
-  font-family: "Fredoka", sans-serif;
-  color: #1e1e1e;
-  font-weight: 400;
-  font-size: 36px;
   border-left: solid 4px;
   border-color: #ff9c77;
   padding-left: 11px !important;
-}
-
-article h3 {
-  font-family: "Fredoka", sans-serif;
-  color: #1e1e1e;
-  font-weight: 400;
-  font-size: 24px;
-}
-
-article h4 {
-  font-family: "Fredoka", sans-serif;
-  color: #1e1e1e;
-  font-weight: 400;
-  font-size: 18px;
-}
-
-article h5 > em {
-  font-style: normal;
 }
 
 /* Lists */


### PR DESCRIPTION
Headers from the toolkit have Fredoka, so that's what we should use in the MDX content, but that style was being overwritten with Nunito. Fix this, and also slightly increase the size of h3 and h4 so set apart better from standard paragraph text.

Also, with this change, it was apparent that a number of headings in existing MDX content looked like this:

```
### **Heading text**
```

Which was resulting in extra bold, so I've remove the ** in all these cases as well. There may be more to do on this front in the publish branch, will check that next.