### PR TITLE
feat: added "date" field to showcase items

### DIFF
--- a/content/showcase/sharing-birth-stories-in-the-motherhood-project.mdx
+++ b/content/showcase/sharing-birth-stories-in-the-motherhood-project.mdx
@@ -2,6 +2,7 @@
 title: "Sharing Birth Stories in The Motherhood Project "
 slug: sharing-birth-stories-in-the-motherhood-project
 image: /images/showcase-thumbnail-3-.png
+date: 8/14/2024
 link: https://storymaps.com/stories/e57626b6483e4ddfb35f2c06cd914bfd
 tech_used: Storymaps.com
 fellow: Makiya Thomas
@@ -10,13 +11,13 @@ fellow: Makiya Thomas
 
 ### App Motivations
 
-This project is called C-Ur Experience—which is a play on the city name Champaign-Urbana—The Motherhood Project. Makiya created this data application to shed light on the fatal infant and maternal mortalities in the United States and the state of Illinois. Also, to provide a platform for minority mothers to share and unite. This project has a special focus on Black mothers within the community because of the rising birth mortality rate within Illinois. This project specifically centers on the local Champaign-Urbana area. 
+This project is called C-Ur Experience—which is a play on the city name Champaign-Urbana—The Motherhood Project. Makiya created this data application to shed light on the fatal infant and maternal mortalities in the United States and the state of Illinois. Also, to provide a platform for minority mothers to share and unite. This project has a special focus on Black mothers within the community because of the rising birth mortality rate within Illinois. This project specifically centers on the local Champaign-Urbana area.
 
-The target audience for this application is mothers, healthcare providers, community members, and advocates of the Champaign-Urbana area. 
+The target audience for this application is mothers, healthcare providers, community members, and advocates of the Champaign-Urbana area.
 
 ### Features
 
-This project is a story map focusing on the alarming rates of Black maternal health and infant maternity rates. Additionally, this project shares stories from members of the community about their experiences giving birth in the Champaign-Urbana area. These stories are snippets of interviews with mothers of the community. 
+This project is a story map focusing on the alarming rates of Black maternal health and infant maternity rates. Additionally, this project shares stories from members of the community about their experiences giving birth in the Champaign-Urbana area. These stories are snippets of interviews with mothers of the community.
 
 <br/>
 
@@ -24,7 +25,7 @@ This project is a story map focusing on the alarming rates of Black maternal hea
 
 <br/>
 
-Viewers of the website can also view facts from the CDC regarding infant mortality rates in the local area as of 2021. This information can be taken and used to apply to the mother's daily life. Providing this information to the public and a community provides a chance for Black mother's to be more knowledgeable regarding their health and what to advocate for with regards to their health and their community. This knowledge can be an agent for change in improving healthcare around birth. 
+Viewers of the website can also view facts from the CDC regarding infant mortality rates in the local area as of 2021. This information can be taken and used to apply to the mother's daily life. Providing this information to the public and a community provides a chance for Black mother's to be more knowledgeable regarding their health and what to advocate for with regards to their health and their community. This knowledge can be an agent for change in improving healthcare around birth.
 
 <br/>
 
@@ -36,7 +37,7 @@ Viewers of the website can also view facts from the CDC regarding infant mortali
 
 <br/>
 
-Also, through the project's instagram page, members of the community can be a part of a community of mothers to support each other. The Motherhood Project will be working to bring all the mothers and their children involved in this project to get together in the Fall to celebrate their community and further solidify a network of support. If you are a mother in the Champaign-Urbana area and have given birth in the last 5 years, consider contacting Makiya to be interviewed about your experience giving birth in Champaign-Urbana (information provided in the link below). 
+Also, through the project's instagram page, members of the community can be a part of a community of mothers to support each other. The Motherhood Project will be working to bring all the mothers and their children involved in this project to get together in the Fall to celebrate their community and further solidify a network of support. If you are a mother in the Champaign-Urbana area and have given birth in the last 5 years, consider contacting Makiya to be interviewed about your experience giving birth in Champaign-Urbana (information provided in the link below).
 
 ### Acknowledgements
 

