### PR TITLE
feat: added DecapCMS collection for Research Rabbit entries

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -435,3 +435,46 @@ collections:
       - label: "Body"
         name: "body"
         widget: "markdown"
+
+  - name: "research-rabbit"
+    label: "Research Rabbit"
+    delete: false
+    editor:
+      preview: false
+    files:
+      - name: research-rabbit
+        label: Research Rabbit
+        file: "meta/research-rabbit.json"
+        label_singular: "item"
+        fields:
+          - name: title
+            label: Title
+            widget: string
+          - label: "Metadata Record ID"
+            name: "record_ids"
+            widget: "list"
+            summary: "{{record_id}}"
+            fields:
+              - label: Record ID
+                name: record_id
+                widget: string
+          - label: Public Link
+            name: link_url
+            widget: string
+            pattern:
+              [
+                '[(http(s)?):\/\/(www\\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)',
+                "Must be a valid URL.",
+              ]
+          - label: Collected by
+            name: collected_by
+            widget: string
+          - label: Reviewed by
+            name: reviewed_by
+            widget: string
+          - label: Documentation/Report
+            name: doc_report
+            widget: boolean
+          - label: Original peer-reviewed article by authors
+            name: peer_reviewed
+            widget: boolean

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -445,36 +445,42 @@ collections:
       - name: research-rabbit
         label: Research Rabbit
         file: "meta/research-rabbit.json"
-        label_singular: "item"
+        label_singular: "Research Rabbit"
         fields:
-          - name: title
-            label: Title
-            widget: string
-          - label: "Metadata Record ID"
-            name: "record_ids"
-            widget: "list"
-            summary: "{{record_id}}"
+          - name: research-rabbit
+            label: Research Rabbit
+            label_singular: "entry"
+            widget: list
+            summary: "{{title}}"
             fields:
-              - label: Record ID
-                name: record_id
-                widget: string
-          - label: Public Link
-            name: link_url
-            widget: string
-            pattern:
-              [
-                '[(http(s)?):\/\/(www\\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)',
-                "Must be a valid URL.",
-              ]
-          - label: Collected by
-            name: collected_by
-            widget: string
-          - label: Reviewed by
-            name: reviewed_by
-            widget: string
-          - label: Documentation/Report
-            name: doc_report
-            widget: boolean
-          - label: Original peer-reviewed article by authors
-            name: peer_reviewed
-            widget: boolean
+            - name: title
+              label: Title
+              widget: string
+            - label: "Metadata Record ID"
+              name: "record_ids"
+              widget: "list"
+              summary: "{{link_label}} - {{link_url}}"
+              fields:
+                - label: Record ID
+                  name: record_id
+                  widget: string
+            - label: Public Link
+              name: link_url
+              widget: string
+              pattern:
+                [
+                  '[(http(s)?):\/\/(www\\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)',
+                  "Must be a valid URL.",
+                ]
+            - label: Collected by
+              name: collected_by
+              widget: string
+            - label: Reviewed by
+              name: reviewed_by
+              widget: string
+            - label: Documentation/Report
+              name: doc_report
+              widget: boolean
+            - label: Original peer-reviewed article by authors
+              name: peer_reviewed
+              widget: boolean

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -89,6 +89,49 @@ collections:
                 name: "name"
                 widget: "string"
                 hint: "Tag name for displaying on the site"
+      - name: research-rabbit
+        label: Research Rabbit
+        file: "meta/research-rabbit.json"
+        label_singular: "Research Rabbit"
+        fields:
+          - name: research-rabbit
+            label: Research Rabbit
+            label_singular: "entry"
+            widget: list
+            summary: "{{title}}"
+            fields:
+              - name: title
+                label: Title
+                widget: string
+              - label: "Metadata Record ID"
+                name: "record_ids"
+                widget: "list"
+                summary: "{{link_label}} - {{link_url}}"
+                fields:
+                  - label: Record ID
+                    name: record_id
+                    widget: string
+              - label: Public Link
+                name: link_url
+                widget: string
+                pattern:
+                  [
+                    '[(http(s)?):\/\/(www\\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)',
+                    "Must be a valid URL.",
+                  ]
+              - label: Collected by
+                name: collected_by
+                widget: string
+              - label: Reviewed by
+                name: reviewed_by
+                widget: string
+              - label: Documentation/Report
+                name: doc_report
+                widget: boolean
+              - label: Original peer-reviewed article by authors
+                name: peer_reviewed
+                widget: boolean
+
 
   - name: "people"
     label: "People"
@@ -436,51 +479,3 @@ collections:
         name: "body"
         widget: "markdown"
 
-  - name: "research-rabbit"
-    label: "Research Rabbit"
-    delete: false
-    editor:
-      preview: false
-    files:
-      - name: research-rabbit
-        label: Research Rabbit
-        file: "meta/research-rabbit.json"
-        label_singular: "Research Rabbit"
-        fields:
-          - name: research-rabbit
-            label: Research Rabbit
-            label_singular: "entry"
-            widget: list
-            summary: "{{title}}"
-            fields:
-            - name: title
-              label: Title
-              widget: string
-            - label: "Metadata Record ID"
-              name: "record_ids"
-              widget: "list"
-              summary: "{{link_label}} - {{link_url}}"
-              fields:
-                - label: Record ID
-                  name: record_id
-                  widget: string
-            - label: Public Link
-              name: link_url
-              widget: string
-              pattern:
-                [
-                  '[(http(s)?):\/\/(www\\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)',
-                  "Must be a valid URL.",
-                ]
-            - label: Collected by
-              name: collected_by
-              widget: string
-            - label: Reviewed by
-              name: reviewed_by
-              widget: string
-            - label: Documentation/Report
-              name: doc_report
-              widget: boolean
-            - label: Original peer-reviewed article by authors
-              name: peer_reviewed
-              widget: boolean


### PR DESCRIPTION
## Problem
We would like to add a new collection for tracking Research Rabbit entries

Fixes #401 

## Approach
* feat: added a new collection in DecapCMS for Research Rabbit entries
* fix: move to Meta collection, allow multiple entries to be saved 

## How to Test
1. Navigate to `/admin/index.html#/collections/research-rabbit/entries/research-rabbit`
2. Click on the Meta collection
    * You should see a new listing here for Research Rabbit
3. Click on Research Rabbit
    * You should see a list of existing Research Rabbit entries listed here
    * You should see a button to "Add entry"
4. Click on "Add entry"
    * You should see a new Research Rabbit entry is added to the collection
5. Fill out necessary fields, click Save, then refresh the page
    * You should see that your changes are persisted
    * You should see that your changes are saved to the `meta/research-rabbit.json` file