### PR TITLE
style: add containers around central content in deiscovery app #376

### DIFF
--- a/src/components/search/detailPanel/headerRow/headerRow.tsx
+++ b/src/components/search/detailPanel/headerRow/headerRow.tsx
@@ -75,7 +75,7 @@ const HeaderRow = (props: Props): JSX.Element => {
           </div>
           <Box
             sx={{ display: "inline" }}
-            className={`text-4xl leading-8 ml-[0.5em] ${classes.introCard}`}
+            className={`text-4xl leading-10 ml-[0.5em] ${classes.introCard}`}
           >
             {props.resultItem.title}
           </Box>

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -243,73 +243,70 @@ export default function DiscoveryArea({
   ]);
   return (
     <Grid container>
-      <Grid item xs={12}>
-        <SearchRow
-          header={SearchUIConfig.search.headerRow.title}
-          description={SearchUIConfig.search.headerRow.subtitle}
-          schema={schema}
-          autocompleteKey={autocompleteKey}
-          options={options}
-          handleInputReset={handleInputReset}
-          setOptions={setOptions}
-          inputRef={inputRef}
-          inputValue={inputValue}
-          setInputValue={setInputValue}
-          value={value}
-          setValue={setValue}
-          setQuery={params.setQuery}
-          handleSearch={handleSearch}
-          filterQueries={filterQueries}
-        />
+      <Grid className="w-full px-[1em] sm:px-[2em] sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
+        <Grid container className="container mx-auto pt-[2em] sm:pt-0">
+          <SearchRow
+            header={SearchUIConfig.search.headerRow.title}
+            description={SearchUIConfig.search.headerRow.subtitle}
+            schema={schema}
+            autocompleteKey={autocompleteKey}
+            options={options}
+            handleInputReset={handleInputReset}
+            setOptions={setOptions}
+            inputRef={inputRef}
+            inputValue={inputValue}
+            setInputValue={setInputValue}
+            value={value}
+            setValue={setValue}
+            setQuery={params.setQuery}
+            handleSearch={handleSearch}
+            filterQueries={filterQueries}
+          />
+        </Grid>
       </Grid>
-      <Grid item className="sm:px-[2em]" xs={12} sm={4}>
-        <ResultsPanel
-          isLoading={isLoading}
-          updateKey={updateKey}
-          resultsList={fetchResults}
-          relatedList={relatedResults}
-          isQuery={isQuery || filterQueries.length > 0}
-          filterComponent={filterComponent}
-          showFilter={params.showFilter}
-          setShowFilter={params.setShowFilter}
-          setHighlightLyr={setHighlightLyr}
-          setHighlightIds={setHighlightIds}
-          handleSearch={handleSearch}
-          handleInputReset={handleInputReset}
-        />
-      </Grid>
-      <Grid item xs={8} className="sm:ml-[0.5em]">
-        {/* <Grid
-          item
-          className="sm:px-[2em]"
-          xs={12}
-          sx={{
-            display: params.showDetailPanel.length == 0 ? "block" : "none",
-          }}
-        > */}
-        <MapPanel
-          showMap={
-            isResetting || params.showDetailPanel.length == 0 ? "block" : "none"
-          }
-          resultsList={fetchResults}
-          highlightLyr={highlightLyr}
-          highlightIds={highlightIds}
-        />
-        {/* </Grid> */}
-        <Grid
-          sx={{
-            display: params.showDetailPanel.length > 0 ? "block" : "none",
-          }}
-        >
-          <DetailPanel
-            fetchResults={fetchResults}
-            relatedResults={relatedResults}
-            setShowDetailPanel={params.setShowDetailPanel}
-            showSharedLink={params.showSharedLink}
-            setShowSharedLink={params.setShowSharedLink}
+      <Grid container className="container mx-auto pt-[1em] ">
+        <Grid item xs={12} sm={4}>
+          <ResultsPanel
+            isLoading={isLoading}
+            updateKey={updateKey}
+            resultsList={fetchResults}
+            relatedList={relatedResults}
+            isQuery={isQuery || filterQueries.length > 0}
+            filterComponent={filterComponent}
+            showFilter={params.showFilter}
+            setShowFilter={params.setShowFilter}
+            setHighlightLyr={setHighlightLyr}
+            setHighlightIds={setHighlightIds}
             handleSearch={handleSearch}
             handleInputReset={handleInputReset}
           />
+        </Grid>
+        <Grid item xs={12} sm={8} className="sm:ml-[0.5em]">
+          <MapPanel
+            showMap={
+              isResetting || params.showDetailPanel.length == 0
+                ? "block"
+                : "none"
+            }
+            resultsList={fetchResults}
+            highlightLyr={highlightLyr}
+            highlightIds={highlightIds}
+          />
+          <Grid
+            sx={{
+              display: params.showDetailPanel.length > 0 ? "block" : "none",
+            }}
+          >
+            <DetailPanel
+              fetchResults={fetchResults}
+              relatedResults={relatedResults}
+              setShowDetailPanel={params.setShowDetailPanel}
+              showSharedLink={params.showSharedLink}
+              setShowSharedLink={params.setShowSharedLink}
+              handleSearch={handleSearch}
+              handleInputReset={handleInputReset}
+            />
+          </Grid>
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -171,7 +171,7 @@ const SearchBox = (props: Props): JSX.Element => {
     }
   }, [urlParams.query]);
   return (
-    <div className={`sm:mt-6 sm:ml-[3em] sm:mr-[2em]`}>
+    <div className={`sm:mt-6`}>
       <form id="search-form" onSubmit={handleSubmit}>
         <Autocomplete
           PopperComponent={CustomPopper}

--- a/src/components/search/searchArea/searchRow.tsx
+++ b/src/components/search/searchArea/searchRow.tsx
@@ -38,82 +38,71 @@ const SearchRow = (props: Props): JSX.Element => {
   const classes = useStyles();
   let params = GetAllParams();
   return (
-    // The mt for top nav is 8, therefore set the row mt to 32
-    <Box className="w-full mt-8 sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
-      <Grid container className="sm:mb-7">
-        <Grid
-          item
-          xs={12}
-          sm={4}
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-          className="pt-[2em] px-[2em]"
-        >
-          <Box display="flex" flexDirection="column" width="100%">
-            <div className="text-[3em] sm:text-[3.5em] xl:text-[4em] text-center sm:text-left">
-              {props.header}
-            </div>
-            <div className={`text-s text-center sm:text-left sm:mt-[1em]`}>
-              Our data discovery platform provides access to spatially indexed
-              and curated databases, specifically designed for conducting{" "}
-              <GlossaryPopover entry={"health equity"} /> research.
-            </div>
-          </Box>
-        </Grid>
-        <Grid
-          item
-          xs={12}
-          sm={8}
-          display="flex"
-          flexDirection="column"
-          justifyContent="flex-start"
-          alignItems="flex-start"
-          order={{ xs: 1, sm: 0 }}
-          className={`pt-[2.1825em] pb-[2.875em] ${classes.searchRow}`}
-        >
-          {!params.showInfoPanel && (
-            <Box width="100%">
-              <Box width="100%">
-                <SpatialResolutionCheck
-                  src={SearchUIConfig.search.searchBox.spatialResOptions}
-                  handleSearch={props.handleSearch}
-                  filterQueries={props.filterQueries}
-                />
-              </Box>
-              <Box
-                width="100%"
-                className="mt-[2em] sm:mt-0 3xl:max-w-[1203px] pr-[1em] md:pr-[3.375em]"
-              >
-                <SearchBox
-                  schema={props.schema}
-                  autocompleteKey={props.autocompleteKey}
-                  options={props.options}
-                  setOptions={props.setOptions}
-                  handleInputReset={props.handleInputReset}
-                  inputValue={props.inputValue}
-                  setInputValue={props.setInputValue}
-                  value={props.value}
-                  setValue={props.setValue}
-                  inputRef={props.inputRef}
-                  handleSearch={props.handleSearch}
-                  setQuery={props.setQuery}
-                />
-              </Box>
-            </Box>
-          )}
-          {params.showInfoPanel && (
-            <div>
-              <div
-                className={`flex items-center space-x-10 md:ml-[6em] md:mr-[5.3125em]`}
-              >
-                <InfoPanel />
-              </div>
-            </div>
-          )}
-        </Grid>
+    <>
+      <Grid
+        item
+        xs={12}
+        sm={4}
+        display="flex"
+        flexDirection="column"
+        className="py-[2em] sm:pr-[2em] xs:text-center sm:text-left"
+      >
+        <h2>{props.header}</h2>
+        <div className={`text-s text-center sm:text-left sm:mt-[1em]`}>
+          Our data discovery platform provides access to spatially indexed and
+          curated databases, specifically designed for conducting{" "}
+          <GlossaryPopover entry={"health equity"} /> research.
+        </div>
       </Grid>
-    </Box>
+      <Grid
+        item
+        xs={12}
+        sm={8}
+        display="flex"
+        flexDirection="column"
+        justifyContent="flex-start"
+        alignItems="flex-start"
+        order={{ xs: 1, sm: 0 }}
+        className={`py-[2em] ${classes.searchRow}`}
+      >
+        {!params.showInfoPanel && (
+          <Box width="100%">
+            <Box width="100%">
+              <SpatialResolutionCheck
+                src={SearchUIConfig.search.searchBox.spatialResOptions}
+                handleSearch={props.handleSearch}
+                filterQueries={props.filterQueries}
+              />
+            </Box>
+            <Box width="100%" className="mt-[2em] sm:mt-0">
+              <SearchBox
+                schema={props.schema}
+                autocompleteKey={props.autocompleteKey}
+                options={props.options}
+                setOptions={props.setOptions}
+                handleInputReset={props.handleInputReset}
+                inputValue={props.inputValue}
+                setInputValue={props.setInputValue}
+                value={props.value}
+                setValue={props.setValue}
+                inputRef={props.inputRef}
+                handleSearch={props.handleSearch}
+                setQuery={props.setQuery}
+              />
+            </Box>
+          </Box>
+        )}
+        {params.showInfoPanel && (
+          <div>
+            <div
+              className={`flex items-center space-x-10 md:ml-[6em] md:mr-[5.3125em]`}
+            >
+              <InfoPanel />
+            </div>
+          </div>
+        )}
+      </Grid>
+    </>
   );
 };
 export default SearchRow;

--- a/src/components/search/searchArea/spatialResolutionCheck.tsx
+++ b/src/components/search/searchArea/spatialResolutionCheck.tsx
@@ -81,7 +81,7 @@ const SpatialResolutionCheck = (props: Props): JSX.Element => {
     props.handleSearch(params, q, newFilterQueries);
   };
   return (
-    <div className={`flex items-center space-x-10 md:ml-[6em]`}>
+    <div className={`flex items-center space-x-10`}>
       <div className="text-l whitespace-nowrap">Spatial Resolution:</div>
       <div className="flex space-x-4">
         {Array.from(sRCheckboxes).map((checkbox, index) => (


### PR DESCRIPTION
This PR adds two internal containers around the content within the discovery app search bar, and the middle content below. This isn't a significant change, but will help the layout stay contained on very wide screens, and I believe create a little better foundation for improving the mobile view down the road.