--- a/content/showcase/structural-inequality-health-by-gender-sexuality-in-the-u-s.mdx
+++ b/content/showcase/structural-inequality-health-by-gender-sexuality-in-the-u-s.mdx
@@ -2,6 +2,7 @@
 title: Structural Inequality & Health by Gender & Sexuality in the U.S.
 slug: structural-inequality-health-by-gender-sexuality-in-the-u-s
 image: /images/showcase-thumbnail-2-.png
+date: 8/2/2024
 link: https://tinyurl.com/5y4d57ej
 tech_used: Tableau
 fellow: Madeline Smith-Johnson
@@ -10,13 +11,13 @@ fellow: Madeline Smith-Johnson
 
 ### App Motivations
 
-Madeline created this dashboard to connect gender, sexuality, and health in a way that highlighted the importance of state context. Inequality based on gender and sexuality is increasingly different across states in the U.S. For example, in some states, abortion access is restricted, laws make it more difficult for same-sex couples to build families, and transgender people are banned from using public facilities that align with their gender identity. There is growing academic evidence that living in more unequal state contexts is associated with poorer population health outcomes. Madeline's dashboard allows the user to explore these associations – the changes in state context over time, across states, and their associations with mental and physical health outcomes for specific gender and sexuality groups. 
+Madeline created this dashboard to connect gender, sexuality, and health in a way that highlighted the importance of state context. Inequality based on gender and sexuality is increasingly different across states in the U.S. For example, in some states, abortion access is restricted, laws make it more difficult for same-sex couples to build families, and transgender people are banned from using public facilities that align with their gender identity. There is growing academic evidence that living in more unequal state contexts is associated with poorer population health outcomes. Madeline's dashboard allows the user to explore these associations – the changes in state context over time, across states, and their associations with mental and physical health outcomes for specific gender and sexuality groups.
 
-The target audience of this dashboard is diverse - it includes researchers, policy makers, students, and individuals who are interested in or personally affected by these state contexts. For instance, LGBTQ+ users might use this dashboard to explore what types of non-discrimination protections are available in their state or users moving to a new state might explore whether health disparities are more pronounced in that state.   
+The target audience of this dashboard is diverse - it includes researchers, policy makers, students, and individuals who are interested in or personally affected by these state contexts. For instance, LGBTQ+ users might use this dashboard to explore what types of non-discrimination protections are available in their state or users moving to a new state might explore whether health disparities are more pronounced in that state.
 
 ### Features
 
-The dashboard includes a panel of health data from the Behavioral Risk Factor Surveillance System – a large national health survey that includes information about diverse gender and sexuality. 
+The dashboard includes a panel of health data from the Behavioral Risk Factor Surveillance System – a large national health survey that includes information about diverse gender and sexuality.
 
 <br/>
 
@@ -24,7 +25,7 @@ The dashboard includes a panel of health data from the Behavioral Risk Factor Su
 
 <br/>
 
-Bar charts display weighted proportions of five health outcomes (frequent mental distress, 2 or more chronic conditions, one or more functional limitation, lacking a primary care provider, and poor or fair self-rated health) across gender (cisgender women, cisgender men, and transgender adults) and sexuality groups (heterosexual, bisexual, and gay or lesbian adults). Users can toggle between health outcomes by gender and sexuality to change the visualization. The dashboard includes a second panel that allows users to explore three structural inequality scores – transgender rights, gay rights, and structural sexism – displayed on a map of the United States. The first scores capture legal inequality where higher scores indicate more inequality in the laws and policies governing transgender and gay rights. The structural sexism scale captures systematic inequality in power and resources between (presumably mostly cisgender) men and women across economic, legal, and cultural domains. Higher scores indicate more inequality between men and women. The dashboard also includes a menu of specific indicators, those individual laws, policies, or measures of inequality that are used to calculate structural inequality scores. Users can use this menu to navigate to supplemental maps displaying how the presence of various laws or measures of inequality vary across states and over time.  
+Bar charts display weighted proportions of five health outcomes (frequent mental distress, 2 or more chronic conditions, one or more functional limitation, lacking a primary care provider, and poor or fair self-rated health) across gender (cisgender women, cisgender men, and transgender adults) and sexuality groups (heterosexual, bisexual, and gay or lesbian adults). Users can toggle between health outcomes by gender and sexuality to change the visualization. The dashboard includes a second panel that allows users to explore three structural inequality scores – transgender rights, gay rights, and structural sexism – displayed on a map of the United States. The first scores capture legal inequality where higher scores indicate more inequality in the laws and policies governing transgender and gay rights. The structural sexism scale captures systematic inequality in power and resources between (presumably mostly cisgender) men and women across economic, legal, and cultural domains. Higher scores indicate more inequality between men and women. The dashboard also includes a menu of specific indicators, those individual laws, policies, or measures of inequality that are used to calculate structural inequality scores. Users can use this menu to navigate to supplemental maps displaying how the presence of various laws or measures of inequality vary across states and over time.
 
 <br/>
 

