### PR TITLE
408 display spatial coverage

### DIFF
--- a/meta/interface/SolrObject.ts
+++ b/meta/interface/SolrObject.ts
@@ -32,7 +32,7 @@ export interface SolrObject {
     suppress?: boolean;
     spatial_resolution?: string[];
     spatial_coverage?: string[];
-    sdoh_highlight_ids_sm?: string[];
+    highlight_ids?: string[];
     data_usage_notes?: string;
     data_variables?: string[];
     methods_variables?: string[];

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -37,7 +37,7 @@ interface Props {
 
 export default function DynamicMap(props: Props): JSX.Element {
   const dispatch = useDispatch<AppDispatch>();
-  const { bbox, visLyrs, visOverlays } = useSelector(
+  const { bbox, visOverlays } = useSelector(
     (state: RootState) => state.search
   );
   const mapPreview = useSelector((state: RootState) => state.ui.mapPreview);
@@ -123,23 +123,7 @@ export default function DynamicMap(props: Props): JSX.Element {
         map.removeLayer(overlayRegistry[lyr].spec.id);
       }
     });
-    visLyrs.forEach((lyr) => {
-      if (
-        layerRegistry[lyr] &&
-        !mapLyrIds.includes(layerRegistry[lyr].spec.id)
-      ) {
-        map.addLayer(layerRegistry[lyr].spec, layerRegistry[lyr].addBefore);
-      }
-    });
-    Object.keys(layerRegistry).forEach((lyr) => {
-      if (
-        mapLyrIds.includes(layerRegistry[lyr].spec.id) &&
-        !visLyrs.includes(lyr)
-      ) {
-        map.removeLayer(layerRegistry[lyr].spec.id);
-      }
-    });
-  }, [visLyrs, visOverlays, mapLoaded]);
+  }, [visOverlays, mapLoaded]);
 
   const onMouseMove = useCallback((event: MapLayerMouseEvent) => {
     if (!mapRef.current) {

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -59,7 +59,7 @@ export default function DynamicMap(props: Props): JSX.Element {
         "040": "state-2018",
         "050": "county-2018",
         "140": "tract-2018",
-        "150": "blockgroup-2018",
+        "150": "bg-2018",
         "860": "zcta-2018",
       }
       const source = lookup[previewLyr.filterIds[0].slice(0,3)]
@@ -234,7 +234,7 @@ export default function DynamicMap(props: Props): JSX.Element {
       <Source id="state-2018" type="vector" url="pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/state-2018.pmtiles" />
       <Source id="county-2018" type="vector" url="pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/county-2018.pmtiles" />
       <Source id="tract-2018" type="vector" url="pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/tract-2018.pmtiles" />
-      <Source id="blockgroup-2018" type="vector" url="pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/bg-2018.pmtiles" />
+      <Source id="bg-2018" type="vector" url="pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/bg-2018.pmtiles" />
       <Source id="zcta-2018" type="vector" url="pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/zcta-2018.pmtiles" />
       <Source id="place-2018" type="vector" url="pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/place-2018.pmtiles" />
 

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -40,7 +40,7 @@ export default function DynamicMap(props: Props): JSX.Element {
   const { bbox, visLyrs, visOverlays } = useSelector(
     (state: RootState) => state.search
   );
-  const mapPreview = useSelector((state: RootState) => state.search.mapPreview);
+  const mapPreview = useSelector((state: RootState) => state.ui.mapPreview);
   const [parkPopupInfo, setParkPopupInfo] = useState(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const mapRef = useRef<MapRef>(null);
@@ -55,7 +55,6 @@ export default function DynamicMap(props: Props): JSX.Element {
     });
 
     mapPreview.map((previewLyr) => {
-
       const lookup = {
         "040": "state",
         "050": "county",
@@ -79,7 +78,7 @@ export default function DynamicMap(props: Props): JSX.Element {
         "source-layer": source + "-2018",
         type: "line",
         paint: {
-          "line-color": "#ff9c77",
+          "line-color": "#FF9C77",
           "line-width": 1,
         },
         filter: expression,

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -28,6 +28,7 @@ import "@maptiler/geocoding-control/style.css";
 import * as turf from "@turf/turf";
 
 import GeoSearchControl from "./geoSearchControl";
+import {clearMapPreview} from "@/store/slices/uiSlice";
 
 const apiKey = process.env.NEXT_PUBLIC_MAPTILER_API_KEY;
 
@@ -196,6 +197,7 @@ export default function DynamicMap(props: Props): JSX.Element {
 
   const handleGeoSearchSelection = useCallback(
     (e) => {
+      dispatch(clearMapPreview());
       const map = mapRef.current.getMap();
       const highlightSource = map.getSource(
         "geoSearchHighlight"

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -78,7 +78,7 @@ export default function DynamicMap(props: Props): JSX.Element {
           ]);
         } else if (id.startsWith("-") && !id.endsWith("*")) {
           // Excludes - exclude any IDs that start with "-"
-          clauses.push(["!=", ["get", "HEROP_ID"], id]);
+          clauses.push(["!=", ["get", "HEROP_ID"], id.slice(1, id.length)]);
         } else if (!id.startsWith("-") && id.endsWith("*")) {
           // Wildcards - "*" on the end works as a wildcard match
           clauses.push([
@@ -101,6 +101,7 @@ export default function DynamicMap(props: Props): JSX.Element {
       }
 
       const expression = [operator, ...clauses];
+      console.log(expression);
 
       const previewLyrs = makePreviewLyrs(
         previewLyr.lyrId,

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -53,16 +53,36 @@ export default function DynamicMap(props: Props): JSX.Element {
         map.removeLayer(lyr.id);
       }
     });
-    mapPreview.map((layerInfo) => {
+
+    mapPreview.map((previewLyr) => {
+
+      const lookup = {
+        "040": "state",
+        "050": "county",
+        "140": "tract",
+        "150": "bg",
+        "860": "zcta",
+      }
+      const source = lookup[previewLyr.filterIds[0].slice(0,3)]
+
+      let expression: FilterSpecification;
+      if (previewLyr.filterIds[0].endsWith("*")) {
+        const strId = previewLyr.filterIds[0].slice(0,-1)
+        expression = ["==", ["slice", ['get', 'HEROP_ID'], 0, strId.length], strId]
+      } else {
+        expression = ["in", ['get', 'HEROP_ID'], ["literal", previewLyr.filterIds]]
+      }
+
       const newLayerSpec: LineLayerSpecification = {
-        id: layerInfo.id,
-        source: layerInfo.source,
-        "source-layer": layerInfo.source + "-2018",
+        id: previewLyr.lyrId,
+        source: source,
+        "source-layer": source + "-2018",
         type: "line",
         paint: {
-          "line-color": "blue",
-          "line-width": 1.5,
+          "line-color": "#ff9c77",
+          "line-width": 1,
         },
+        filter: expression,
       };
       const newLayer: LayerDef = {
         addBefore: "Ocean labels",

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -41,12 +41,6 @@ export default function DynamicMap(props: Props): JSX.Element {
     (state: RootState) => state.search
   );
   const mapPreview = useSelector((state: RootState) => state.search.mapPreview);
-  const [currentDisplayLayers, setCurrentDisplayLayers] = useState<
-    LayerSpecification[]
-  >([]);
-  const [currentInteractiveLayers, setCurrentInteractiveLayers] = useState<
-    LayerSpecification[]
-  >([]);
   const [parkPopupInfo, setParkPopupInfo] = useState(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const mapRef = useRef<MapRef>(null);

--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -56,11 +56,11 @@ export default function DynamicMap(props: Props): JSX.Element {
 
     mapPreview.map((previewLyr) => {
       const lookup = {
-        "040": "state",
-        "050": "county",
-        "140": "tract",
-        "150": "bg",
-        "860": "zcta",
+        "040": "state-2018",
+        "050": "county-2018",
+        "140": "tract-2018",
+        "150": "blockgroup-2018",
+        "860": "zcta-2018",
       }
       const source = lookup[previewLyr.filterIds[0].slice(0,3)]
 
@@ -73,15 +73,15 @@ export default function DynamicMap(props: Props): JSX.Element {
       }
 
       const newLayerSpec: LineLayerSpecification = {
-        id: previewLyr.lyrId,
-        source: source,
-        "source-layer": source + "-2018",
-        type: "line",
-        paint: {
+        "id": previewLyr.lyrId,
+        "source": source,
+        "source-layer": source,
+        "type": "line",
+        "paint": {
           "line-color": "#FF9C77",
           "line-width": 1,
         },
-        filter: expression,
+        "filter": expression,
       };
       const newLayer: LayerDef = {
         addBefore: "Ocean labels",

--- a/src/components/map/geoSearchControl.tsx
+++ b/src/components/map/geoSearchControl.tsx
@@ -4,6 +4,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 
 import { GeocodingControl } from "@maptiler/geocoding-control/maplibregl";
 import "@maptiler/geocoding-control/style.css";
+import {clearMapPreview} from "@/store/slices/uiSlice";
 
 interface GeoSearchControlProps {
   apiKey: string;

--- a/src/components/map/helper/layers.tsx
+++ b/src/components/map/helper/layers.tsx
@@ -7,27 +7,41 @@ import {
 
 export type LayerDef = {
   addBefore: string;
-  spec: FillLayerSpecification | LineLayerSpecification | CircleLayerSpecification;
+  spec:
+    | FillLayerSpecification
+    | LineLayerSpecification
+    | CircleLayerSpecification;
 };
 
-export const makePreviewLyr = function (id: string, source: string, filter: FilterSpecification) {
-  const newLayerSpec: LineLayerSpecification = {
-    "id": id,
-    "source": source,
+export const makePreviewLyrs = function (
+  id: string,
+  source: string,
+  filter: FilterSpecification
+) {
+  const newLineLayerSpec: LineLayerSpecification = {
+    id: `${id}-line`,
+    source: source,
     "source-layer": source,
-    "type": "line",
-    "paint": {
+    type: "line",
+    paint: {
       "line-color": "#FF9C77",
       "line-width": 1,
     },
-    "filter": filter,
+    filter: filter,
   };
-  const outLayerDef: LayerDef = {
-    addBefore: "Ocean labels",
-    spec: newLayerSpec,
+  const newFillLayerSpec: FillLayerSpecification = {
+    id: `${id}-fill`,
+    source: source,
+    "source-layer": source,
+    type: "fill",
+    paint: {
+      "fill-color": "#FF9C77",
+      "fill-opacity": 0.25,
+    },
+    filter: filter,
   };
-  return outLayerDef
-}
+  return [newLineLayerSpec, newFillLayerSpec];
+};
 
 // demo POI layer
 const parksSpec: CircleLayerSpecification = {

--- a/src/components/map/helper/layers.tsx
+++ b/src/components/map/helper/layers.tsx
@@ -36,7 +36,7 @@ export const makePreviewLyrs = function (
     type: "fill",
     paint: {
       "fill-color": "#FF9C77",
-      "fill-opacity": 0.25,
+      "fill-opacity": 0.1,
     },
     filter: filter,
   };

--- a/src/components/map/helper/layers.tsx
+++ b/src/components/map/helper/layers.tsx
@@ -2,221 +2,32 @@ import {
   FillLayerSpecification,
   LineLayerSpecification,
   CircleLayerSpecification,
+  FilterSpecification,
 } from "maplibre-gl";
 
-// Important note: Before we used "LayerSpecification" but this was too generic
-// to pass our pre-commit hooks, after it was used as the nested spec property type
-// within the LayerDef type. Specifically, it failed because in some places the source property
-// is referenced, and on BackgroundLayerSpecification this property does not exist.
-
-// It is better to use more specific types here anyway, so prefer this use of
-// FillLayerSpecification, LineLayerSpecification etc.
-
 export type LayerDef = {
-  addBefore: string | null;
-  spec:
-    | FillLayerSpecification
-    | LineLayerSpecification
-    | CircleLayerSpecification
-    | null;
-  specHl:
-    | FillLayerSpecification
-    | LineLayerSpecification
-    | CircleLayerSpecification
-    | null;
+  addBefore: string;
+  spec: FillLayerSpecification | LineLayerSpecification | CircleLayerSpecification;
 };
 
-function makeHighlightLayer(
-  spec:
-    | FillLayerSpecification
-    | LineLayerSpecification
-    | CircleLayerSpecification
-) {
-  const specHl = structuredClone(spec);
-  specHl.id += "-hl";
-  specHl.paint = {
-    "line-color": "#7e1cc4",
-    "line-width": 0.25,
+export const makePreviewLyr = function (id: string, source: string, filter: FilterSpecification) {
+  const newLayerSpec: LineLayerSpecification = {
+    "id": id,
+    "source": source,
+    "source-layer": source,
+    "type": "line",
+    "paint": {
+      "line-color": "#FF9C77",
+      "line-width": 1,
+    },
+    "filter": filter,
   };
-  return specHl;
+  const outLayerDef: LayerDef = {
+    addBefore: "Ocean labels",
+    spec: newLayerSpec,
+  };
+  return outLayerDef
 }
-
-// SR: City
-const placeSpec: FillLayerSpecification = {
-  id: "place-2018",
-  source: "place",
-  "source-layer": "place-2018",
-  type: "fill",
-  paint: {
-    "fill-color": "#a05a18",
-    "fill-opacity": 0.5,
-  },
-};
-const placeLyr: LayerDef = {
-  addBefore: "Landcover",
-  spec: placeSpec,
-  specHl: makeHighlightLayer(placeSpec),
-};
-
-// SR: Zip Code Tabulation Area (ZCTA)
-const zctaSpec: LineLayerSpecification = {
-  id: "zcta-2018",
-  source: "zcta",
-  "source-layer": "zcta-2018",
-  type: "line",
-  paint: {
-    "line-color": "#aeaeae",
-    "line-width": 0.25,
-  },
-};
-const zctaLyr: LayerDef = {
-  addBefore: "Ocean labels",
-  spec: zctaSpec,
-  specHl: makeHighlightLayer(zctaSpec),
-};
-
-// SR: Census Block Group
-const bgSpec: LineLayerSpecification = {
-  id: "bg-2018",
-  source: "bg",
-  "source-layer": "bg-2018",
-  type: "line",
-  paint: {
-    "line-color": "#ff9c77",
-    "line-width": 0.75,
-  },
-};
-const bgLyr: LayerDef = {
-  addBefore: "Ocean labels",
-  spec: bgSpec,
-  specHl: makeHighlightLayer(bgSpec),
-};
-
-// SR: Census Tract
-const tractSpec: LineLayerSpecification = {
-  id: "tract-2018",
-  source: "tract",
-  "source-layer": "tract-2018",
-  type: "line",
-  paint: {
-    "line-color": "#9490B6",
-    "line-width": 1,
-  },
-};
-const tractLyr: LayerDef = {
-  addBefore: "Ocean labels",
-  spec: tractSpec,
-  specHl: makeHighlightLayer(tractSpec),
-};
-
-// SR: County
-const countySpec: LineLayerSpecification = {
-  id: "county-2018",
-  source: "county",
-  "source-layer": "county-2018",
-  type: "line",
-  paint: {
-    "line-color": "lightgray",
-    "line-width": 1.5,
-  },
-};
-const countyLyr: LayerDef = {
-  addBefore: "Ocean labels",
-  spec: countySpec,
-  specHl: makeHighlightLayer(countySpec),
-};
-
-// Make it always there
-const stateSpec: LineLayerSpecification = {
-  id: "state-2018",
-  source: "state",
-  "source-layer": "state-2018",
-  type: "line",
-  paint: {
-    "line-color": "#CCC",
-    "line-width": 2,
-  },
-};
-const stateLyr: LayerDef = {
-  addBefore: "Ocean labels",
-  spec: stateSpec,
-  specHl: makeHighlightLayer(stateSpec),
-};
-
-export const displayLayers = [
-  placeLyr,
-  zctaLyr,
-  bgLyr,
-  tractLyr,
-  countyLyr,
-  stateLyr,
-];
-
-// use FillLayers for interactive layers (selection based on interior of polygons)
-// because with DisplayLayers, selection/interaction is only on the lines themselves
-const stateInteractive: FillLayerSpecification = {
-  id: "state-interactive",
-  source: "state",
-  "source-layer": "state-2018",
-  type: "fill",
-  paint: {
-    "fill-opacity": 0,
-  },
-};
-const countyInteractive: FillLayerSpecification = {
-  id: "county-interactive",
-  source: "county",
-  "source-layer": "county-2018",
-  type: "fill",
-  paint: {
-    "fill-opacity": 0,
-  },
-};
-const placeInteractive: FillLayerSpecification = {
-  id: "place-interactive",
-  source: "place",
-  "source-layer": "place-2018",
-  type: "fill",
-  paint: {
-    "fill-opacity": 0,
-  },
-};
-const zctaInteractive: FillLayerSpecification = {
-  id: "zcta-interactive",
-  source: "zcta",
-  "source-layer": "zcta-2018",
-  type: "fill",
-  paint: {
-    "fill-opacity": 0,
-  },
-};
-const bgInteractive: FillLayerSpecification = {
-  id: "bg-interactive",
-  source: "bg",
-  "source-layer": "bg-2018",
-  type: "fill",
-  paint: {
-    "fill-opacity": 0,
-  },
-};
-const tractInteractive: FillLayerSpecification = {
-  id: "tract-interactive",
-  source: "tract",
-  "source-layer": "tract-2018",
-  type: "fill",
-  paint: {
-    "fill-opacity": 0,
-  },
-};
-
-export const interactiveLayers = [
-  stateInteractive,
-  countyInteractive,
-  placeInteractive,
-  zctaInteractive,
-  bgInteractive,
-  tractInteractive,
-];
 
 // demo POI layer
 const parksSpec: CircleLayerSpecification = {
@@ -235,16 +46,6 @@ const parksSpec: CircleLayerSpecification = {
 export const parksLayer: LayerDef = {
   addBefore: "Ocean labels",
   spec: parksSpec,
-  specHl: makeHighlightLayer(parksSpec),
-};
-
-export const layerRegistry = {
-  state: stateLyr,
-  place: placeLyr,
-  county: countyLyr,
-  bg: bgLyr,
-  tract: tractLyr,
-  zcta: zctaLyr,
 };
 
 export const overlayRegistry = {

--- a/src/components/map/helper/sources.tsx
+++ b/src/components/map/helper/sources.tsx
@@ -1,39 +1,9 @@
-import data from "./ks-parks-example.json";
-
 // these are the sources for all overlay layers. multiple layers can be added to the map
 // that use the same source: for example a source for state boundaries can be displayed as a
 // polygon (fill) layer as well as a line (outline) layer
-export const sources = {
-  "state-2018": {
-    type: "vector",
-    url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/state-2018.pmtiles",
-  },
-  "county-2018": {
-    type: "vector",
-    url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/county-2018.pmtiles",
-  },
-  "tract-2018": {
-    type: "vector",
-    url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/tract-2018.pmtiles",
-  },
-  "blockgroup-2018": {
-    type: "vector",
-    url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/bg-2018.pmtiles",
-  },
-  "zcta-2018": {
-    type: "vector",
-    url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/zcta-2018.pmtiles",
-  },
-  "place-2018": {
-    type: "vector",
-    url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/place-2018.pmtiles",
-  },
+export const overlaySources = {
   "us-parks": {
     type: "vector",
     url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/overlays/us-parks.pmtiles",
-  },
-  geoSearchHighlight: {
-    type: "geojson",
-    data: null,
   },
 };

--- a/src/components/map/helper/sources.tsx
+++ b/src/components/map/helper/sources.tsx
@@ -4,27 +4,27 @@ import data from "./ks-parks-example.json";
 // that use the same source: for example a source for state boundaries can be displayed as a
 // polygon (fill) layer as well as a line (outline) layer
 export const sources = {
-  state: {
+  "state-2018": {
     type: "vector",
     url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/state-2018.pmtiles",
   },
-  county: {
+  "county-2018": {
     type: "vector",
     url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/county-2018.pmtiles",
   },
-  tract: {
+  "tract-2018": {
     type: "vector",
     url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/tract-2018.pmtiles",
   },
-  bg: {
+  "blockgroup-2018": {
     type: "vector",
     url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/bg-2018.pmtiles",
   },
-  zcta: {
+  "zcta-2018": {
     type: "vector",
     url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/zcta-2018.pmtiles",
   },
-  place: {
+  "place-2018": {
     type: "vector",
     url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/place-2018.pmtiles",
   },

--- a/src/components/map/mapArea.tsx
+++ b/src/components/map/mapArea.tsx
@@ -10,13 +10,7 @@ const DynamicMap = dynamic(() => import("./dynamicMap"), {
   loading: () => <div className="h-full w-full bg-gray-100 animate-pulse" />,
 });
 
-interface Props {
-  resultsList: SolrObject[];
-  highlightLyr?: string;
-  highlightIds?: string[];
-}
-
-export default function MapArea(props: Props): JSX.Element {
+export default function MapArea(): JSX.Element {
   const [isMounted, setIsMounted] = useState(false);
   const contiguousBounds: LngLatBoundsLike = [
     -125.3321, 23.8991, -65.7421, 49.4325,

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -5,6 +5,7 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import { AppDispatch, RootState } from "@/store";
 import { useDispatch, useSelector } from "react-redux";
 import { setSubject } from "@/store/slices/searchSlice";
+import {clearMapPreview} from "@/store/slices/uiSlice";
 
 interface Props {
   svgIcon: any;
@@ -36,6 +37,7 @@ const IconTag = (props: Props): JSX.Element => {
     } else {
       newSubjects = [...currentSubjects, sub];
     }
+    dispatch(clearMapPreview());
     dispatch(setSubject(newSubjects));
   };
 

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -21,8 +21,6 @@ const DynamicResultsPanel = dynamic(() => import("./resultsPanel"), {
 });
 
 export default function DiscoveryArea({ schema }): JSX.Element {
-  const [highlightIds, setHighlightIds] = useState([]);
-  const [highlightLyr, setHighlightLyr] = useState("");
   const dispatch = useDispatch<AppDispatch>();
   const { results, relatedResults } = useSelector(
     (state: RootState) => state.search
@@ -60,8 +58,6 @@ export default function DiscoveryArea({ schema }): JSX.Element {
           <Grid item xs={12} sm={4}>
             <DynamicResultsPanel
               schema={schema}
-              setHighlightLyr={setHighlightLyr}
-              setHighlightIds={setHighlightIds}
             />
           </Grid>
           <Grid item xs={12} sm={8} className="sm:ml-[0.5em]">

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -55,12 +55,12 @@ export default function DiscoveryArea({ schema }): JSX.Element {
       </Grid>
       <Grid className="w-full px-[1em] sm:px-[2em]">
         <Grid container className="container mx-auto pt-[1.5rem]">
-          <Grid item xs={12} sm={4}>
+          <Grid item xs={12} sm={5}>
             <DynamicResultsPanel
               schema={schema}
             />
           </Grid>
-          <Grid item xs={12} sm={8} className="sm:ml-[0.5em]">
+          <Grid item xs={12} sm={7} className="sm:ml-[0.5em]">
             <MapPanel
               resultsList={results}
               showMap={showDetailPanel ? "none" : "block"}

--- a/src/components/search/mapPanel/index.tsx
+++ b/src/components/search/mapPanel/index.tsx
@@ -5,8 +5,6 @@ import { SolrObject } from "meta/interface/SolrObject";
 
 interface Props {
   resultsList: SolrObject[];
-  highlightLyr?: string;
-  highlightIds?: string[];
   showMap: string;
   schema: any;
 }

--- a/src/components/search/mapPanel/mapPanelContent.tsx
+++ b/src/components/search/mapPanel/mapPanelContent.tsx
@@ -32,8 +32,6 @@ import dynamic from "next/dynamic";
 
 interface Props {
   resultsList: SolrObject[];
-  highlightLyr?: string;
-  highlightIds?: string[];
   showMap: string;
   schema: any;
 }
@@ -196,11 +194,7 @@ const MapPanelContent = (props: Props): JSX.Element => {
           height: `${SearchUIConfig.search.searchResults.resultListHeight}`,
         }}
       >
-        <DynamicMapArea
-          resultsList={props.resultsList}
-          highlightIds={props.highlightIds}
-          highlightLyr={props.highlightLyr}
-        />
+        <DynamicMapArea/>
       </Box>
       <Box className="sm:my-[1.68em]">
         <div className="sm:mb-[1.5em] sm:flex-col">

--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from "@mui/styles";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import SearchIcon from "@mui/icons-material/Search";
-import { setShowFilter } from "@/store/slices/uiSlice";
+import {clearMapPreview, setShowFilter} from "@/store/slices/uiSlice";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import { Box, SvgIcon, CircularProgress, Fade, Skeleton } from "@mui/material";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
@@ -62,6 +62,7 @@ const ResultsPanel = (props: Props): JSX.Element => {
     dispatch(setShowFilter(!showFilter));
   };
   const handleClearFilters = async () => {
+    dispatch(clearMapPreview());
     setIsResetting(true);
     await resetFilters(store);
     setTimeout(() => {

--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -21,8 +21,6 @@ import ThemeIcons from "../helper/themeIcons";
 
 interface Props {
   schema: any;
-  setHighlightLyr: (value: string) => void;
-  setHighlightIds: (value: string[]) => void;
 }
 
 const fullConfig = resolveConfig(tailwindConfig);
@@ -167,8 +165,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
                         <div key={result.id} className="mb-[0.75em]">
                           <ResultCard
                             resultItem={result}
-                            setHighlightIds={props.setHighlightIds}
-                            setHighlightLyr={props.setHighlightLyr}
                           />
                         </div>
                       ))}
@@ -218,8 +214,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
                             <div key={result.id} className="mb-[0.75em]">
                               <ResultCard
                                 resultItem={result}
-                                setHighlightIds={props.setHighlightIds}
-                                setHighlightLyr={props.setHighlightLyr}
                               />
                             </div>
                           ))}

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -7,13 +7,12 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import IconText from "../iconText";
 import { SolrObject } from "meta/interface/SolrObject";
 import IconMatch from "../helper/IconMatch";
-import { setShowDetailPanel } from "@/store/slices/uiSlice";
+import { setShowDetailPanel, setMapPreview } from "@/store/slices/uiSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store";
 import { Tooltip } from "@mui/material";
 import { getScoreExplanation } from "../helper/FilterByScore";
 import { getAllScoresSelector } from "../../../store/selectors/SearchSelector";
-import { setMapPreview } from "@/store/slices/searchSlice";
 
 interface Props {
   resultItem: SolrObject;
@@ -104,7 +103,7 @@ const ResultCard = (props: Props): JSX.Element => {
   const dispatch = useDispatch();
   const classes = useStyles();
   const { showDetailPanel } = useSelector((state: RootState) => state.ui);
-  const mapPreview = useSelector((state: RootState) => state.search.mapPreview);
+  const mapPreview = useSelector((state: RootState) => state.ui.mapPreview);
   const { maxScore, avgScore } = useSelector(getAllScoresSelector);
 
   const cardContent = props.resultItem && (
@@ -166,6 +165,7 @@ const ResultCard = (props: Props): JSX.Element => {
             <Checkbox
               id={`sc-checkbox-${props.resultItem.id}`}
               value={props.resultItem.meta}
+              disabled={!props.resultItem.meta.highlight_ids?.length}
               onChange={(event) => {
 
                 if (event.target.checked) {

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -17,8 +17,6 @@ import { setMapPreview } from "@/store/slices/searchSlice";
 
 interface Props {
   resultItem: SolrObject;
-  setHighlightLyr: (value: string) => void;
-  setHighlightIds: (value: string[]) => void;
 }
 const fullConfig = resolveConfig(tailwindConfig);
 const useStyles = makeStyles((theme) => ({
@@ -148,14 +146,6 @@ const ResultCard = (props: Props): JSX.Element => {
           showDetailPanel === props.resultItem.id
             ? "0px 4px 4px 0px lightgray"
             : undefined,
-      }}
-      onMouseOver={() => {
-        props.setHighlightLyr(null);
-        props.setHighlightLyr(lyrId);
-        props.setHighlightIds(props.resultItem.meta.sdoh_highlight_ids_sm);
-      }}
-      onMouseOut={() => {
-        props.setHighlightLyr(null);
       }}
     >
       <div className="flex flex-col sm:flex-row items-center mb-2">

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -105,25 +105,6 @@ const ResultCard = (props: Props): JSX.Element => {
   const classes = useStyles();
   const { showDetailPanel } = useSelector((state: RootState) => state.ui);
   const mapPreview = useSelector((state: RootState) => state.search.mapPreview);
-  // show the most detailed geography that a record represents
-  let lyrId: string;
-  const spatial_res = props.resultItem.meta.spatial_resolution
-    ? props.resultItem.meta.spatial_resolution
-    : [];
-  if (
-    spatial_res.includes("Census Block Group") ||
-    spatial_res.includes("Census Block")
-  ) {
-    lyrId = "bg";
-  } else if (spatial_res.includes("Census Tract")) {
-    lyrId = "tract";
-  } else if (spatial_res.includes("County")) {
-    lyrId = "county";
-  } else if (spatial_res.includes("Zip Code Tabulation Area (ZCTA)")) {
-    lyrId = "zcta";
-  } else if (spatial_res.includes("State")) {
-    lyrId = "state";
-  }
   const { maxScore, avgScore } = useSelector(getAllScoresSelector);
 
   const cardContent = props.resultItem && (
@@ -187,20 +168,12 @@ const ResultCard = (props: Props): JSX.Element => {
               value={props.resultItem.meta}
               onChange={(event) => {
 
-                // if highlight_ids are available, ignore spatial_coverage and infer
-                // layer and filterset from these ids.
-                // "add the county layer and filter by the provided ids"
-
-                // otherwise: inspect spatial_resolution to determine the correct layer to add
-                // and then add that layer without any filtering.
-
                 if (event.target.checked) {
                   dispatch(
                     setMapPreview([
                       ...mapPreview,
                       {
-                        id: props.resultItem.id,
-                        source: lyrId,
+                        lyrId: props.resultItem.id,
                         filterIds: props.resultItem.meta.highlight_ids,
                       },
                     ])
@@ -209,7 +182,7 @@ const ResultCard = (props: Props): JSX.Element => {
                   dispatch(
                     setMapPreview(
                       mapPreview.filter(
-                        (item) => item.id != props.resultItem.id
+                        (item) => item.lyrId != props.resultItem.id
                       )
                     )
                   );

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
-import { Checkbox, FormControlLabel } from "@mui/material";
+import {Checkbox, FormControlLabel, Typography} from "@mui/material";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import IconText from "../iconText";
@@ -156,82 +156,6 @@ const ResultCard = (props: Props): JSX.Element => {
             </button>
           </div>
         </div>
-        <FormControlLabel
-          label="Show coverage area"
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-          control={
-            <Checkbox
-              id={`sc-checkbox-${props.resultItem.id}`}
-              value={props.resultItem.meta}
-              disabled={!props.resultItem.meta.highlight_ids?.length}
-              onChange={(event) => {
-
-                if (event.target.checked) {
-                  dispatch(
-                    setMapPreview([
-                      ...mapPreview,
-                      {
-                        lyrId: props.resultItem.id,
-                        filterIds: props.resultItem.meta.highlight_ids,
-                      },
-                    ])
-                  );
-                } else {
-                  dispatch(
-                    setMapPreview(
-                      mapPreview.filter(
-                        (item) => item.lyrId != props.resultItem.id
-                      )
-                    )
-                  );
-                }
-              }}
-              icon={
-                <span
-                  style={{
-                    borderRadius: "4px",
-                    border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
-                    width: "24px",
-                    height: "24px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: "transparent",
-                  }}
-                ></span>
-              }
-              checkedIcon={
-                <span
-                  style={{
-                    borderRadius: "4px",
-                    border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
-                    width: "24px",
-                    height: "24px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: `${fullConfig.theme.colors["frenchviolet"]}`,
-                  }}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="white"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    style={{ width: "16px", height: "16px" }}
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                </span>
-              }
-            />
-          }
-        />
       </div>
       <div className="flex flex-col sm:flex-row sm:mt-4">
         <div className="flex-1 w-full sm:w-1/2">
@@ -274,6 +198,92 @@ const ResultCard = (props: Props): JSX.Element => {
               : ""}
           </div>
         </div>
+      </div>
+
+      {/* Checkbox : Show coverage area on map */}
+      <div>
+        <FormControlLabel
+          disabled={!props.resultItem.meta.highlight_ids?.length}
+          title={!props.resultItem.meta.highlight_ids?.length ? 'No geographic areas have been defined for this dataset' : 'Preview the geographic areas that this dataset covers'}
+          label={<div style={{
+            color: `${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["almostblack"] : fullConfig.theme.colors["darkgray"]}`,
+            padding: 0,
+            fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+            fontWeight: 400,
+            fontSize: "0.875rem" }}>Show coverage area</div>}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          control={
+            <Checkbox
+              id={`sc-checkbox-${props.resultItem.id}`}
+              value={props.resultItem.meta}
+              onChange={(event) => {
+
+                if (event.target.checked) {
+                  dispatch(
+                    setMapPreview([
+                      ...mapPreview,
+                      {
+                        lyrId: props.resultItem.id,
+                        filterIds: props.resultItem.meta.highlight_ids,
+                      },
+                    ])
+                  );
+                } else {
+                  dispatch(
+                    setMapPreview(
+                      mapPreview.filter(
+                        (item) => item.lyrId != props.resultItem.id
+                      )
+                    )
+                  );
+                }
+              }}
+              icon={
+                <span
+                  style={{
+                    borderRadius: "4px",
+                    border: `2px solid ${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["frenchviolet"] : fullConfig.theme.colors["darkgray"]}`,
+                    width: "14px",
+                    height: "14px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundColor: "transparent",
+                  }}
+                ></span>
+              }
+              checkedIcon={
+                <span
+                  style={{
+                    borderRadius: "4px",
+                    border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
+                    width: "14px",
+                    height: "14px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundColor: `${fullConfig.theme.colors["frenchviolet"]}`,
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    style={{ width: "16px", height: "16px" }}
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                </span>
+              }
+            />
+          }
+        />
       </div>
     </div>
   );

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
+import { Checkbox, FormControlLabel } from "@mui/material";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import IconText from "../iconText";
@@ -12,6 +13,7 @@ import { RootState } from "@/store";
 import { Tooltip } from "@mui/material";
 import { getScoreExplanation } from "../helper/FilterByScore";
 import { getAllScoresSelector } from "../../../store/selectors/SearchSelector";
+import { setMapPreview } from "@/store/slices/searchSlice";
 
 interface Props {
   resultItem: SolrObject;
@@ -104,6 +106,7 @@ const ResultCard = (props: Props): JSX.Element => {
   const dispatch = useDispatch();
   const classes = useStyles();
   const { showDetailPanel } = useSelector((state: RootState) => state.ui);
+  const mapPreview = useSelector((state: RootState) => state.search.mapPreview);
   // show the most detailed geography that a record represents
   let lyrId: string;
   const spatial_res = props.resultItem.meta.spatial_resolution
@@ -183,6 +186,89 @@ const ResultCard = (props: Props): JSX.Element => {
             </button>
           </div>
         </div>
+        <FormControlLabel
+          label="Show coverage area"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          control={
+            <Checkbox
+              id={`sc-checkbox-${props.resultItem.id}`}
+              value={props.resultItem.meta}
+              onChange={(event) => {
+
+                // if highlight_ids are available, ignore spatial_coverage and infer
+                // layer and filterset from these ids.
+                // "add the county layer and filter by the provided ids"
+
+                // otherwise: inspect spatial_resolution to determine the correct layer to add
+                // and then add that layer without any filtering.
+
+                if (event.target.checked) {
+                  dispatch(
+                    setMapPreview([
+                      ...mapPreview,
+                      {
+                        id: props.resultItem.id,
+                        source: lyrId,
+                        filterIds: props.resultItem.meta.highlight_ids,
+                      },
+                    ])
+                  );
+                } else {
+                  dispatch(
+                    setMapPreview(
+                      mapPreview.filter(
+                        (item) => item.id != props.resultItem.id
+                      )
+                    )
+                  );
+                }
+              }}
+              icon={
+                <span
+                  style={{
+                    borderRadius: "4px",
+                    border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
+                    width: "24px",
+                    height: "24px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundColor: "transparent",
+                  }}
+                ></span>
+              }
+              checkedIcon={
+                <span
+                  style={{
+                    borderRadius: "4px",
+                    border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
+                    width: "24px",
+                    height: "24px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundColor: `${fullConfig.theme.colors["frenchviolet"]}`,
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    style={{ width: "16px", height: "16px" }}
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                </span>
+              }
+            />
+          }
+        />
       </div>
       <div className="flex flex-col sm:flex-row sm:mt-4">
         <div className="flex-1 w-full sm:w-1/2">

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -21,7 +21,13 @@ import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import { AppDispatch, RootState } from "@/store";
 import { setQuery, fetchSuggestions, setInputValue } from "@/store/slices/searchSlice";
-import { setShowInfoPanel, setShowClearButton, setShowDetailPanel, setMapPreview } from "@/store/slices/uiSlice";
+import {
+  setShowInfoPanel,
+  setShowClearButton,
+  setShowDetailPanel,
+  setMapPreview,
+  clearMapPreview
+} from "@/store/slices/uiSlice";
 import SpellCheckMessage from "./spellCheckMessage";
 interface Props {
   schema: any;
@@ -104,6 +110,7 @@ const SearchBox = ({ schema }: Props): JSX.Element => {
   const performSearch = React.useCallback(
     (searchValue: string | null) => {
       if (searchValue) {
+        dispatch(clearMapPreview());
         dispatch(setQuery(searchValue));
         dispatch(setShowDetailPanel(null));
       }

--- a/src/components/search/searchArea/searchBox.tsx
+++ b/src/components/search/searchArea/searchBox.tsx
@@ -20,9 +20,8 @@ import { makeStyles } from "@mui/styles";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import { AppDispatch, RootState } from "@/store";
-import { setQuery, fetchSuggestions } from "@/store/slices/searchSlice";
-import { setInputValue } from "@/store/slices/searchSlice";
-import { setShowInfoPanel, setShowClearButton, setShowDetailPanel } from "@/store/slices/uiSlice";
+import { setQuery, fetchSuggestions, setInputValue } from "@/store/slices/searchSlice";
+import { setShowInfoPanel, setShowClearButton, setShowDetailPanel, setMapPreview } from "@/store/slices/uiSlice";
 import SpellCheckMessage from "./spellCheckMessage";
 interface Props {
   schema: any;
@@ -154,6 +153,7 @@ const SearchBox = ({ schema }: Props): JSX.Element => {
     dispatch(setQuery(null));
     dispatch(setShowDetailPanel(null));
     dispatch(setShowClearButton(false));
+    dispatch(setMapPreview([]))
   };
   const isIOS = React.useMemo(() => {
     if (

--- a/src/components/search/searchArea/spatialResolutionCheck.tsx
+++ b/src/components/search/searchArea/spatialResolutionCheck.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from "@mui/material";
 import tailwindConfig from "tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import { RootState } from "@/store";
-import { setSpatialResolution, setVisLyrs } from "@/store/slices/searchSlice";
+import { setSpatialResolution } from "@/store/slices/searchSlice";
 import { useDispatch, useSelector } from "react-redux";
 interface SpatialResolutionCheck {
   value: string;
@@ -50,7 +50,6 @@ const SpatialResolutionCheck = (props: Props): JSX.Element => {
       .filter((box) => box.checked)
       .map((box) => box.value);
     dispatch(setSpatialResolution(selectedValues));
-    dispatch(setVisLyrs(selectedValues));
   };
 
   return (

--- a/src/middleware/actionConfig.ts
+++ b/src/middleware/actionConfig.ts
@@ -39,26 +39,6 @@ export const actionConfig: Record<string, ActionConfig> = {
       fromUrl: (value: string) => value.split(",").filter(Boolean),
     },
   },
-  "search/setVisOverlays": {
-    param: "vis_overlays",
-    syncWithUrl: false,
-    requiresFetch: false,
-    isFilter: true,
-    transform: {
-      toUrl: (value: string[]) => value.join(","),
-      fromUrl: (value: string) => value.split(",").filter(Boolean),
-    },
-  },
-  "search/setVisLyrs": {
-    param: "layers",
-    syncWithUrl: true,
-    requiresFetch: false,
-    isFilter: true,
-    transform: {
-      toUrl: (value: string[]) => value.join(","),
-      fromUrl: (value: string) => value.split(",").filter(Boolean),
-    },
-  },
   "search/setBbox": {
     param: "bbox",
     syncWithUrl: true,

--- a/src/middleware/filterHelper.ts
+++ b/src/middleware/filterHelper.ts
@@ -172,6 +172,7 @@ export const resetFilters = async (store: any) => {
   filterActions.forEach((action) => {
     store.dispatch(action);
   });
+  store.dispatch({type: "search/setMapPreview", payload: []})
   if (isBrowser) {
     const searchParams = new URLSearchParams(window.location.search);
     Object.entries(actionConfig)

--- a/src/middleware/filterHelper.ts
+++ b/src/middleware/filterHelper.ts
@@ -127,14 +127,6 @@ export const generateFilterQueries = (searchState: any) => {
       });
     }
   }
-  if (searchState.visLyrs?.length) {
-    searchState.visLyrs.forEach((value: string) => {
-      queries.push({
-        attribute: "vis_lyrs",
-        value,
-      });
-    });
-  }
   return queries;
 };
 

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -254,6 +254,9 @@ const searchSlice = createSlice({
     setVisLyrs: (state, action) => {
       state.visLyrs = action.payload;
     },
+    setMapPreview: (state, action) => {
+      state.mapPreview = action.payload;
+    },
     setSubject: (state, action) => {
       state.subject = action.payload;
     },
@@ -386,6 +389,7 @@ export const {
   setBbox,
   setVisOverlays,
   setVisLyrs,
+  setMapPreview,
   setSubject,
   setSpatialResolution,
   setIndexYear,

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -254,9 +254,6 @@ const searchSlice = createSlice({
     setVisLyrs: (state, action) => {
       state.visLyrs = action.payload;
     },
-    setMapPreview: (state, action) => {
-      state.mapPreview = action.payload;
-    },
     setSubject: (state, action) => {
       state.subject = action.payload;
     },
@@ -389,7 +386,6 @@ export const {
   setBbox,
   setVisOverlays,
   setVisLyrs,
-  setMapPreview,
   setSubject,
   setSpatialResolution,
   setIndexYear,

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -251,9 +251,6 @@ const searchSlice = createSlice({
     setVisOverlays: (state, action) => {
       state.visOverlays = action.payload;
     },
-    setVisLyrs: (state, action) => {
-      state.visLyrs = action.payload;
-    },
     setSubject: (state, action) => {
       state.subject = action.payload;
     },
@@ -385,7 +382,6 @@ export const {
   setSortOrder,
   setBbox,
   setVisOverlays,
-  setVisLyrs,
   setSubject,
   setSpatialResolution,
   setIndexYear,

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -47,6 +47,9 @@ const uiSlice = createSlice({
     setShowSharedLink: (state, action) => {
       state.showSharedLink = action.payload;
     },
+    clearMapPreview: (state, action) => {
+      state.mapPreview = [];
+    },
     setMapPreview: (state, action) => {
       state.mapPreview = action.payload;
     },
@@ -61,6 +64,7 @@ export const {
   setShowClearButton,
   setShowSharedLink,
   setMapPreview,
+  clearMapPreview
 } = uiSlice.actions;
 
 export default uiSlice.reducer;

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -47,7 +47,7 @@ const uiSlice = createSlice({
     setShowSharedLink: (state, action) => {
       state.showSharedLink = action.payload;
     },
-    clearMapPreview: (state, action) => {
+    clearMapPreview: (state) => {
       state.mapPreview = [];
     },
     setMapPreview: (state, action) => {

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -1,5 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+interface MapPreviewLyr {
+  lyrId: string;
+  filterIds: string[];
+}
+
 interface UIState {
   pageFirstLoad: boolean;
   showInfoPanel: boolean;
@@ -7,6 +12,7 @@ interface UIState {
   showFilter: boolean;
   showClearButton: boolean;
   showSharedLink: boolean;
+  mapPreview: MapPreviewLyr[];
 }
 
 const initialState: UIState = {
@@ -16,6 +22,7 @@ const initialState: UIState = {
   showFilter: false,
   showClearButton: false,
   showSharedLink: false,
+  mapPreview: [],
 };
 
 const uiSlice = createSlice({
@@ -40,6 +47,9 @@ const uiSlice = createSlice({
     setShowSharedLink: (state, action) => {
       state.showSharedLink = action.payload;
     },
+    setMapPreview: (state, action) => {
+      state.mapPreview = action.payload;
+    },
   },
 });
 
@@ -50,6 +60,7 @@ export const {
   setShowFilter,
   setShowClearButton,
   setShowSharedLink,
+  setMapPreview,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;

--- a/src/store/types/search.ts
+++ b/src/store/types/search.ts
@@ -1,8 +1,3 @@
-interface MapPreviewLyr {
-  lyrId: string;
-  filterIds: string[];
-}
-
 export interface SearchState {
   schema: any;
   // object
@@ -30,7 +25,6 @@ export interface SearchState {
   // map
   visOverlays: string[];
   visLyrs: string[];
-  mapPreview: MapPreviewLyr[];
   bbox: [number, number, number, number] | null;
 
   // status
@@ -55,7 +49,6 @@ export const initialState: SearchState = {
   spatialResolution: [],
   visOverlays: [],
   visLyrs: [],
-  mapPreview: [],
   indexYear: [],
   spellCheck: "",
   originalQuery: "",

--- a/src/store/types/search.ts
+++ b/src/store/types/search.ts
@@ -1,7 +1,6 @@
 interface MapPreviewLyr {
-  id: string;
-  source: string;
-  filterIds?: string[];
+  lyrId: string;
+  filterIds: string[];
 }
 
 export interface SearchState {

--- a/src/store/types/search.ts
+++ b/src/store/types/search.ts
@@ -24,7 +24,6 @@ export interface SearchState {
 
   // map
   visOverlays: string[];
-  visLyrs: string[];
   bbox: [number, number, number, number] | null;
 
   // status
@@ -48,7 +47,6 @@ export const initialState: SearchState = {
   subject: [],
   spatialResolution: [],
   visOverlays: [],
-  visLyrs: [],
   indexYear: [],
   spellCheck: "",
   originalQuery: "",

--- a/src/store/types/search.ts
+++ b/src/store/types/search.ts
@@ -1,3 +1,9 @@
+interface MapPreviewLyr {
+  id: string;
+  source: string;
+  filterIds?: string[];
+}
+
 export interface SearchState {
   schema: any;
   // object
@@ -25,6 +31,7 @@ export interface SearchState {
   // map
   visOverlays: string[];
   visLyrs: string[];
+  mapPreview: MapPreviewLyr[];
   bbox: [number, number, number, number] | null;
 
   // status
@@ -49,6 +56,7 @@ export const initialState: SearchState = {
   spatialResolution: [],
   visOverlays: [],
   visLyrs: [],
+  mapPreview: [],
   indexYear: [],
   spellCheck: "",
   originalQuery: "",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,6 @@
     "incremental": true,
     "paths": {
       "@/*": ["src/*"],
-      "@/components/*": ["src/components/*"],
-      "@/hooks/*": ["src/hooks/*"],
       "@/public/*": ["public/*"]
     }
   },


### PR DESCRIPTION
This PR adds a new feature that allows users to check a box on each result item to add a preview layer to the map that shows the spatial coverage for a given dataset.

Closes #408 

We had something like this before on hover of the result item, but this is more explicit, and the implementation also offers a lot more flexibility in how the preview layer is constructed.

In the metadata schema we have a field "Highlight IDs" that must be filled out with one or more "HEROP_IDs", and that field powers this preview. The first three characters of a HEROP_ID denote what geography level the rest of the ID pertains to, and this is used to denote what geography layer is used for the preview layer. For a full explanation of HEROP_IDs, see: https://github.com/healthyregions. There are two ways to fill out the field.

1. With a * wildcard to show all geographies matching a pattern
2. With a list of specific HEROP_IDs to show a certain set of geographies

Examples of wildcards:

- All states: `040US*`
- All counties within Illinois: `050US17*`
- All ZCTAs: `860US*`
- All tracts in Cook County, Illinois: `140US17031*`

Examples of individual ID lists:

- Only show the state of Illinois: `040US17`
- Show counties around Chicago:
    ```
    040US17089
    040US17043
    040US17031
    040US17093
    040US17197
    ```

Here is a mockup example showing all counties in Illinois (though this dataset actually has a wider coverage area)
![image](https://github.com/user-attachments/assets/99190936-c853-4a6d-ade0-27e3f9ef3e1e)

Big thanks to @bodom0015 for working through all of this with me!
