### PR TITLE
Improved help text

### DIFF
--- a/src/components/search/mapPanel/mapPanelContent.tsx
+++ b/src/components/search/mapPanel/mapPanelContent.tsx
@@ -29,6 +29,7 @@ import { setSchema, setVisOverlays } from "@/store/slices/searchSlice";
 import { overlayRegistry } from "../../map/helper/layers";
 import { localStyles } from "../../../lib/localStyles";
 import dynamic from "next/dynamic";
+import { setShowInfoPanel, setInfoPanelTab } from "@/store/slices/uiSlice";
 
 interface Props {
   resultsList: SolrObject[];
@@ -117,49 +118,18 @@ const MapPanelContent = (props: Props): JSX.Element => {
             />
             {overlaysBtnTxt}
           </Button>
-          <Button
-            id="basic-button"
-            className="flex items-center sm:justify-end mt-0 order-1 sm:order-none flex-none text-l-500 sm:mr-[2.3em]"
-            style={{ color: fullConfig.theme.colors["frenchviolet"] }}
-            aria-controls={infoOpen ? "info-popover" : undefined}
-            aria-haspopup="true"
-            aria-expanded={infoOpen ? "true" : undefined}
-            onClick={handleInfoClick}
-          >
-            <SvgIcon
-              component={InfoOutlinedIcon}
-              sx={{
-                color: fullConfig.theme.colors["frenchviolet"],
+          <Box component="span" className="mx-2">
+            <a
+              onClick={() => {
+                dispatch(setShowInfoPanel(true));
+                dispatch(setInfoPanelTab(3))
               }}
-            />
-          </Button>
-          <Popover
-            id="info-popover"
-            open={infoOpen}
-            anchorEl={infoAnchorEl}
-            onClose={handleInfoClose}
-            anchorOrigin={{
-              vertical: "bottom",
-              horizontal: "left",
-            }}
-          >
-            <Box className="py-2 px-4 rounded bg-lightbisque">
-              <p className="text-almostblack font-sans text-sm">
-                Overlays created from{" "}
-                <Link
-                  href="https://docs.overturemaps.org/guides/places/"
-                  target="_blank"
-                >
-                  Places
-                </Link>{" "}
-                theme,{" "}
-                <Link href="https://overturemaps.org" target="_blank">
-                  Overture Maps Foundation
-                </Link>
-                .
-              </p>
-            </Box>
-          </Popover>
+              style={{ cursor: "pointer" }}
+              className="no-underline text-frenchviolet"
+            >
+              <InfoOutlinedIcon />
+            </a>
+          </Box>
           <Menu
             id="basic-menu"
             className="flex items-center sm:justify-end mt-0 order-1 sm:order-none flex-none text-l-500 sm:mr-[2.3em]"

--- a/src/components/search/searchArea/index.tsx
+++ b/src/components/search/searchArea/index.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { makeStyles } from "@mui/styles";
 import { Box, Grid } from "@mui/material";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { SearchUIConfig } from "@/components/searchUIConfig";
 import GlossaryPopover from "@/components/GlossaryPopover";
 import tailwindConfig from "../../../../tailwind.config";
@@ -10,6 +11,7 @@ import SearchBox from "./searchBox";
 import InfoPanel from "./infoPanel";
 import { RootState } from "@/store";
 import SpatialResolutionCheck from "./spatialResolutionCheck";
+import { setShowInfoPanel, setInfoPanelTab } from "@/store/slices/uiSlice";
 
 interface Props {
   header: string;
@@ -24,6 +26,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const SearchArea = (props: Props): JSX.Element => {
+  const dispatch = useDispatch()
   const classes = useStyles();
   const { showInfoPanel } = useSelector((state: RootState) => state.ui);
 
@@ -42,9 +45,17 @@ const SearchArea = (props: Props): JSX.Element => {
           className="text-s text-center sm:text-left sm:mt-[1em]"
           style={{ textWrap: "balance" }}
         >
-          Our data discovery platform provides access to spatially indexed and
-          curated databases, specifically designed for conducting{" "}
-          <GlossaryPopover entry={"health equity"} /> research.
+          This platform provides access to spatially indexed and
+          curated databases, specifically designed for conducting health equity research. <a
+          onClick={() => {
+            dispatch(setShowInfoPanel(true));
+            dispatch(setInfoPanelTab(0));
+          }}
+          style={{ cursor: "pointer" }}
+          className="no-underline text-frenchviolet"
+        >
+          Get started &rarr;
+        </a>
         </div>
       </Grid>
       <Grid
@@ -72,7 +83,7 @@ const SearchArea = (props: Props): JSX.Element => {
           </Box>
         ) : (
           <div>
-            <div className="flex items-center space-x-10 md:ml-[6em] md:mr-[5.3125em]">
+            <div className="flex items-center space-x-10">
               <InfoPanel />
             </div>
           </div>

--- a/src/components/search/searchArea/index.tsx
+++ b/src/components/search/searchArea/index.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const SearchArea = (props: Props): JSX.Element => {
-  const dispatch = useDispatch()
+  const dispatch = useDispatch();
   const classes = useStyles();
   const { showInfoPanel } = useSelector((state: RootState) => state.ui);
 
@@ -45,17 +45,19 @@ const SearchArea = (props: Props): JSX.Element => {
           className="text-s text-center sm:text-left sm:mt-[1em]"
           style={{ textWrap: "balance" }}
         >
-          This platform provides access to spatially indexed and
-          curated databases, specifically designed for conducting health equity research. <a
-          onClick={() => {
-            dispatch(setShowInfoPanel(true));
-            dispatch(setInfoPanelTab(0));
-          }}
-          style={{ cursor: "pointer" }}
-          className="no-underline text-frenchviolet"
-        >
-          Get started &rarr;
-        </a>
+          This platform provides access to spatially indexed and curated
+          databases, specifically designed for conducting health equity
+          research.{" "}
+          <a
+            onClick={() => {
+              dispatch(setShowInfoPanel(true));
+              dispatch(setInfoPanelTab(0));
+            }}
+            style={{ cursor: "pointer" }}
+            className="no-underline text-frenchviolet"
+          >
+            <strong>Get started &rarr;</strong>
+          </a>
         </div>
       </Grid>
       <Grid

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -4,7 +4,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import CloseIcon from "@mui/icons-material/Close";
 import tailwindConfig from "tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
-import { Box, Tabs, Tab, IconButton, Typography } from "@mui/material";
+import { Box, Tabs, Tab, IconButton, Typography, List, ListItem, Divider, Link } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store";
 import { setShowInfoPanel, setInfoPanelTab } from "@/store/slices/uiSlice";
@@ -22,6 +22,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 function CustomTabPanel(props: Props) {
+  const dispatch = useDispatch();
   const { children, value, index, ...other } = props;
   return (
     <div
@@ -31,7 +32,34 @@ function CustomTabPanel(props: Props) {
       aria-labelledby={`simple-tab-${index}`}
       {...other}
     >
-      {value === index && <Box sx={{ p: 3, pl: 0 }}>{children}</Box>}
+      {value === index && <Box sx={{ py: 3 }}>
+        <Box sx={{height:"200px", overflowY:"auto"}}>
+        {children}
+        </Box>
+        <Divider sx={{py:1}}/>
+        {value != 0 && (
+          <a
+            onClick={() => {
+              dispatch(setInfoPanelTab(value-1));
+            }}
+            style={{ cursor: "pointer" }}
+            className="no-underline text-frenchviolet"
+          >
+            &larr; Previous&nbsp;&nbsp;
+          </a>
+        )}
+        {value != 3 && (
+          <a
+            onClick={() => {
+              dispatch(setInfoPanelTab(value+1));
+            }}
+            style={{ cursor: "pointer" }}
+            className="no-underline text-frenchviolet"
+          >
+            Next &rarr;
+          </a>
+        )}
+      </Box>}
     </div>
   );
 }
@@ -45,7 +73,6 @@ export default function InfoPanel() {
   const dispatch = useDispatch();
   const classes = useStyles();
   const { infoPanelTab } = useSelector((state: RootState) => state.ui);
-  const [maxHeight, setMaxHeight] = React.useState(0);
   const tabPanelRef = React.useRef(null);
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     dispatch(setInfoPanelTab(newValue));
@@ -53,16 +80,6 @@ export default function InfoPanel() {
   const handleClosePanel = () => {
     dispatch(setShowInfoPanel(false));
   };
-  React.useEffect(() => {
-    if (tabPanelRef.current) {
-      const panels = Array.from(tabPanelRef.current.children) as HTMLElement[];
-      const maxContentHeight = panels.reduce(
-        (maxHeight, panel) => Math.max(maxHeight, panel.scrollHeight),
-        0
-      );
-      setMaxHeight(maxContentHeight);
-    }
-  }, []);
   return (
     <div className={`${classes.infoPanel}`}>
       <Box
@@ -74,25 +91,9 @@ export default function InfoPanel() {
           alignItems: "center",
         }}
       >
-        <IconButton
-          onClick={handleClosePanel}
-          style={{
-            position: "absolute",
-            left: -72,
-            top: 4,
-            color: fullConfig.theme.colors["frenchviolet"],
-          }}
-        >
-          <InfoOutlinedIcon />
-        </IconButton>
-
         <Tabs
           value={infoPanelTab}
           onChange={handleChange}
-          sx={{
-            paddingLeft: "2em",
-            minWidth: "fit-content",
-          }}
           TabIndicatorProps={{
             style: {
               backgroundColor: fullConfig.theme.colors["frenchviolet"],
@@ -101,7 +102,7 @@ export default function InfoPanel() {
           }}
         >
           <Tab
-            sx={{ paddingRight: "2em" }}
+            sx={{ paddingRight: "1em" }}
             label={
               <Typography
                 sx={{
@@ -114,13 +115,14 @@ export default function InfoPanel() {
                       : fullConfig.theme.colors["almostblack"],
                 }}
               >
-                Spatial resolution
+                Getting started
               </Typography>
             }
+            wrapped
             {...a11yProps(0)}
           />
           <Tab
-            sx={{ paddingRight: "2em" }}
+            sx={{ paddingRight: "1em" }}
             label={
               <Typography
                 sx={{
@@ -133,10 +135,48 @@ export default function InfoPanel() {
                       : fullConfig.theme.colors["almostblack"],
                 }}
               >
-                Search keywords
+                Making queries
               </Typography>
             }
             {...a11yProps(1)}
+          />
+          <Tab
+            sx={{ paddingRight: "1em" }}
+            label={
+              <Typography
+                sx={{
+                  textTransform: "none",
+                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                  fontWeight: 500,
+                  color:
+                    infoPanelTab === 2
+                      ? fullConfig.theme.colors["frenchviolet"]
+                      : fullConfig.theme.colors["almostblack"],
+                }}
+              >
+                Geography filters
+              </Typography>
+            }
+            {...a11yProps(2)}
+          />
+          <Tab
+            sx={{ paddingRight: "1em" }}
+            label={
+              <Typography
+                sx={{
+                  textTransform: "none",
+                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                  fontWeight: 500,
+                  color:
+                    infoPanelTab === 3
+                      ? fullConfig.theme.colors["frenchviolet"]
+                      : fullConfig.theme.colors["almostblack"],
+                }}
+              >
+                Map overlays
+              </Typography>
+            }
+            {...a11yProps(3)}
           />
         </Tabs>
 
@@ -154,24 +194,37 @@ export default function InfoPanel() {
       </Box>
       <Box
         sx={{
-          minHeight: maxHeight,
-          transition: "height 0.3s ease",
+          transition: "left 0.3s linear",
         }}
         ref={tabPanelRef}
       >
         <CustomTabPanel value={infoPanelTab} index={0}>
-          Spatial resolution is the level of geographic detail of how the data
-          is displayed: state (largest, most general level), county (subdivision
-          of a state, including multiple cities and towns), census tract
-          (smaller geographical unit), block group (smallest unit, a subdivision
-          of census tract), and ZIP Code.
+        You can begin your search by first selecting a geographic scale&mdash;such as state, county, or census tract&mdash;as an initial filter. This allows you to narrow down the scope of your query to a specific level of spatial detail. After applying this geographic filter, you can enter keywords of interest to search within the filtered results. 
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={1}>
           If you know the general SDOH topic you are interested in finding data
           for, first try the themes in the <strong>Sort & Filter</strong> panel
-          at left. Not finding the theme you want? Try typing it into the search
+          at left. Not finding the theme you want? Try typing it into the main search
           bar to see if it appears in the auto-suggest dropdown, or just click
           &rarr; and see what you find!
+        </CustomTabPanel>
+        <CustomTabPanel value={infoPanelTab} index={2}>
+          Some sources provide data at the state level, while others may provide data at smaller resolutions
+          like county or tract level. The interface makes it easy to filter by this geography level, or "spatial resolution",
+          allowing you to find only data relevant for your work.
+          <List>
+            <ListItem>State (largest, most general level)</ListItem>
+            <ListItem>County (subdivision of a state)</ListItem>
+            <ListItem>Census Tract (smaller geographical unit),</ListItem>
+            <ListItem>Block Group (smallest unit, a subdivision of census tract)</ListItem>
+            <ListItem>ZIP Code Tabulation Area (ZCTA)</ListItem>
+          </List>
+        </CustomTabPanel>
+        <CustomTabPanel value={infoPanelTab} index={3}>
+          We provide a few map overlay layers that can be used as reference data during your search.
+          <List>
+            <ListItem>Parks (<Link href="https://overturemaps.org/">Overture Maps foundation</Link>)</ListItem>
+          </List>
         </CustomTabPanel>
       </Box>
     </div>

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -4,7 +4,17 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import CloseIcon from "@mui/icons-material/Close";
 import tailwindConfig from "tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
-import { Box, Tabs, Tab, IconButton, Typography, List, ListItem, Divider, Link } from "@mui/material";
+import {
+  Box,
+  Tabs,
+  Tab,
+  IconButton,
+  Typography,
+  List,
+  ListItem,
+  Divider,
+  Link,
+} from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store";
 import { setShowInfoPanel, setInfoPanelTab } from "@/store/slices/uiSlice";
@@ -21,6 +31,13 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
   },
 }));
+const tabTitles = [
+  "Getting started",
+  "Search results",
+  "Keyword searches",
+  "Geography filters",
+  "Map overlays",
+];
 function CustomTabPanel(props: Props) {
   const dispatch = useDispatch();
   const { children, value, index, ...other } = props;
@@ -32,34 +49,34 @@ function CustomTabPanel(props: Props) {
       aria-labelledby={`simple-tab-${index}`}
       {...other}
     >
-      {value === index && <Box sx={{ py: 3 }}>
-        <Box sx={{height:"200px", overflowY:"auto"}}>
-        {children}
+      {value === index && (
+        <Box sx={{ py: 1 }}>
+          <Box sx={{ height: "200px", overflowY: "auto" }}>{children}</Box>
+          <Divider sx={{ mb: 1 }} />
+          {value != 0 && (
+            <a
+              onClick={() => {
+                dispatch(setInfoPanelTab(value - 1));
+              }}
+              style={{ cursor: "pointer" }}
+              className="no-underline text-frenchviolet"
+            >
+              &larr; Previous&nbsp;&nbsp;
+            </a>
+          )}
+          {value != tabTitles.length - 1 && (
+            <a
+              onClick={() => {
+                dispatch(setInfoPanelTab(value + 1));
+              }}
+              style={{ cursor: "pointer" }}
+              className="no-underline text-frenchviolet"
+            >
+              Next &rarr;
+            </a>
+          )}
         </Box>
-        <Divider sx={{py:1}}/>
-        {value != 0 && (
-          <a
-            onClick={() => {
-              dispatch(setInfoPanelTab(value-1));
-            }}
-            style={{ cursor: "pointer" }}
-            className="no-underline text-frenchviolet"
-          >
-            &larr; Previous&nbsp;&nbsp;
-          </a>
-        )}
-        {value != 3 && (
-          <a
-            onClick={() => {
-              dispatch(setInfoPanelTab(value+1));
-            }}
-            style={{ cursor: "pointer" }}
-            className="no-underline text-frenchviolet"
-          >
-            Next &rarr;
-          </a>
-        )}
-      </Box>}
+      )}
     </div>
   );
 }
@@ -69,6 +86,7 @@ function a11yProps(index: number) {
     "aria-controls": `simple-tabpanel-${index}`,
   };
 }
+
 export default function InfoPanel() {
   const dispatch = useDispatch();
   const classes = useStyles();
@@ -101,83 +119,29 @@ export default function InfoPanel() {
             },
           }}
         >
-          <Tab
-            sx={{ paddingRight: "1em" }}
-            label={
-              <Typography
-                sx={{
-                  textTransform: "none",
-                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
-                  fontWeight: 500,
-                  color:
-                    infoPanelTab === 0
-                      ? fullConfig.theme.colors["frenchviolet"]
-                      : fullConfig.theme.colors["almostblack"],
-                }}
-              >
-                Getting started
-              </Typography>
-            }
-            wrapped
-            {...a11yProps(0)}
-          />
-          <Tab
-            sx={{ paddingRight: "1em" }}
-            label={
-              <Typography
-                sx={{
-                  textTransform: "none",
-                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
-                  fontWeight: 500,
-                  color:
-                    infoPanelTab === 1
-                      ? fullConfig.theme.colors["frenchviolet"]
-                      : fullConfig.theme.colors["almostblack"],
-                }}
-              >
-                Making queries
-              </Typography>
-            }
-            {...a11yProps(1)}
-          />
-          <Tab
-            sx={{ paddingRight: "1em" }}
-            label={
-              <Typography
-                sx={{
-                  textTransform: "none",
-                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
-                  fontWeight: 500,
-                  color:
-                    infoPanelTab === 2
-                      ? fullConfig.theme.colors["frenchviolet"]
-                      : fullConfig.theme.colors["almostblack"],
-                }}
-              >
-                Geography filters
-              </Typography>
-            }
-            {...a11yProps(2)}
-          />
-          <Tab
-            sx={{ paddingRight: "1em" }}
-            label={
-              <Typography
-                sx={{
-                  textTransform: "none",
-                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
-                  fontWeight: 500,
-                  color:
-                    infoPanelTab === 3
-                      ? fullConfig.theme.colors["frenchviolet"]
-                      : fullConfig.theme.colors["almostblack"],
-                }}
-              >
-                Map overlays
-              </Typography>
-            }
-            {...a11yProps(3)}
-          />
+          {tabTitles.map((title, index) => (
+            <Tab
+              key={index}
+              sx={{ paddingRight: "1em" }}
+              label={
+                <Typography
+                  sx={{
+                    textTransform: "none",
+                    fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                    fontWeight: 500,
+                    color:
+                      infoPanelTab === index
+                        ? fullConfig.theme.colors["frenchviolet"]
+                        : fullConfig.theme.colors["almostblack"],
+                  }}
+                >
+                  {title}
+                </Typography>
+              }
+              wrapped
+              {...a11yProps(index)}
+            />
+          ))}
         </Tabs>
 
         <IconButton
@@ -199,32 +163,108 @@ export default function InfoPanel() {
         ref={tabPanelRef}
       >
         <CustomTabPanel value={infoPanelTab} index={0}>
-        You can begin your search by first selecting a geographic scale&mdash;such as state, county, or census tract&mdash;as an initial filter. This allows you to narrow down the scope of your query to a specific level of spatial detail. After applying this geographic filter, you can enter keywords of interest to search within the filtered results. 
+          Welcome to our data discovery application. Here are a few ways for you
+          to get started:
+          <List>
+            <ListItem>
+              Search by terms and keywords: Use the main search bar to search
+              for a concept you are interested in. As you type, a dropdown will
+              appear with suggestions pulled directly from the datasets
+              themselves.
+            </ListItem>
+            <ListItem>
+              Filter by geography: Are you looking only for county-level data?
+              Use the &quot;County&quot; filter to only show datasets at that
+              level.
+            </ListItem>
+            <ListItem>
+              Filter by theme or year: Researching food access? Only want the
+              latest data? Click the &quot;Sort & Filter&quot; button to narrow
+              results by theme and date.
+            </ListItem>
+            <ListItem>
+              Filter by location: Only looking for datasets that cover your
+              state or city? Use the search box within the map to find a place
+              and filter for datasets that geographically overlap it.
+            </ListItem>
+          </List>
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={1}>
-          If you know the general SDOH topic you are interested in finding data
-          for, first try the themes in the <strong>Sort & Filter</strong> panel
-          at left. Not finding the theme you want? Try typing it into the main search
-          bar to see if it appears in the auto-suggest dropdown, or just click
-          &rarr; and see what you find!
+          Once you have performed a search or set a filter, you will get a list
+          of the items matching your query. Each item will have a collection of
+          metadata associated with it, as well as actions for further
+          exploration:
+          <List>
+            <ListItem>
+              Click &quot;Show on map&quot; to get a preview of what areas the
+              dataset covers.
+            </ListItem>
+            <ListItem>
+              Click &quot;Details&quot; to open the item details panel and learn
+              more about the dataset.
+            </ListItem>
+            <ListItem>
+              Click &quot;Access&quot; to leave the discovery app and head to
+              the source location of this dataset, for download and further
+              analysis. Note: we do not store any raw data in this system, we
+              only help you find and link out to the source repositories.
+            </ListItem>
+            <ListItem>
+              Click &quot;Share&quot; to acquire a shareable link you can send
+              to colleagues, the URL will bring them right to the same record
+              you are looking at.
+            </ListItem>
+          </List>
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={2}>
-          Some sources provide data at the state level, while others may provide data at smaller resolutions
-          like county or tract level. The interface makes it easy to filter by this geography level, or &quot;spatial resolution&quot;,
-          allowing you to find only data relevant for your work.
+          As you type search terms into the main search box, you will notice
+          that suggestions appear below the input box. This suggestion list is
+          pulled straight from the data itself (we have tried to index a lot of
+          information about each record) but there may still be times that your
+          search turns up no results. In this case, it never hurts to try
+          another word for your topic, or even just go ahead with a theme filter
+          and browse through all results.
+          <List>
+            <ListItem>
+              Tip: If you have used the search bar to make your query, you will
+              then be able to hover each result to learn more about why that
+              item matched your query.
+            </ListItem>
+          </List>
+        </CustomTabPanel>
+        <CustomTabPanel value={infoPanelTab} index={3}>
+          Some sources provide data at the state level, while others may provide
+          data at smaller resolutions like county or tract level. The interface
+          makes it easy to filter by this geography level, or &quot;spatial
+          resolution&quot;, allowing you to find only data relevant for your
+          work.
           <List>
             <ListItem>State (largest, most general level)</ListItem>
             <ListItem>County (subdivision of a state)</ListItem>
             <ListItem>Census Tract (smaller geographical unit),</ListItem>
-            <ListItem>Block Group (smallest unit, a subdivision of census tract)</ListItem>
+            <ListItem>
+              Block Group (smallest unit, a subdivision of census tract)
+            </ListItem>
             <ListItem>ZIP Code Tabulation Area (ZCTA)</ListItem>
           </List>
         </CustomTabPanel>
-        <CustomTabPanel value={infoPanelTab} index={3}>
-          We provide a few map overlay layers that can be used as reference data during your search.
+        <CustomTabPanel value={infoPanelTab} index={4}>
+          We provide a few map overlay layers that can be used as reference data
+          during your search.
           <List>
-            <ListItem>Parks (<Link href="https://overturemaps.org/">Overture Maps foundation</Link>)</ListItem>
+            <ListItem>
+              Parks (
+              <Link href="https://overturemaps.org/">
+                Overture Maps foundation
+              </Link>
+              )
+            </ListItem>
           </List>
+          <em>
+            This is a feature we hope to expand in the future. Please don&quot;t
+            hesitate to <Link href="/contact">get in touch</Link> if you have
+            ideas for more overlays you would like to see or contribute.
+          </em>
         </CustomTabPanel>
       </Box>
     </div>

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -210,7 +210,7 @@ export default function InfoPanel() {
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={2}>
           Some sources provide data at the state level, while others may provide data at smaller resolutions
-          like county or tract level. The interface makes it easy to filter by this geography level, or "spatial resolution",
+          like county or tract level. The interface makes it easy to filter by this geography level, or &quot;spatial resolution&quot;,
           allowing you to find only data relevant for your work.
           <List>
             <ListItem>State (largest, most general level)</ListItem>

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -5,8 +5,9 @@ import CloseIcon from "@mui/icons-material/Close";
 import tailwindConfig from "tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import { Box, Tabs, Tab, IconButton, Typography } from "@mui/material";
-import { useDispatch } from "react-redux";
-import { setShowInfoPanel } from "@/store/slices/uiSlice";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/store";
+import { setShowInfoPanel, setInfoPanelTab } from "@/store/slices/uiSlice";
 
 interface Props {
   children?: React.ReactNode;
@@ -43,11 +44,11 @@ function a11yProps(index: number) {
 export default function InfoPanel() {
   const dispatch = useDispatch();
   const classes = useStyles();
-  const [value, setValue] = React.useState(0);
+  const { infoPanelTab } = useSelector((state: RootState) => state.ui);
   const [maxHeight, setMaxHeight] = React.useState(0);
   const tabPanelRef = React.useRef(null);
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
-    setValue(newValue);
+    dispatch(setInfoPanelTab(newValue));
   };
   const handleClosePanel = () => {
     dispatch(setShowInfoPanel(false));
@@ -86,7 +87,7 @@ export default function InfoPanel() {
         </IconButton>
 
         <Tabs
-          value={value}
+          value={infoPanelTab}
           onChange={handleChange}
           sx={{
             paddingLeft: "2em",
@@ -108,7 +109,7 @@ export default function InfoPanel() {
                   fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
                   fontWeight: 500,
                   color:
-                    value === 0
+                    infoPanelTab === 0
                       ? fullConfig.theme.colors["frenchviolet"]
                       : fullConfig.theme.colors["almostblack"],
                 }}
@@ -127,7 +128,7 @@ export default function InfoPanel() {
                   fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
                   fontWeight: 500,
                   color:
-                    value === 1
+                    infoPanelTab === 1
                       ? fullConfig.theme.colors["frenchviolet"]
                       : fullConfig.theme.colors["almostblack"],
                 }}
@@ -158,14 +159,14 @@ export default function InfoPanel() {
         }}
         ref={tabPanelRef}
       >
-        <CustomTabPanel value={value} index={0}>
+        <CustomTabPanel value={infoPanelTab} index={0}>
           Spatial resolution is the level of geographic detail of how the data
           is displayed: state (largest, most general level), county (subdivision
           of a state, including multiple cities and towns), census tract
           (smaller geographical unit), block group (smallest unit, a subdivision
           of census tract), and ZIP Code.
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={1}>
+        <CustomTabPanel value={infoPanelTab} index={1}>
           If you know the general SDOH topic you are interested in finding data
           for, first try the themes in the <strong>Sort & Filter</strong> panel
           at left. Not finding the theme you want? Try typing it into the search

--- a/src/components/search/searchArea/spatialResolutionCheck.tsx
+++ b/src/components/search/searchArea/spatialResolutionCheck.tsx
@@ -53,9 +53,9 @@ const SpatialResolutionCheck = (props: Props): JSX.Element => {
   };
 
   return (
-    <div className={`flex flex-col sm:flex-row items-center ml-4 space-x-7`}>
-      <div className="text-l whitespace-nowrap">Spatial Resolution:</div>
-      <div className="flex flex-col sm:flex-row space-x-4">
+    <div className={`flex flex-col items-start ml-4`}>
+      <div className="text-sm whitespace-nowrap">Filter by geography:</div>
+      <div className="flex flex-col sm:flex-row flex-wrap">
         {Array.from(checkboxes).map((checkbox, index) => (
           <div key={index} className="flex items-center">
             <Checkbox

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -8,6 +8,7 @@ interface MapPreviewLyr {
 interface UIState {
   pageFirstLoad: boolean;
   showInfoPanel: boolean;
+  infoPanelTab: number;
   showDetailPanel: string;
   showFilter: boolean;
   showClearButton: boolean;
@@ -18,6 +19,7 @@ interface UIState {
 const initialState: UIState = {
   pageFirstLoad: true,
   showInfoPanel: false,
+  infoPanelTab: 0,
   showDetailPanel: "",
   showFilter: false,
   showClearButton: false,
@@ -34,6 +36,9 @@ const uiSlice = createSlice({
     },
     setShowInfoPanel: (state, action) => {
       state.showInfoPanel = action.payload;
+    },
+    setInfoPanelTab: (state, action) => {
+      state.infoPanelTab = action.payload;
     },
     setShowDetailPanel: (state, action) => {
       state.showDetailPanel = action.payload;
@@ -59,6 +64,7 @@ const uiSlice = createSlice({
 export const {
   setPageFirstLoad,
   setShowInfoPanel,
+  setInfoPanelTab,
   setShowDetailPanel,
   setShowFilter,
   setShowClearButton,


### PR DESCRIPTION
We have been in need of more help text since it was identified as a shortcoming in the superuser meeting. Additionally, we had determined that the info box could be used thoroughly within the app, and it could be activated by click events outside of the single "i" icon in the search box.

I'm starting this PR as a work in progress so we can get a preview deploy going. Initially, I have focused on the box itself rather than the content.

- move the active tab id to a global store so it can be set from anywhere within the app
- added a "get started" link in the left-hand text, to directly open the box
- added "next/previous" links at the bottom of each tab to create a better "on-boarding"-style flow.
- changed the overlays info icon to now open a new overlays tab in the info box (content still incomplete)
- set a height on the tab text content and then enabled overflow scrolling. I tried for a while to infer the height from the banner itself, but because it will change heights as the screen is resized, but for now just ended up just explicitly setting the height... I actually think it isn't so bad to expand the bar when the info panel is open, it provides more real estate for content.

![image](https://github.com/user-attachments/assets/f429ddb7-896f-44ff-aaf6-7baa2a42f354)
![image](https://github.com/user-attachments/assets/49a3801b-d090-47c4-8ffe-def5dac410cf)

(looks like the scroll bar isn't showing up in the screenshot, but there is one present on the screen below)
![image](https://github.com/user-attachments/assets/81357e48-e838-4f03-ac7c-029ecd155bf2)