--- a/content/showcase/the-montgomery-alabama-asset-map.mdx
+++ b/content/showcase/the-montgomery-alabama-asset-map.mdx
@@ -2,6 +2,7 @@
 title: The Montgomery, Alabama Asset Map
 slug: the-montgomery-alabama-asset-map
 image: /images/showcase-thumbnail.png
+date: 7/23/2024
 link: https://akryston.shinyapps.io/final_map/
 tech_used: R, R-Shiny
 fellow: Amy Kryston
@@ -10,11 +11,11 @@ fellow: Amy Kryston
 
 Amy, on behalf of her colleagues, wanted to highlight the many available resources in Montgomery, Alabama, especially those directly related to physical wellness, emotional and community wellness, and public safety. They also wanted to create a central hub where residents could locate and learn about resources.
 
-The primary goal of this asset map is to provide a resource to the community and to community health workers (CHWs). Secondary goals include: 
+The primary goal of this asset map is to provide a resource to the community and to community health workers (CHWs). Secondary goals include:
 
 1. identifying health disparities
 2. assessing access to health care and other resources
-3. informing health policy and planning decisions. 
+3. informing health policy and planning decisions.
 
 CHWs and community members must know where to access resources. It is also critical for city policy and programming to identify areas of social determinants of health (SDOH) deserts, to inform future resource development and allocation.
 
@@ -35,7 +36,7 @@ The current map provides information about various food resources, from farmers 
   <figcaption>Recreational assets displayed within the mapping application.</figcaption>
 </figure>
 
-Also, recreation resources, like public parks and private gyms. 
+Also, recreation resources, like public parks and private gyms.
 
 <figure>
   <img src="/images/recreation-assets-ss.png" alt="Recreational assets displayed within the mapping application."/>
@@ -48,8 +49,8 @@ This is a very user-friendly map, and they've taken care to ensure it's accessib
 
 There is still much work they would like to do, including:
 
-1. Adding more resource types (beyond food and recreation assets). 
-2. Adding information about benefits, hours open, populations served, and more. 
+1. Adding more resource types (beyond food and recreation assets).
+2. Adding information about benefits, hours open, populations served, and more.
 3. Overlaying a map of public transit.
 
 While there is ongoing work, this is a working draft that can still be accessed by Montgomery, Alabama community members.

--- a/content/showcase/windham-willmantic-conn-food-access-map.mdx
+++ b/content/showcase/windham-willmantic-conn-food-access-map.mdx
@@ -2,6 +2,7 @@
 title: Windham & Willmantic, Conn. Food Access Map
 slug: windham-willmantic-conn-food-access-map
 image: /images/showcase-thumbnail-1-.png
+date: 7/26/2024
 link: https://experience.arcgis.com/experience/8c7230430b6f4e92ab7c6353fe0e94a0
 tech_used: ArcGIS Online
 fellow: Peter Chen
@@ -16,17 +17,17 @@ Target users of this application include those that are low-income, those receiv
 
 ### Features
 
