### PR TITLE
enable mul-ti selection of the theme filter

### DIFF
--- a/src/components/search/detailPanel/detailPanel.tsx
+++ b/src/components/search/detailPanel/detailPanel.tsx
@@ -79,7 +79,6 @@ const DetailPanel = (props: Props): JSX.Element => {
                 labelColor={fullConfig.theme.colors["almostblack"]}
                 roundBackground={true}
                 handleSearch={props.handleSearch}
-                handleInputReset={props.handleInputReset}
               />
             ))}
           </div>

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -67,13 +67,23 @@ const IconTag = (props: Props): JSX.Element => {
 
   return (
     <div
-      className={`flex items-center shadow-none bg-lightbisque border border-1 border-strongorange rounded-[0.5em] py-[0.375em] pl-[0.5em] pr-[1em] space-x-2 ${classes.iconTag} cursor-pointer`}
+      className={`flex items-center shadow-none bg-lightbisque border border-1 rounded-[0.5em] py-[0.375em] pl-[0.5em] pr-[1em] space-x-2 ${
+        classes.iconTag
+      } cursor-pointer ${
+        isSelected(props.label) ? "border-frenchviolet" : "border-strongorange"
+      }`}
       onClick={() => handleSubjectClick(props.label)}
     >
       {props.roundBackground ? (
         <div
           className="relative flex items-center justify-center"
-          style={{ color: `${fullConfig.theme.colors["strongorange"]}` }}
+          style={{
+            color: `${
+              isSelected(props.label)
+                ? fullConfig.theme.colors["frenchviolet"]
+                : fullConfig.theme.colors["strongorange"]
+            }`,
+          }}
         >
           {props.svgIcon}
         </div>
@@ -84,7 +94,7 @@ const IconTag = (props: Props): JSX.Element => {
         className={`${props.labelClass}`}
         style={{
           color: isSelected(props.label)
-            ? `${fullConfig.theme.colors["strongorange"]}`
+            ? `${fullConfig.theme.colors["frenchviolet"]}`
             : props.labelColor,
           fontWeight: isSelected(props.label) ? 900 : 400,
         }}

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -56,9 +56,12 @@ const IconTag = (props: Props): JSX.Element => {
   };
 
   const isSelected = (label: string): boolean => {
-    const currentSubjects = params.subject
-      ? params.subject.split(",").map((s) => s.trim())
-      : [];
+    const currentSubjects =
+      typeof params.subject === "string"
+        ? params.subject.split(",").map((s) => s.trim())
+        : params.subject
+        ? params.subject.map((s) => s.trim())
+        : [];
     return currentSubjects.includes(label);
   };
 

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -17,6 +17,7 @@ interface Props {
   handleInputReset: () => void;
   handleSearch(params: any, value: string, filterQueries: any): void;
 }
+
 const fullConfig = resolveConfig(tailwindConfig);
 const useStyles = makeStyles((theme) => ({
   iconTag: {
@@ -29,21 +30,45 @@ const useStyles = makeStyles((theme) => ({
 const IconTag = (props: Props): JSX.Element => {
   let params = GetAllParams();
   const classes = useStyles();
+
   const handleSubjectClick = (sub: string) => {
-    let filterQueries = [{ attribute: "subject", value: "sub" }];
+    let filterQueries = reGetFilterQueries(params);
+    let currentSubjects = params.subject
+      ? params.subject.split(",").map((s) => s.trim())
+      : [];
+    let newSubjects: string[];
+    if (currentSubjects.includes(sub)) {
+      newSubjects = currentSubjects.filter((s) => s !== sub);
+    } else {
+      newSubjects = [...currentSubjects, sub];
+    }
+    const subjectString = newSubjects.length > 0 ? newSubjects.join(",") : "";
+    filterQueries = filterQueries.filter(
+      (query) => query.attribute !== "subject"
+    );
+    if (subjectString) {
+      filterQueries.push({ attribute: "subject", value: subjectString });
+    }
     updateAll(params, null, null, filterQueries, "*");
     params.setQuery("*");
-    params.setSubject(sub);
+    params.setSubject(subjectString);
     props.handleSearch(reGetFilterQueries(params), "*", filterQueries);
     props.handleInputReset();
   };
+
+  const isSelected = (label: string): boolean => {
+    const currentSubjects = params.subject
+      ? params.subject.split(",").map((s) => s.trim())
+      : [];
+    return currentSubjects.includes(label);
+  };
+
   return (
     <div
-      className={`flex items-center shadow-none bg-lightbisque border border-1 border-strongorange rounded-[0.5em] py-[0.375em] pl-[0.5em] pr-[1em] space-x-2 ${classes.iconTag}  cursor-pointer`}
+      className={`flex items-center shadow-none bg-lightbisque border border-1 border-strongorange rounded-[0.5em] py-[0.375em] pl-[0.5em] pr-[1em] space-x-2 ${classes.iconTag} cursor-pointer`}
       onClick={() => handleSubjectClick(props.label)}
     >
       {props.roundBackground ? (
-        // for icon with background as the theme tags.
         <div
           className="relative flex items-center justify-center"
           style={{ color: `${fullConfig.theme.colors["strongorange"]}` }}
@@ -56,11 +81,10 @@ const IconTag = (props: Props): JSX.Element => {
       <span
         className={`${props.labelClass}`}
         style={{
-          color:
-            params.subject === props.label
-              ? `${fullConfig.theme.colors["strongorange"]}`
-              : props.labelColor,
-          fontWeight: params.subject === props.label ? 900 : 400,
+          color: isSelected(props.label)
+            ? `${fullConfig.theme.colors["strongorange"]}`
+            : props.labelColor,
+          fontWeight: isSelected(props.label) ? 900 : 400,
         }}
       >
         {props.label}

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -60,7 +60,7 @@ const IconTag = (props: Props): JSX.Element => {
       typeof params.subject === "string"
         ? params.subject.split(",").map((s) => s.trim())
         : params.subject
-        ? params.subject.map((s) => s.trim())
+        ? (params.subject as string[]).map((s) => s.trim())
         : [];
     return currentSubjects.includes(label);
   };

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -14,7 +14,6 @@ interface Props {
   labelClass: string;
   labelColor: string;
   roundBackground: boolean;
-  handleInputReset: () => void;
   handleSearch(params: any, value: string, filterQueries: any): void;
 }
 
@@ -49,11 +48,11 @@ const IconTag = (props: Props): JSX.Element => {
     if (subjectString) {
       filterQueries.push({ attribute: "subject", value: subjectString });
     }
-    updateAll(params, null, null, filterQueries, "*");
-    params.setQuery("*");
+    const currentQuery = params.query ? params.query : "*";
+    updateAll(params, null, null, filterQueries, currentQuery);
+    params.setQuery(currentQuery);
     params.setSubject(subjectString);
-    props.handleSearch(reGetFilterQueries(params), "*", filterQueries);
-    props.handleInputReset();
+    props.handleSearch(reGetFilterQueries(params), currentQuery, filterQueries);
   };
 
   const isSelected = (label: string): boolean => {

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -199,7 +199,6 @@ export default function DiscoveryArea({
     setIsResetting(true);
   };
 
-
   /**
    * ***************
    * Filter & Sort Component
@@ -221,7 +220,6 @@ export default function DiscoveryArea({
       setSortBy={params.setSortBy}
     />
   );
-
 
   useEffect(() => {
     if (isResetting) {

--- a/src/components/search/filterPanel/filterPanel.tsx
+++ b/src/components/search/filterPanel/filterPanel.tsx
@@ -2,13 +2,7 @@
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
 import { useQueryState, parseAsString } from "nuqs";
-import {
-  Button,
-  IconButton,
-  Slider,
-  SxProps,
-  Theme,
-} from "@mui/material";
+import { Button, IconButton, Slider, SxProps, Theme } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
@@ -152,7 +146,7 @@ const FilterPanel = (props: Props): JSX.Element => {
       props.sortBy,
       props.sortOrder,
       newFilterQueries,
-      props.term,
+      props.term
     );
     if (yearsString === null) {
       setYearRange([minRange, maxRange]);

--- a/src/components/search/filterPanel/filterPanel.tsx
+++ b/src/components/search/filterPanel/filterPanel.tsx
@@ -119,9 +119,9 @@ const FilterPanel = (props: Props): JSX.Element => {
     params.setShowDetailPanel(null);
     params.setPrevAction("filter");
     setYearRange(newValue);
-    const newFilterQueries = props.filterQueries
-      .filter((f) => f["attribute"] !== "index_year")
-      .filter((f) => f["attribute"] !== "subject");
+    const newFilterQueries = props.filterQueries.filter(
+      (f) => f["attribute"] !== "index_year"
+    );
     const yearsArray = Array.from(
       { length: newValue[1] - newValue[0] + 1 },
       (_, i) => newValue[0] + i
@@ -314,9 +314,7 @@ const FilterPanel = (props: Props): JSX.Element => {
             Theme
           </Box>
           <Box className="flex flex-col sm:flex-row flex-wrap gap-4">
-            <ThemeIcons
-              handleSearch={props.handleSearch}
-            />
+            <ThemeIcons handleSearch={props.handleSearch} />
           </Box>
         </Box>
       </Box>

--- a/src/components/search/filterPanel/filterPanel.tsx
+++ b/src/components/search/filterPanel/filterPanel.tsx
@@ -9,8 +9,8 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import { SolrObject } from "meta/interface/SolrObject";
 import { useEffect, useMemo, useState } from "react";
 import { SearchUIConfig } from "@/components/searchUIConfig";
-import { Box, Checkbox, FormControlLabel, FormGroup } from "@mui/material";
-import { generateFilterList, updateFilter } from "../helper/FilterHelpMethods";
+import { Box } from "@mui/material";
+import { generateFilterList } from "../helper/FilterHelpMethods";
 import {
   GetAllParams,
   reGetFilterQueries,
@@ -39,11 +39,6 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: `${fullConfig.theme.fontFamily["sans"]} !important`,
   },
 }));
-
-const filterNameLookup = SearchUIConfig.search.searchFilters.filters.reduce(
-  (o, f) => ({ ...o, [f.attribute]: f.displayName }),
-  {}
-);
 
 /**
  * Only show filter items in url
@@ -321,7 +316,6 @@ const FilterPanel = (props: Props): JSX.Element => {
           <Box className="flex flex-col sm:flex-row flex-wrap gap-4">
             <ThemeIcons
               handleSearch={props.handleSearch}
-              handleInputReset={props.handleInputReset}
             />
           </Box>
         </Box>

--- a/src/components/search/helper/ParameterList.tsx
+++ b/src/components/search/helper/ParameterList.tsx
@@ -261,8 +261,9 @@ export const reGetFilterQueries = (params) => {
     });
   }
   if (params.subject) {
-    res.push({ attribute: "subject", value: params.subject });
-    // subject can only be one at a time
+    params.subject.split(",").forEach((i) => {
+      res.push({ attribute: "subject", value: i });
+    });
   }
   if (params.visLyrs) {
     params.visLyrs.forEach((i) => {

--- a/src/components/search/helper/ParameterList.tsx
+++ b/src/components/search/helper/ParameterList.tsx
@@ -261,9 +261,15 @@ export const reGetFilterQueries = (params) => {
     });
   }
   if (params.subject) {
-    params.subject.split(",").forEach((i) => {
-      res.push({ attribute: "subject", value: i });
-    });
+    if (typeof params.subject === "string") {
+      params.subject.split(",").forEach((i) => {
+        res.push({ attribute: "subject", value: i });
+      });
+    } else {
+      params.subject.forEach((i) => {
+        res.push({ attribute: "subject", value: i });
+      });
+    }
   }
   if (params.visLyrs) {
     params.visLyrs.forEach((i) => {
@@ -271,9 +277,15 @@ export const reGetFilterQueries = (params) => {
     });
   }
   if (params.indexYear) {
-    params.indexYear.split(",").forEach((i) => {
-      res.push({ attribute: "index_year", value: i });
-    });
+    if (typeof params.indexYear === "string") {
+      params.indexYear.split(",").forEach((i) => {
+        res.push({ attribute: "index_year", value: i });
+      });
+    } else {
+      params.indexYear.forEach((i) => {
+        res.push({ attribute: "index_year", value: i });
+      });
+    }
   }
   if (params.query) {
     res.push({ attribute: "query", value: params.query });

--- a/src/components/search/helper/themeIcons.tsx
+++ b/src/components/search/helper/themeIcons.tsx
@@ -6,7 +6,6 @@ import resolveConfig from "tailwindcss/resolveConfig";
 
 interface Props {
   handleSearch(params: any, value: string, filterQueries: any): void;
-  handleInputReset: () => void;
 }
 const fullConfig = resolveConfig(tailwindConfig);
 const useStyles = makeStyles((theme) => ({
@@ -41,7 +40,6 @@ const ThemeIcons = (props: Props): JSX.Element => {
           labelColor={fullConfig.theme.colors["almostblack"]}
           roundBackground={true}
           handleSearch={props.handleSearch}
-          handleInputReset={props.handleInputReset}
         />
       ))}
     </>

--- a/src/components/search/resultsPanel/resultsPanel.tsx
+++ b/src/components/search/resultsPanel/resultsPanel.tsx
@@ -9,8 +9,6 @@ import { Box, Button, CircularProgress } from "@mui/material";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import { SvgIcon } from "@mui/material";
 import { SearchUIConfig } from "@/components/searchUIConfig";
-import IconTag from "../detailPanel/iconTag";
-import IconMatch from "../helper/IconMatch";
 import {
   GetAllParams,
   isFiltersOn,
@@ -152,7 +150,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
               <Box className="flex flex-col sm:flex-row flex-wrap gap-4">
                 <ThemeIcons
                   handleSearch={props.handleSearch}
-                  handleInputReset={props.handleInputReset}
                 />
               </Box>
             </div>

--- a/src/components/search/resultsPanel/resultsPanel.tsx
+++ b/src/components/search/resultsPanel/resultsPanel.tsx
@@ -49,7 +49,7 @@ const ResultsPanel = (props: Props): JSX.Element => {
       .filter((v, i, a) => a.findIndex((t) => t.id === v.id) === i)
       .filter((v) => props.resultsList.every((t) => t.id !== v.id));
   }, [props.relatedList, props.resultsList]);
-  
+
   return (
     <div
       className="results-panel"

--- a/src/components/search/resultsPanel/resultsPanel.tsx
+++ b/src/components/search/resultsPanel/resultsPanel.tsx
@@ -148,9 +148,7 @@ const ResultsPanel = (props: Props): JSX.Element => {
                 <div className="text-s">Search for themes instead?</div>
               </Box>
               <Box className="flex flex-col sm:flex-row flex-wrap gap-4">
-                <ThemeIcons
-                  handleSearch={props.handleSearch}
-                />
+                <ThemeIcons handleSearch={props.handleSearch} />
               </Box>
             </div>
           )}


### PR DESCRIPTION
This PR addresses #363. It enbles multi-selection for the themes filter.

##How to Test
1. Navigate to the search page and open the filter panel.

2. Select the "Demographic" theme filter, then add the "Employment" filter. You should see the result list length increase due to the additional filter:
<img width="736" alt="Screenshot 2024-11-11 at 12 46 17 PM" src="https://github.com/user-attachments/assets/66acdbff-4ac1-4fa2-8c15-4e7fff8d0977">

3. Open a result detail, and the corresponding theme icon should be highlighted:
<img width="1561" alt="Screenshot 2024-11-11 at 12 45 31 PM" src="https://github.com/user-attachments/assets/0391e7c4-05a3-4dab-9e9b-ba7aa6dac413">

4. Experiment with the filters to ensure the list updates as expected.