### PR TITLE
feat: remove existing map previews/coverage when new result is clicked

### DIFF
--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -188,7 +188,6 @@ const ResultCard = (props: Props): JSX.Element => {
                       if (event.target.checked) {
                         dispatch(
                           setMapPreview([
-                            ...mapPreview,
                             {
                               lyrId: props.resultItem.id,
                               filterIds: props.resultItem.meta.highlight_ids,


### PR DESCRIPTION
## Problem
We would like to disable/clear existing map preview when the user clicks "Show on map"

Fixes #440

## Approach
* feat: remove spread operator to implement "radio" behavior for map coverage/preview

## How to Test
1. Navigate to https://deploy-preview-442--cheerful-treacle-913a24.netlify.app/search
    * You should see results listed on the left side
    * You should see "Show on map" listed on the top-right of each result card
    * NOTE: some buttons may be disabled here if there are no Highlight IDs set up in the Metadata Manager
2. Click the "Show on map" button beside one result
    * You should see that the button text changes to "Remove preview" - this signifies that the result is now being shown on the map
    * After a few seconds, you should see the preview layer appear on the map
3. Choose a different result card and click "Show on map"
    * You should see that the most recently clicked button text changes to "Remove preview"
    * You should see that the first result you chose goes back to saying "Show on map" - this signifies that the first result is no longer being shown, and offers the user an option to show it again
    * After a few seconds, you should see the new preview layer appear on the map