-1. Transportation-oriented design: All bus stops and routes are included, as some target users will take buses to access food. Additionally, each bus stop has a Google Street View showing its surroundings, helping users find the stop easily. Each food place has a link called 'How To Get Here,' which directs users to Google Maps for route information. 
+1. Transportation-oriented design: All bus stops and routes are included, as some target users will take buses to access food. Additionally, each bus stop has a Google Street View showing its surroundings, helping users find the stop easily. Each food place has a link called 'How To Get Here,' which directs users to Google Maps for route information.
 
 ![Screenshot showing the Food Access Map.](/images/picture1-peter-chen-peter-.png)
 
-2. Responsive app design: The app follows a responsive design, meaning it can be viewed on large, medium, and small screens with different layouts. 
+2. Responsive app design: The app follows a responsive design, meaning it can be viewed on large, medium, and small screens with different layouts.
 
 ![Screenshot of the Food Access Map's mobile version.](/images/picture3-peter-chen-peter-.jpg)
 
 3. Usability testing: We are testing the app's usability in a follow-up study using structured surveys and semi-structured interviews.
 
-This project is completed and ready for all Windham and Willimantic community members to use. 
+This project is completed and ready for all Windham and Willimantic community members to use.
 
 ### Acknowledgements
 

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -373,6 +373,7 @@ collections:
       - label: "Date"
         name: "date"
         widget: "datetime"
+        date_format: "M/D/YYYY"
         default: '{{now}}'
         hint: "The date when this showcase case was created, updated, or published."
       - label: "External Link"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -370,6 +370,11 @@ collections:
         widget: "image"
         choose_url: true
         default: "/images/default.jpg"
+      - label: "Date"
+        name: "date"
+        widget: "datetime"
+        default: '{{now}}'
+        hint: "The date when this showcase case was created, updated, or published."
       - label: "External Link"
         name: "link"
         widget: "string"

--- a/src/lib/showcases.ts
+++ b/src/lib/showcases.ts
@@ -7,6 +7,7 @@ export type ShowcaseContent = {
   readonly title: string;
   readonly slug: string;
   readonly image: string;
+  readonly date: string;
   readonly fellow: string;
   readonly techUsed: string;
   readonly fullPath: string;
@@ -38,6 +39,7 @@ export function fetchShowcaseContent(directory: string): ShowcaseContent[] {
         title: string;
         slug: string;
         image: string;
+        date: string;
         fellow: string;
         techUsed: string;
         fullPath: string;
@@ -62,5 +64,11 @@ export function listShowcaseContent(
   limit: number
 ): ShowcaseContent[] {
   return fetchShowcaseContent(directory)
+    // Sort by date (newest to oldest)
+    .sort((a, b) => {
+      const dateA = new Date(a.date);
+      const dateB = new Date(b.date);
+      return (dateA > dateB) ? -1 : (dateB > dateA) ? 1 : 0;
+    })
     .slice((page - 1) * limit, page * limit);
 }


### PR DESCRIPTION
## Problem
Showcase items cannot be easily sorted by date, since we are not tracking the dates they were added

Fixes #303 

## Approach
* feat: added a new `date` field to Showcase items
    * This adds a new `DateTime` widget to the Showcase editor (defaults to the current date, no time)
    * This `date` field is not currently displayed on the list of Showcases or when viewing a rendered Showcase :+1:
    * Sort ShowcaseList by this new date field (newest to oldest)
* NOTE: This PR does not retroactively add `date` fields to older Showcase items (but I am happy to add these if we know the expected/desired date for each Showcase)
    * ~~Old entries without a date are currently tolerated - no extra errors should occur if they are not present~~ date is now required, since we are sorting by it
    * To add a `date` to an old entry, you can simply use DecapCMS to Save/Publish a new version

## How to Test
1. Navigate to /admin/index.html
2. Click on Showcases on the left side
3. Choose a Showcase from the list to edit
    * You should be brought to the Showcase Editor
    * You should see a new widget about halfway down the page that says `date`
4. If you add a date and click "Save", a new PR is created that will add the date field to the Showcase item
    * For example: https://github.com/bodom0015/SDOHPlace/pull/2/files