### PR TITLE
#416: remove the initial state on sort

### DIFF
--- a/src/components/search/helper/CleanHtml.tsx
+++ b/src/components/search/helper/CleanHtml.tsx
@@ -1,5 +1,0 @@
-export const stripHtmlTags = (html: string | null | undefined) => {
-  if (!html) return "";
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  return doc.body.textContent || "";
-};

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -2,7 +2,6 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import SolrQueryBuilder from "../../components/search/helper/SolrQueryBuilder";
 import { generateSolrObjectList } from "meta/helper/solrObjects";
 import { initialState, SolrSuggestResponse } from "@/store/types/search";
-import { stripHtmlTags } from "@/components/search/helper/CleanHtml";
 import { generateFilterQueries } from "@/middleware/filterHelper";
 import { setShowClearButton } from "./uiSlice";
 

--- a/src/store/types/search.ts
+++ b/src/store/types/search.ts
@@ -42,7 +42,7 @@ export const initialState: SearchState = {
   results: [],
   relatedResults: [],
   suggestions: [],
-  sortBy: "score",
+  sortBy: "",
   sortOrder: "desc",
   bbox: null,
   subject: [],


### PR DESCRIPTION
This PR addresses issue #416 and removes the default sorting configuration from the front-end. The corresponding Solr configuration is available in [SDOHPlace-MetadataManager PR #39](https://github.com/healthyregions/SDOHPlace-MetadataManager/pull/39).

## How to Test
1. Navigate to search page. You should see that results are sorted by title by default.
<img width="1411" alt="Screenshot 2025-01-17 at 3 13 12 PM" src="https://github.com/user-attachments/assets/18c286b8-c81d-49c5-a975-1e3b1affe070" />

2. Perform any search. Results should now be sorted by score.
<img width="1364" alt="Screenshot 2025-01-17 at 3 13 45 PM" src="https://github.com/user-attachments/assets/80d3fe1d-0d44-4c4a-8d3a-d8e9f8c12976" />

3. Clear the search term in the Search Box. A re-fetch action should be triggered, and the results should once again be sorted by title.