### PR TITLE
#381: Force the search box to refocus after the input got cleared out

### DIFF
--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -179,7 +179,7 @@ export default function DiscoveryArea({
 
   const handleInputReset = () => {
     setValue("*");
-    setInputValue("*");
+    setInputValue("");
     params.setQuery("*");
     params.setShowDetailPanel(null);
     setIsResetting(true);

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState, useRef, use, useMemo } from "react";
-import { useSearchParams } from "next/navigation";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { SolrObject } from "meta/interface/SolrObject";
 import { debounce, Grid } from "@mui/material";
 import SolrQueryBuilder from "./helper/SolrQueryBuilder";
@@ -11,8 +10,6 @@ import { SearchUIConfig } from "../searchUIConfig";
 import MapPanel from "./mapPanel/mapPanel";
 import { GetAllParams, reGetFilterQueries } from "./helper/ParameterList";
 import FilterPanel from "./filterPanel/filterPanel";
-import { fi } from "date-fns/locale";
-import { parseArgs } from "util";
 
 export default function DiscoveryArea({
   results,
@@ -24,17 +21,6 @@ export default function DiscoveryArea({
   const inputRef = useRef<HTMLInputElement>(null);
   const [autocompleteKey, setAutocompleteKey] = useState(0);
   const [checkboxes, setCheckboxes] = useState([]);
-  // let tempSRChecboxes = new Set<CheckBoxObject>();
-  // SearchUIConfig.search.searchBox.spatialResOptions.forEach((option) => {
-  //   tempSRChecboxes.add({
-  //     attribute: "spatial_resolution",
-  //     value: option.value,
-  //     checked: searchParams.get("layers")
-  //       ? searchParams.get("layers").toString().includes(option.value)
-  //       : false,
-  //     displayName: option.display_name,
-  //   });
-  // });
   const [options, setOptions] = useState([]);
   const [resetStatus, setResetStatus] = useState(true);
 

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -85,6 +85,7 @@ const CustomPaper = (props) => {
 };
 
 const SearchBox = (props: Props): JSX.Element => {
+  const autocompleteRef = React.useRef<any>(null);
   const textFieldRef = React.useRef<HTMLInputElement>(null);
   const [showClearButton, setShowClearButton] = React.useState(
     props.value ? true : false
@@ -118,8 +119,6 @@ const SearchBox = (props: Props): JSX.Element => {
     urlParams.setShowDetailPanel(null); // always show the map panel if user searches
     props.handleSearch(urlParams, value, filterQueries);
   };
-  const [shouldRemount, setShouldRemount] = React.useState(false);
-  const autocompleteRef = React.useRef<any>(null);
   const isIOS = React.useMemo(() => {
     if (
       typeof window !== "undefined" &&

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -125,7 +125,7 @@ const SearchBox = (props: Props): JSX.Element => {
       typeof window.navigator !== "undefined"
     ) {
       return (
-        /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !window.MSStream
+        /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !(window as any).MSStream
       );
     }
     return false;

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -158,6 +158,21 @@ const SearchBox = (props: Props): JSX.Element => {
         });
     } else {
       props.handleInputReset();
+      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
+      if (isIOS) {
+      requestAnimationFrame(() => {
+        if (textFieldRef.current) {
+          textFieldRef.current.blur();
+          setTimeout(() => {
+            textFieldRef.current?.focus();
+            textFieldRef.current?.scrollIntoView({ behavior: 'smooth' });
+            if (document.documentElement) {
+              document.documentElement.style.touchAction = 'manipulation';
+            }
+          }, 300); // extra time for ios device
+        }
+      });
+    } else {
       requestAnimationFrame(() => {
         if (textFieldRef.current) {
           textFieldRef.current.blur();
@@ -170,6 +185,7 @@ const SearchBox = (props: Props): JSX.Element => {
         }
       });
     }
+  }
   };
   useEffect(() => {
     if (!urlParams.query) {

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -222,13 +222,6 @@ const SearchBox = (props: Props): JSX.Element => {
                   borderColor: "transparent",
                 },
               }}
-              onFocus={(e) => {
-                // Prevent any immediate blur
-                e.preventDefault();
-                if (textFieldRef.current) {
-                  textFieldRef.current.focus();
-                }
-              }}
               InputProps={{
                 ...params.InputProps,
                 startAdornment: (

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -20,8 +20,6 @@ import { SearchObject } from "../interface/SearchObject";
 import SolrQueryBuilder from "../helper/SolrQueryBuilder";
 import { useEffect } from "react";
 import { GetAllParams, reGetFilterQueries } from "../helper/ParameterList";
-import { containsYear } from "../helper/SuggestMethods";
-import { p } from "nuqs/dist/serializer-C_l8WgvO";
 
 interface Props {
   schema: any;
@@ -87,6 +85,7 @@ const CustomPaper = (props) => {
 };
 
 const SearchBox = (props: Props): JSX.Element => {
+  const textFieldRef = React.useRef<HTMLInputElement>(null);
   const [showClearButton, setShowClearButton] = React.useState(
     props.value ? true : false
   );
@@ -159,6 +158,17 @@ const SearchBox = (props: Props): JSX.Element => {
         });
     } else {
       props.handleInputReset();
+      requestAnimationFrame(() => {
+        if (textFieldRef.current) {
+          textFieldRef.current.blur();
+          setTimeout(() => {
+            textFieldRef.current?.focus();
+            if (textFieldRef.current?.setSelectionRange) {
+              textFieldRef.current.setSelectionRange(0, 0);
+            }
+          }, 100);
+        }
+      });
     }
   };
   useEffect(() => {
@@ -193,7 +203,7 @@ const SearchBox = (props: Props): JSX.Element => {
           renderInput={(params) => (
             <TextField
               {...params}
-              inputRef={props.inputRef}
+              inputRef={textFieldRef}
               variant="outlined"
               fullWidth
               placeholder="Search"
@@ -211,6 +221,13 @@ const SearchBox = (props: Props): JSX.Element => {
                 "& .MuiOutlinedInput-notchedOutline": {
                   borderColor: "transparent",
                 },
+              }}
+              onFocus={(e) => {
+                // Prevent any immediate blur
+                e.preventDefault();
+                if (textFieldRef.current) {
+                  textFieldRef.current.focus();
+                }
               }}
               InputProps={{
                 ...params.InputProps,


### PR DESCRIPTION
This PR addresses issue #381. It forces the search text box to refocus after the user removes all their input. I also removed some unused legacy code from discoveryApp.tsx.

##How to Test
1. Navigate to the search page and start typing in the search box.
2. Delete all input using the keyboard, and you should see that the search box remains focused after everything is cleared.