### PR TITLE
feat: added Newsletter button to the footer

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -17,3 +17,8 @@ declare module "*.yml" {
   const value: any;
   export default value;
 }
+
+declare module "*.svg?component" {
+  const value: any;
+  export default value;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -8,16 +8,30 @@ module.exports = {
     unoptimized: true,
   },
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
+    // Grab the existing rule that handles SVG imports
+    const fileLoaderRule = config.module.rules.find((rule) =>
+      rule.test?.test?.('.svg'),
+    )
+
     config.module.rules.push(
       ...[
         {
           test: /\.yml$/,
           use: "yaml-loader",
         },
-        // {
-        //   test: /\.svg$/,
-        //   use: "@svgr/webpack",
-        // },
+        // Reapply the existing rule, but only for svg imports not ending in ?component
+        {
+          ...fileLoaderRule,
+          test: /\.svg$/i,
+          resourceQuery: { not: [...fileLoaderRule.resourceQuery.not, /component/] }, // exclude if *.svg?component
+        },
+        // Convert all other *.svg imports to React components
+        {
+          test: /\.svg$/i,
+          issuer: fileLoaderRule.issuer,
+          resourceQuery: /component/, // *.svg?component
+          use: ['@svgr/webpack'],
+        },
       ]
     );
     return config;

--- a/src/components/homepage/buttonwithicon/buttonwithicon.tsx
+++ b/src/components/homepage/buttonwithicon/buttonwithicon.tsx
@@ -44,20 +44,9 @@ const ButtonWithIcon = (props: Props): JSX.Element => {
       <Button
         className={props.endIcon ? classes.buttonWithEndIcon : ""}
         variant="contained"
-        startIcon={
-          <Image
-            priority
-            src={props.svgIcon}
-            alt={props.label}
-            style={{
-              opacity: props.iconOpacity ? props.iconOpacity : 1,
-            }}
-          />
-        }
+        startIcon={props.svgIcon}
         endIcon={
-          props.endIcon ? (
-            <Image priority src={props.endIcon} alt={props.label} style={{}} />
-          ) : null
+          props.endIcon ? props.endIcon : null
         }
         onClick={props.onClick}
         disabled={props.disabled}

--- a/src/components/homepage/footer/footer.tsx
+++ b/src/components/homepage/footer/footer.tsx
@@ -324,8 +324,7 @@ const Footer = (): JSX.Element => {
                 labelColor={"salmonpink"}
                 onClick={() => {
                   // Link to sign up to the Mailing List
-                  window.open
-                  window.location.href = "https://groups.webservices.illinois.edu/subscribe/192463";
+                  window.open("https://groups.webservices.illinois.edu/subscribe/192463", "_blank");
                 }}
               ></ButtonWithIcon>
             </div>

--- a/src/components/homepage/footer/footer.tsx
+++ b/src/components/homepage/footer/footer.tsx
@@ -22,9 +22,11 @@ import linkedinIcon from "@/public/logos/linkedin-purple-icon.svg";
 import facebookIcon from "@/public/logos/facebook-purple-icon.svg";
 import xIcon from "@/public/logos/x-purple-icon.svg";
 import newsIcon from "@/public/logos/news.svg";
+import emailIcon from "@/public/logos/email-icon.svg";
 import chevronRight from "@/public/logos/chevron-right.svg";
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "tailwind.config.js";
+import {ChevronRight, Feed, MailOutline} from "@mui/icons-material";
 
 const fullConfig = resolveConfig(tailwindConfig);
 const useStyles = makeStyles((theme) => ({
@@ -300,8 +302,8 @@ const Footer = (): JSX.Element => {
               <h5 className="text-gray-500">For all the latest and greatest</h5>
               <ButtonWithIcon
                 label={"NEWS"}
-                svgIcon={newsIcon}
-                endIcon={chevronRight}
+                svgIcon={<Feed />}
+                endIcon={<ChevronRight />}
                 borderRadius={"1rem"}
                 width={"100%"}
                 justifyContent="space-between"
@@ -311,9 +313,24 @@ const Footer = (): JSX.Element => {
                   window.location.href = "/news";
                 }}
               ></ButtonWithIcon>
+              <ButtonWithIcon
+                label={"NEWSLETTER"}
+                svgIcon={<MailOutline />}
+                endIcon={<ChevronRight />}
+                borderRadius={"1rem"}
+                width={"100%"}
+                justifyContent="space-between"
+                fillColor={"smokegray"}
+                labelColor={"salmonpink"}
+                onClick={() => {
+                  // Link to sign up to the Mailing List
+                  window.open
+                  window.location.href = "https://groups.webservices.illinois.edu/subscribe/192463";
+                }}
+              ></ButtonWithIcon>
             </div>
           </div>
-          {/*           
+          {/*
           <div className="flex flex-col justify-center flex-[34.86] items-start">
             <div className=" text-white text-2xl-rfs leading-8 tracking-[0.03125rem]">
               Sign up for our newsletter!

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,8 +5,7 @@ import Link from "next/link";
 import React, { useEffect, useRef, useState } from "react";
 
 import mainLogo from "@/public/logos/place-project-logo-hero.svg";
-import dataDiscoveryIcon from "@/public/logos/data-discovery-icon.svg";
-import communityToolkitIcon from "@/public/logos/community-toolkit-icon.svg";
+import DataDiscoveryIcon from "@/public/logos/data-discovery-icon.svg?component";
 import transitIcon from "@/public/logos/transit-icon.svg";
 import greenspacesIcon from "@/public/logos/greenspaces.svg";
 import educationIcon from "@/public/logos/education-icon.svg";
@@ -48,6 +47,7 @@ import {
   FaChevronCircleRight,
   FaPlus,
 } from "react-icons/fa";
+import {Handyman} from "@mui/icons-material";
 
 const fullConfig = resolveConfig(tailwindConfig);
 
@@ -102,6 +102,8 @@ const useStyles = makeStyles({
     },
   },
 });
+
+const DataDiscovery = () => (<div><DataDiscoveryIcon /></div>);
 
 const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
   const learnMoreRef = React.useRef(null);
@@ -249,7 +251,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
             <div>
               <ButtonWithIcon
                 label={"Data Discovery"}
-                svgIcon={dataDiscoveryIcon}
+                svgIcon={<DataDiscovery />}
                 fillColor={"salmonpink"}
                 labelColor={"almostblack"}
                 onClick={scrollToComingSoon}
@@ -258,7 +260,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
             <div>
               <ButtonWithIcon
                 label={"Community Toolkit"}
-                svgIcon={communityToolkitIcon}
+                svgIcon={<Handyman />}
                 fillColor={"frenchviolet"}
                 labelColor={"white"}
                 onClick={scrollToComingSoon}
@@ -486,7 +488,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
                     <div>
                       <ButtonWithIcon
                         label={"Data Discovery"}
-                        svgIcon={dataDiscoveryIcon}
+                        svgIcon={<DataDiscovery />}
                         fillColor={"salmonpink"}
                         labelColor={"almostblack"}
                         onClick={scrollToComingSoon}
@@ -522,7 +524,7 @@ const HomePage: NextPage<HomePageProps> = ({ newsItem }) => {
                   <div>
                     <ButtonWithIcon
                       label={"Community Toolkit"}
-                      svgIcon={communityToolkitIcon}
+                      svgIcon={<Handyman />}
                       fillColor={"frenchviolet"}
                       labelColor={"white"}
                       onClick={() => {


### PR DESCRIPTION
## Problem
We don't currently have a link allowing the user to subscribe to the Newsletter / Mailing list

Fixes #47 

## Approach
* fix: use actual SVG in ButtonWithIcon (instead of `<img src={mySvg} />`)
    * This now uses Material UI's [button with label & icons](https://mui.com/material-ui/react-button/#buttons-with-icons-and-label) under the hood
    * This only affects ~6 buttons in the UI
* fix: customized SVG loader in webpack
    * This allows us to import a custom SVG and use it immediately as a React component
    * This only affects import URLs that end with `?component` (to preserve existing imports where we need the raw SVG - there are a lot of these)
* feat: added a Newsletter button to the header that opens the subscribe link in a new tab

![Screenshot 2024-11-11 at 11 52 55 AM](https://github.com/user-attachments/assets/05b3f4c4-387e-4991-bd14-7f4c707032b2)

## How to Test
1. Navigate to the homepage
2. Scroll down to the footer
    * You should see a NEWSLETTER button now appears here
3. Click the NEWSLETTER button
    * You should see a page open in a new tab that allows you to subscribe to the newsletter / mailing list