### PR TITLE
feat: include preview_path for posts/showcases/guides

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -298,6 +298,7 @@ collections:
     create: true
     slug: "{{slug}}"
     summary: "{{title}}"
+    preview_path: "news/{{slug}}"
     fields:
       - label: "Title"
         name: "title"
@@ -358,6 +359,7 @@ collections:
     format: "frontmatter"
     create: true # Allow users to create new documents in this collection
     slug: "{{slug}}"
+    preview_path: "showcase/{{slug}}"
     fields: # The fields for each document, usually in front matter
       - label: "Project Title"
         name: "title"
@@ -401,6 +403,7 @@ collections:
     format: "frontmatter"
     create: true # Allow users to create new documents in this collection
     slug: "{{slug}}"
+    preview_path: "guides/{{slug}}"
     fields: # The fields for each document, usually in front matter
       - label: "Title"
         name: "title"


### PR DESCRIPTION
## Problem
There is no easy way for a non-technical user to preview their finalized post before Publishing

Fixes #258 

## Approach
* feat: use `preview_path` field to point at the location of the unpublished news/showcase/guides piece

## How to Test
1. Navigate to https://deploy-preview-357--cheerful-treacle-913a24.netlify.app/admin/index.html#/collections/guides/entries/example-deleteme?ref=workflow
    * You should see an editor/preview for this unpublished draft
    * You should see "View Preview" at the top-right
2. Click on the "View Preview" button
    * You should see a new tab opens to the Preview from PR #358 
    * You should be automatically brought to the path of this guide's preview
    * You should see a preview of how the guide will look once it is published