### PR TITLE
style: adjust styling for result cards within the Discovery App

### DIFF
--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -2,12 +2,13 @@
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "../../store";
-import { Grid } from "@mui/material";
+import {Collapse, Grid} from "@mui/material";
 import SearchArea from "./searchArea";
 import DetailPanel from "./detailPanel";
 import { setSchema } from "@/store/slices/searchSlice";
 import MapPanel from "./mapPanel/mapPanelContent";
 import dynamic from "next/dynamic";
+import * as React from "react";
 
 const DynamicResultsPanel = dynamic(() => import("./resultsPanel"), {
   ssr: false,
@@ -21,7 +22,9 @@ const DynamicResultsPanel = dynamic(() => import("./resultsPanel"), {
 });
 
 export default function DiscoveryArea({ schema }): JSX.Element {
+  const [checked, setChecked] = useState(true);
   const dispatch = useDispatch<AppDispatch>();
+  const { showInfoPanel } = useSelector((state: RootState) => state.ui);
   const { results, relatedResults } = useSelector(
     (state: RootState) => state.search
   );
@@ -48,19 +51,21 @@ export default function DiscoveryArea({ schema }): JSX.Element {
   }
   return (
     <Grid container>
-      <Grid className="w-full px-[1em] sm:px-[2em] sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
-        <Grid container className="container mx-auto pt-[2em] sm:pt-0">
-          <SearchArea schema={schema} header="Data Discovery" />
+      <Collapse className={'w-full'} in={showInfoPanel} collapsedSize={350}>
+        <Grid className="w-full px-[1em] sm:px-[2em] sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
+          <Grid container className="container mx-auto pt-[2em] sm:pt-0">
+            <SearchArea schema={schema} header="Data Discovery" />
+          </Grid>
         </Grid>
-      </Grid>
+      </Collapse>
       <Grid className="w-full px-[1em] sm:px-[2em]">
         <Grid container className="container mx-auto pt-[1.5rem]">
-          <Grid item xs={12} sm={5}>
+          <Grid item xs={12} sm={6}>
             <DynamicResultsPanel
               schema={schema}
             />
           </Grid>
-          <Grid item xs={12} sm={7} className="sm:ml-[0.5em]">
+          <Grid item xs={12} sm={6} className="sm:ml-[0.5em]">
             <MapPanel
               resultsList={results}
               showMap={showDetailPanel ? "none" : "block"}

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -255,7 +255,7 @@ const ResultCard = (props: Props): JSX.Element => {
         </Grid>
       </div>
       <Grid spacing={0} container className="flex flex-col sm:flex-row px-2 mt-1">
-        <Grid item spacing={0} xs={7} className="flex-1">
+        <Grid item xs={8}>
           <div className={`${classes.resultCard} truncate `}>
             Keywords:{" "}
             {props.resultItem.meta.keyword
@@ -269,7 +269,7 @@ const ResultCard = (props: Props): JSX.Element => {
               : ""}
           </div>
         </Grid>
-        <Grid spacing={0} xs={5} className="flex-1 w-1/3 sm:pl-8">
+        <Grid item xs={4}>
           <div className={`${classes.resultCard} truncate `}>
             Year:{" "}
             {props.resultItem.index_year?.length > 1

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
-import {Checkbox, FormControlLabel, Typography} from "@mui/material";
+import {Checkbox, FormControlLabel, Grid, Typography} from "@mui/material";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import IconText from "../iconText";
@@ -108,7 +108,7 @@ const ResultCard = (props: Props): JSX.Element => {
 
   const cardContent = props.resultItem && (
     <div
-      className={`container mx-auto p-5 bg-lightbisque shadow-none rounded aspect-ratio`}
+      className={`container mx-auto p-3 bg-lightbisque shadow-none rounded aspect-ratio`}
       onClick={() => {
         dispatch(setShowDetailPanel(props.resultItem.id));
       }}
@@ -128,9 +128,9 @@ const ResultCard = (props: Props): JSX.Element => {
             : undefined,
       }}
     >
-      <div className="flex flex-col sm:flex-row items-center mb-2">
+      <div className="flex flex-col sm:flex-row items-center px-2">
         <div className="flex flex-col sm:flex-row items-center w-full">
-          <div className="w-full sm:w-4/5 flex items-center">
+          <div className="w-full sm:w-4/5 flex items-start flex-col">
             <IconText
               roundBackground={true}
               svgIcon={IconMatch(
@@ -144,23 +144,117 @@ const ResultCard = (props: Props): JSX.Element => {
               labelClass={`text-l font-medium ${fullConfig.theme.fontFamily["sans"]}`}
               labelColor={fullConfig.theme.colors["almostblack"]}
             />
+            <div className={`${classes.resultCard} truncate ml-12`} style={{ marginTop: '-0.5rem'}}>
+              by{" "}
+              {props.resultItem.meta.publisher
+                ? props.resultItem.meta.publisher[0]
+                : ""}
+            </div>
           </div>
           <div className="sm:w-1/5 order-1 sm:order-none w-full sm:ml-auto flex items-center justify-center sm:justify-end font-bold">
-            <button
-              onClick={() => {
-                dispatch(setShowDetailPanel(props.resultItem.id));
-              }}
-              style={{ color: fullConfig.theme.colors["frenchviolet"] }}
-            >
-              View <span className="ml-1">&#8594;</span>
-            </button>
+            <div className={'flex flex-col'}>
+              <button
+                onClick={() => {
+                  dispatch(setShowDetailPanel(props.resultItem.id));
+                }}
+                style={{ color: fullConfig.theme.colors["frenchviolet"] }}
+              >
+                Details <span className="ml-1">&#8594;</span>
+              </button>
+
+              {/* Checkbox : Show coverage area on map */}
+              <FormControlLabel
+                disabled={!props.resultItem.meta.highlight_ids?.length}
+                title={!props.resultItem.meta.highlight_ids?.length ? 'No geographic areas have been defined for this dataset' : 'Preview the geographic areas that this dataset covers'}
+                label={<div style={{
+                  color: `${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["frenchviolet"] : fullConfig.theme.colors["darkgray"]}`,
+                  padding: 0,
+                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                  fontSize: "0.875rem" }}>
+                  {mapPreview.find(p => p.lyrId === props.resultItem.id) ? 'Hide' : 'Show'} on map
+              </div>}
+                onClick={(event) => {
+                  event.stopPropagation();
+                }}
+                control={
+                  <Checkbox
+                    id={`sc-checkbox-${props.resultItem.id}`}
+                    value={props.resultItem.meta}
+                    style={{display: 'none'}}
+                    onChange={(event) => {
+                      if (event.target.checked) {
+                        dispatch(
+                          setMapPreview([
+                            ...mapPreview,
+                            {
+                              lyrId: props.resultItem.id,
+                              filterIds: props.resultItem.meta.highlight_ids,
+                            },
+                          ])
+                        );
+                      } else {
+                        dispatch(
+                          setMapPreview(
+                            mapPreview.filter(
+                              (item) => item.lyrId != props.resultItem.id
+                            )
+                          )
+                        );
+                      }
+                    }}
+                    icon={
+                      <span
+                        style={{
+                          borderRadius: "4px",
+                          border: `2px solid ${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["frenchviolet"] : fullConfig.theme.colors["darkgray"]}`,
+                          width: "14px",
+                          height: "14px",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          backgroundColor: "transparent",
+                        }}
+                      ></span>
+                    }
+                    checkedIcon={
+                      <span
+                        style={{
+                          borderRadius: "4px",
+                          border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
+                          width: "14px",
+                          height: "14px",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          backgroundColor: `${fullConfig.theme.colors["frenchviolet"]}`,
+                        }}
+                      >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="white"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ width: "16px", height: "16px" }}
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              </span>
+                    }
+                  />
+                }
+              />
+            </div>
           </div>
+
         </div>
       </div>
-      <div className="flex flex-col sm:flex-row sm:mt-4">
-        <div className="flex-1 w-full sm:w-1/2">
+      <Grid spacing={0} container className="flex flex-col sm:flex-row px-2 mt-1">
+        <Grid item spacing={0} xs={7} className="flex-1">
           <div className={`${classes.resultCard} truncate `}>
-            Keyword:{" "}
+            Keywords:{" "}
             {props.resultItem.meta.keyword
               ? props.resultItem.meta.keyword.join(", ")
               : ""}
@@ -171,14 +265,8 @@ const ResultCard = (props: Props): JSX.Element => {
               ? props.resultItem.creator.join(", ")
               : ""}
           </div>
-          <div className={`${classes.resultCard} truncate `}>
-            Publisher:{" "}
-            {props.resultItem.meta.publisher
-              ? props.resultItem.meta.publisher[0]
-              : ""}
-          </div>
-        </div>
-        <div className="flex-1 w-full sm:w-1/2 sm:pl-8">
+        </Grid>
+        <Grid spacing={0} xs={5} className="flex-1 w-1/3 sm:pl-8">
           <div className={`${classes.resultCard} truncate `}>
             Year:{" "}
             {props.resultItem.index_year
@@ -191,100 +279,14 @@ const ResultCard = (props: Props): JSX.Element => {
               ? props.resultItem.meta.spatial_resolution.join(", ")
               : ""}
           </div>
-          <div className={`${classes.resultCard} truncate`}>
+          {/*<div className={`${classes.resultCard} truncate`}>
             Resource:{" "}
             {props.resultItem.resource_class
               ? props.resultItem.resource_class.join(", ")
               : ""}
-          </div>
-        </div>
-      </div>
-
-      {/* Checkbox : Show coverage area on map */}
-      <div>
-        <FormControlLabel
-          disabled={!props.resultItem.meta.highlight_ids?.length}
-          title={!props.resultItem.meta.highlight_ids?.length ? 'No geographic areas have been defined for this dataset' : 'Preview the geographic areas that this dataset covers'}
-          label={<div style={{
-            color: `${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["almostblack"] : fullConfig.theme.colors["darkgray"]}`,
-            padding: 0,
-            fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
-            fontWeight: 400,
-            fontSize: "0.875rem" }}>Show coverage area</div>}
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-          control={
-            <Checkbox
-              id={`sc-checkbox-${props.resultItem.id}`}
-              value={props.resultItem.meta}
-              onChange={(event) => {
-
-                if (event.target.checked) {
-                  dispatch(
-                    setMapPreview([
-                      ...mapPreview,
-                      {
-                        lyrId: props.resultItem.id,
-                        filterIds: props.resultItem.meta.highlight_ids,
-                      },
-                    ])
-                  );
-                } else {
-                  dispatch(
-                    setMapPreview(
-                      mapPreview.filter(
-                        (item) => item.lyrId != props.resultItem.id
-                      )
-                    )
-                  );
-                }
-              }}
-              icon={
-                <span
-                  style={{
-                    borderRadius: "4px",
-                    border: `2px solid ${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["frenchviolet"] : fullConfig.theme.colors["darkgray"]}`,
-                    width: "14px",
-                    height: "14px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: "transparent",
-                  }}
-                ></span>
-              }
-              checkedIcon={
-                <span
-                  style={{
-                    borderRadius: "4px",
-                    border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
-                    width: "14px",
-                    height: "14px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: `${fullConfig.theme.colors["frenchviolet"]}`,
-                  }}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="white"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    style={{ width: "16px", height: "16px" }}
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                </span>
-              }
-            />
-          }
-        />
-      </div>
+          </div>*/}
+        </Grid>
+      </Grid>
     </div>
   );
   return props.resultItem ? (

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -129,8 +129,8 @@ const ResultCard = (props: Props): JSX.Element => {
       }}
     >
       <div className="flex flex-col sm:flex-row items-center px-2">
-        <div className="flex flex-col sm:flex-row items-center w-full">
-          <div className="w-full sm:w-4/5 flex items-start flex-col">
+        <Grid container spacing={0} className="flex flex-col sm:flex-row items-center">
+          <Grid item sm={10} className="items-start">
             <IconText
               roundBackground={true}
               svgIcon={IconMatch(
@@ -150,9 +150,9 @@ const ResultCard = (props: Props): JSX.Element => {
                 ? props.resultItem.meta.publisher[0]
                 : ""}
             </div>
-          </div>
-          <div className="sm:w-1/5 order-1 sm:order-none w-full sm:ml-auto flex items-center justify-center sm:justify-end font-bold">
-            <div className={'flex flex-col'}>
+          </Grid>
+          <Grid item sm={2} className=" order-1 sm:order-none sm:ml-auto items-center justify-center sm:justify-end font-bold">
+            <div className={'flex justify-end'}>
               <button
                 onClick={() => {
                   dispatch(setShowDetailPanel(props.resultItem.id));
@@ -161,9 +161,12 @@ const ResultCard = (props: Props): JSX.Element => {
               >
                 Details <span className="ml-1">&#8594;</span>
               </button>
+            </div>
 
+            <div className={'flex justify-end'}>
               {/* Checkbox : Show coverage area on map */}
               <FormControlLabel
+                className={'nomargin'}
                 disabled={!props.resultItem.meta.highlight_ids?.length}
                 title={!props.resultItem.meta.highlight_ids?.length ? 'No geographic areas have been defined for this dataset' : 'Preview the geographic areas that this dataset covers'}
                 label={<div style={{
@@ -171,7 +174,7 @@ const ResultCard = (props: Props): JSX.Element => {
                   padding: 0,
                   fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
                   fontSize: "0.875rem" }}>
-                  {mapPreview.find(p => p.lyrId === props.resultItem.id) ? 'Hide' : 'Show'} on map
+                  {mapPreview.find(p => p.lyrId === props.resultItem.id) ? 'Remove preview' : 'Show on map'}
               </div>}
                 onClick={(event) => {
                   event.stopPropagation();
@@ -247,9 +250,9 @@ const ResultCard = (props: Props): JSX.Element => {
                 }
               />
             </div>
-          </div>
+          </Grid>
 
-        </div>
+        </Grid>
       </div>
       <Grid spacing={0} container className="flex flex-col sm:flex-row px-2 mt-1">
         <Grid item spacing={0} xs={7} className="flex-1">
@@ -269,9 +272,9 @@ const ResultCard = (props: Props): JSX.Element => {
         <Grid spacing={0} xs={5} className="flex-1 w-1/3 sm:pl-8">
           <div className={`${classes.resultCard} truncate `}>
             Year:{" "}
-            {props.resultItem.index_year
-              ? props.resultItem.index_year.join(", ")
-              : ""}
+            {props.resultItem.index_year?.length > 1
+              ? `${Math.min(...props.resultItem.index_year.map(y => Number(y)))} - ${Math.max(...props.resultItem.index_year.map(y => Number(y)))}`
+              : props.resultItem.index_year}
           </div>
           <div className={`${classes.resultCard} truncate `}>
             Spatial Res:{" "}

--- a/src/components/search/searchArea/index.tsx
+++ b/src/components/search/searchArea/index.tsx
@@ -35,7 +35,7 @@ const SearchArea = (props: Props): JSX.Element => {
       <Grid
         item
         xs={12}
-        sm={4}
+        sm={6}
         display="flex"
         flexDirection="column"
         className="py-[2em] sm:px-[1.1em] xs:text-center sm:text-left"
@@ -63,7 +63,7 @@ const SearchArea = (props: Props): JSX.Element => {
       <Grid
         item
         xs={12}
-        sm={8}
+        sm={6}
         display="flex"
         flexDirection="column"
         justifyContent="flex-start"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,6 +25,10 @@
   text-transform: uppercase;
 }
 
+.nomargin {
+  margin: 0 !important;
+}
+
 
 /* override the tailwind defaults to get bullets and numbers back on lists in blog posts.*/
 article ul {


### PR DESCRIPTION
## Problem
Our designs for Result Cards within the Discovery App have changed

## Approach
* style: adjust styling / layout to match new designs

Before:
![Screenshot 2025-02-04 at 4 58 37 PM](https://github.com/user-attachments/assets/9e7ccab3-f0f3-479a-a66f-e170724cf917)

After:
![Screenshot 2025-02-04 at 4 58 08 PM](https://github.com/user-attachments/assets/e5c60625-4756-42a1-b141-c4f63c8e8982)

## How to Test
1. Navigate to https://deploy-preview-437--cheerful-treacle-913a24.netlify.app/search
    * You should see result cards listed on the left side
    * You should see that the layout / styling has been adjusted to match [the latest designs](https://www.figma.com/design/vD6pC3DsFtGG2aCv4vWXtV/HEROP?node-id=3099-1201&t=Pf64kLoNiSa6xio2-0)