### PR TITLE
Overlay clusters

### DIFF
--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -13,7 +13,6 @@ import {
 } from "react-map-gl/maplibre";
 import maplibregl, {
   FilterSpecification,
-  LineLayerSpecification,
   GeoJSONSource,
 } from "maplibre-gl";
 import { Protocol } from "pmtiles";
@@ -38,13 +37,21 @@ interface Props {
 }
 
 export default function DynamicMap(props: Props): JSX.Element {
+  const [cursor, setCursor] = useState<string>('auto');
   const dispatch = useDispatch<AppDispatch>();
   const plausible = usePlausible();
   const { bbox, visOverlays } = useSelector((state: RootState) => state.search);
   const mapPreview = useSelector((state: RootState) => state.ui.mapPreview);
-  const [parkPopupInfo, setParkPopupInfo] = useState(null);
+  const [popupInfo, setPopupInfo] = useState(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const mapRef = useRef<MapRef>(null);
+
+  const overlayLayerIds = []
+  Object.keys(overlayRegistry).forEach(key => {
+    overlayRegistry[key].layers.forEach(layer => {
+      overlayLayerIds.push(layer.spec.id)
+    })
+  })
 
   useEffect(() => {
     if (!mapRef.current || !mapLoaded) return;
@@ -134,6 +141,17 @@ export default function DynamicMap(props: Props): JSX.Element {
         overlayRegistry[lyr].layers.forEach((lyrDef) => {
           if (!mapLyrIds.includes(lyrDef.spec.id)) {
             map.addLayer(lyrDef.spec, lyrDef.addBefore);
+            if(lyrDef.spec.id.endsWith("-clusters")) {
+              map.on('click', lyrDef.spec.id, async (e) => {
+                const features = map.queryRenderedFeatures(e.point, {
+                    layers: [lyrDef.spec.id]
+                });
+                map.easeTo({
+                    center: features[0].toJSON().geometry.coordinates,
+                    zoom: map.getZoom() + 1
+                });
+              })
+            };
           }
         })
       }
@@ -151,21 +169,19 @@ export default function DynamicMap(props: Props): JSX.Element {
     }
   }, [visOverlays, mapLoaded]);
 
-  const onMouseMove = useCallback((event: MapLayerMouseEvent) => {
-    if (!mapRef.current || !mapLoaded) return;
-    const map = mapRef.current.getMap();
-    const parkFeat = event.features?.find((f) => f["source"] === "us-parks");
+  const onMouseEnter = useCallback(() => setCursor('pointer'), []);
+  const onMouseLeave = useCallback(() => setCursor('auto'), []);
 
-    if (parkFeat) {
-      map.getCanvas().style.cursor = "pointer";
-      setParkPopupInfo({
-        longitude: parkFeat.geometry["coordinates"][0],
-        latitude: parkFeat.geometry["coordinates"][1],
-        name: parkFeat.properties.name,
-      });
-    } else {
-      map.getCanvas().style.cursor = "grab";
-      setParkPopupInfo(null);
+  const onClick = useCallback((event: MapLayerMouseEvent) => {
+    if (event.features.length != 0) {
+      const feat = event.features[0]
+      if (!feat.layer.id.includes("-clustered") && !feat.layer.id.includes("-cluster-count")) {
+        setPopupInfo({
+          longitude: feat.geometry["coordinates"][0],
+          latitude: feat.geometry["coordinates"][1],
+          content: `<ul>${Object.keys(feat.properties).map(key => `<li><strong>${key}:</strong> ${feat.properties[key]}</li>`).join("")}</ul>`,
+        })
+      }
     }
   }, []);
 
@@ -271,12 +287,16 @@ export default function DynamicMap(props: Props): JSX.Element {
       }}
       style={{ width: "100%", height: "100%" }}
       mapStyle={`https://api.maptiler.com/maps/3d4a663a-95c3-42d0-9ee6-6a4cce2ba220/style.json?key=${apiKey}`}
-      onMouseMove={onMouseMove}
+      // onMouseMove={onMouseMove}
       onLoad={onLoad}
+      onClick={onClick}
+      cursor={cursor}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       dragRotate={false}
       touchPitch={false}
       touchZoomRotate={false}
-      interactiveLayerIds={["state-interactive", "us-parks"]}
+      interactiveLayerIds={overlayLayerIds}
     >
       <Source
         id="state-2018"
@@ -315,14 +335,17 @@ export default function DynamicMap(props: Props): JSX.Element {
         position="top-left"
         selectionCallback={handleGeoSearchSelection}
       />
-      {parkPopupInfo && (
+      {popupInfo && (
         <Popup
-          longitude={parkPopupInfo.longitude}
-          latitude={parkPopupInfo.latitude}
+          longitude={popupInfo.longitude}
+          latitude={popupInfo.latitude}
           closeButton={false}
-          className="county-info"
+          onClose={() => setPopupInfo(null)}
         >
-          {parkPopupInfo.name}
+          <div
+            className="text-base"
+            dangerouslySetInnerHTML={{ __html: popupInfo.content }}
+          />
         </Popup>
       )}
       {bbox && mapLoaded && (

--- a/src/components/map/helper/layers.tsx
+++ b/src/components/map/helper/layers.tsx
@@ -3,6 +3,8 @@ import {
   LineLayerSpecification,
   CircleLayerSpecification,
   FilterSpecification,
+  SymbolLayerSpecification,
+  SourceSpecification,
 } from "maplibre-gl";
 
 export type LayerDef = {
@@ -10,8 +12,97 @@ export type LayerDef = {
   spec:
     | FillLayerSpecification
     | LineLayerSpecification
-    | CircleLayerSpecification;
+    | CircleLayerSpecification
+    | SymbolLayerSpecification;
 };
+
+export const makeClusteredLayerSet = function (
+  layerId: string,
+  sourceId: string,
+  sourceLayerId: string,
+  circleColor: string,
+) {
+
+  const clusteredLayer: CircleLayerSpecification = {
+    id: layerId + "-clusters",
+    source: sourceId,
+    "source-layer": sourceLayerId,
+    type: "circle",
+    filter: ['has', 'point_count'],
+    paint: {
+        // Use step expressions (https://maplibre.org/maplibre-style-spec/#expressions-step)
+        // with three steps to implement three types of circles:
+        //   * Blue, 20px circles when point count is less than 100
+        //   * Yellow, 30px circles when point count is between 100 and 750
+        //   * Pink, 40px circles when point count is greater than or equal to 750
+        'circle-color': circleColor,
+        'circle-stroke-width': 1,
+        'circle-stroke-color': "#1e1e1e",
+        // [
+        //     'step',
+        //     ['get', 'point_count'],
+        //     '#51bbd6',
+        //     100,
+        //     '#f1f075',
+        //     750,
+        //     '#f28cb1'
+        // ],
+        'circle-radius': [
+            'step',
+            ['get', 'point_count'],
+            8,
+            50,
+            15,
+            100,
+            20
+        ]
+    }
+  }
+  const clusteredLayerDef: LayerDef = {
+    addBefore: "Ocean labels",
+    spec: clusteredLayer
+  }
+
+  const labelLayer: SymbolLayerSpecification = {
+    id: layerId + 'cluster-count',
+    type: 'symbol',
+    source: sourceId,
+    "source-layer": sourceLayerId,
+    filter: ['has', 'point_count'],
+    layout: {
+      'text-field': '{point_count_abbreviated}',
+      'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+      'text-size': 12
+    },
+    // paint: {
+    //   'text-color': "#ffffff",
+    // }
+  }
+  const labelLayerDef: LayerDef = {
+    addBefore: "Ocean labels",
+    spec: labelLayer
+  }
+
+  const unclusteredLayer: CircleLayerSpecification = {
+    id: layerId + '-unclustered',
+    type: 'circle',
+    source: sourceId,
+    "source-layer": sourceLayerId,
+    filter: ['!', ['has', 'point_count']],
+    paint: {
+        'circle-color': circleColor,
+        'circle-radius': 4,
+        'circle-stroke-width': 1,
+        'circle-stroke-color': "#1e1e1e",
+    }
+  }
+  const unclusteredLayerDef: LayerDef = {
+    addBefore: "Ocean labels",
+    spec: unclusteredLayer
+  }
+
+  return [clusteredLayerDef, labelLayerDef, unclusteredLayerDef]
+}
 
 export const makePreviewLyrs = function (
   id: string,
@@ -43,25 +134,24 @@ export const makePreviewLyrs = function (
   return [newLineLayerSpec, newFillLayerSpec];
 };
 
-// demo POI layer
-const parksSpec: CircleLayerSpecification = {
-  id: "us-parks",
-  source: "us-parks",
-  "source-layer": "resources",
-  type: "circle",
-  paint: {
-    "circle-radius": 5,
-    "circle-color": "#1FBCA3",
-    "circle-stroke-color": "#000000",
-    "circle-stroke-width": 1,
-  },
-};
-
-export const parksLayer: LayerDef = {
-  addBefore: "Ocean labels",
-  spec: parksSpec,
-};
 
 export const overlayRegistry = {
-  Parks: parksLayer,
+  Parks: {
+    source: {
+      id: "la-restaurants-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://http://localhost:8080/la-restaurants.pmtiles",
+        cluster: true,
+        clusterMaxZoom: 14, // Max zoom to cluster points on
+        clusterRadius: 250
+      }
+    },
+    layers: makeClusteredLayerSet(
+      "la-restaurants",
+      "la-restaurants-source",
+      "resources",
+      "#24e8c8",
+    )
+  } ,
 };

--- a/src/components/map/helper/layers.tsx
+++ b/src/components/map/helper/layers.tsx
@@ -16,17 +16,17 @@ export type LayerDef = {
     | SymbolLayerSpecification;
 };
 
-export const makeClusteredLayerSet = function (
+export const makeClusteredLayerSet = function (props: {
   layerId: string,
   sourceId: string,
-  sourceLayerId: string,
+  sourceLayerId?: string,
   circleColor: string,
-) {
+}) {
 
   const clusteredLayer: CircleLayerSpecification = {
-    id: layerId + "-clusters",
-    source: sourceId,
-    "source-layer": sourceLayerId,
+    id: props.layerId + "-clusters",
+    source: props.sourceId,
+    "source-layer": props.sourceLayerId,
     type: "circle",
     filter: ['has', 'point_count'],
     paint: {
@@ -35,7 +35,7 @@ export const makeClusteredLayerSet = function (
         //   * Blue, 20px circles when point count is less than 100
         //   * Yellow, 30px circles when point count is between 100 and 750
         //   * Pink, 40px circles when point count is greater than or equal to 750
-        'circle-color': circleColor,
+        'circle-color': props.circleColor,
         'circle-stroke-width': 1,
         'circle-stroke-color': "#1e1e1e",
         // [
@@ -58,39 +58,41 @@ export const makeClusteredLayerSet = function (
         ]
     }
   }
+  // if (props.sourceLayerId) {clusteredLayer["source-layer"] = props.sourceLayerId}
   const clusteredLayerDef: LayerDef = {
     addBefore: "Ocean labels",
     spec: clusteredLayer
   }
 
   const labelLayer: SymbolLayerSpecification = {
-    id: layerId + 'cluster-count',
+    id: props.layerId + '-cluster-count',
     type: 'symbol',
-    source: sourceId,
-    "source-layer": sourceLayerId,
+    source: props.sourceId,
+    "source-layer": props.sourceLayerId,
     filter: ['has', 'point_count'],
     layout: {
       'text-field': '{point_count_abbreviated}',
       'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
-      'text-size': 12
+      'text-size': 8
     },
     // paint: {
     //   'text-color': "#ffffff",
     // }
   }
+  // if (props.sourceLayerId) {clusteredLayer["source-layer"] = props.sourceLayerId}
   const labelLayerDef: LayerDef = {
     addBefore: "Ocean labels",
     spec: labelLayer
   }
 
   const unclusteredLayer: CircleLayerSpecification = {
-    id: layerId + '-unclustered',
+    id: props.layerId + '-unclustered',
     type: 'circle',
-    source: sourceId,
-    "source-layer": sourceLayerId,
+    source: props.sourceId,
+    "source-layer": props.sourceLayerId,
     filter: ['!', ['has', 'point_count']],
     paint: {
-        'circle-color': circleColor,
+        'circle-color': props.circleColor,
         'circle-radius': 4,
         'circle-stroke-width': 1,
         'circle-stroke-color': "#1e1e1e",
@@ -136,22 +138,58 @@ export const makePreviewLyrs = function (
 
 
 export const overlayRegistry = {
+  // ParksOld: {
+  //   source: {
+  //     id: "la-restaurants-source",
+  //     spec: {
+  //       // type: "vector",
+  //       // url: "pmtiles://http://localhost:8080/la-parks-clustered.pmtiles",
+  //       type: "geojson",
+  //       data: "http://localhost:8080/us-parks.geojson",
+  //       cluster: true,
+  //       clusterMaxZoom: 14, // Max zoom to cluster points on
+  //       clusterRadius: 50
+  //     }
+  //   },
+  //   layers: makeClusteredLayerSet({
+  //     layerId: "la-restaurants",
+  //     sourceId: "la-restaurants-source",
+  //     // sourceLayerId: "resources",
+  //     circleColor: "#24e8c8",
+  //   })
+  // },
   Parks: {
+    url: "https://overturemaps.org/",
+    description: "Parks from Overture Points of Interests dataset",
     source: {
-      id: "la-restaurants-source",
+      id: "la-parks-source",
       spec: {
         type: "vector",
-        url: "pmtiles://http://localhost:8080/la-restaurants.pmtiles",
-        cluster: true,
-        clusterMaxZoom: 14, // Max zoom to cluster points on
-        clusterRadius: 250
+        url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/overlays/us-parks-overture.pmtiles",
       }
     },
-    layers: makeClusteredLayerSet(
-      "la-restaurants",
-      "la-restaurants-source",
-      "resources",
-      "#24e8c8",
-    )
-  } ,
+    layers: makeClusteredLayerSet({
+      layerId: "la-parks",
+      sourceId: "la-parks-source",
+      sourceLayerId: "resources",
+      circleColor: "#24e8c8",
+    })
+  },
+  "NEI Facilities": {
+    url: "https://www.epa.gov/air-emissions-inventories/national-emissions-inventory-nei",
+    description: "Facilities emitting PM2.5, from National Emissions Inventory (NEI)",
+    source: {
+      id: "nei-facilities-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/overlays/nei-facilities.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "nei-facilities",
+      sourceId: "nei-facilities-source",
+      sourceLayerId: "resources",
+      circleColor: "#ff6666",
+    })
+  },
 };

--- a/src/components/map/helper/layers.tsx
+++ b/src/components/map/helper/layers.tsx
@@ -21,6 +21,7 @@ export const makeClusteredLayerSet = function (props: {
   sourceId: string,
   sourceLayerId?: string,
   circleColor: string,
+  labelColor?: string,
 }) {
 
   const clusteredLayer: CircleLayerSpecification = {
@@ -75,9 +76,9 @@ export const makeClusteredLayerSet = function (props: {
       'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
       'text-size': 8
     },
-    // paint: {
-    //   'text-color': "#ffffff",
-    // }
+    paint: {
+      'text-color': props.labelColor ? props.labelColor : "#000000",
+    }
   }
   // if (props.sourceLayerId) {clusteredLayer["source-layer"] = props.sourceLayerId}
   const labelLayerDef: LayerDef = {
@@ -138,44 +139,58 @@ export const makePreviewLyrs = function (
 
 
 export const overlayRegistry = {
-  // ParksOld: {
-  //   source: {
-  //     id: "la-restaurants-source",
-  //     spec: {
-  //       // type: "vector",
-  //       // url: "pmtiles://http://localhost:8080/la-parks-clustered.pmtiles",
-  //       type: "geojson",
-  //       data: "http://localhost:8080/us-parks.geojson",
-  //       cluster: true,
-  //       clusterMaxZoom: 14, // Max zoom to cluster points on
-  //       clusterRadius: 50
-  //     }
-  //   },
-  //   layers: makeClusteredLayerSet({
-  //     layerId: "la-restaurants",
-  //     sourceId: "la-restaurants-source",
-  //     // sourceLayerId: "resources",
-  //     circleColor: "#24e8c8",
-  //   })
-  // },
-  Parks: {
-    url: "https://overturemaps.org/",
-    description: "Parks from Overture Points of Interests dataset",
+  "Adult Education": {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
     source: {
-      id: "la-parks-source",
+      id: "us-adult-education-source",
       spec: {
         type: "vector",
-        url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/overlays/us-parks-overture.pmtiles",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-adult-education.pmtiles",
       }
     },
     layers: makeClusteredLayerSet({
-      layerId: "la-parks",
-      sourceId: "la-parks-source",
+      layerId: "us-adult-education",
+      sourceId: "us-adult-education-source",
       sourceLayerId: "resources",
-      circleColor: "#24e8c8",
+      circleColor: "#FC6DC3",
     })
   },
-  "NEI Facilities": {
+  Airports: {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
+    source: {
+      id: "us-airports-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-airports.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "us-airports",
+      sourceId: "us-airports-source",
+      sourceLayerId: "resources",
+      circleColor: "#BE6DFC",
+    })
+  },
+  "Child Enrichment": {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
+    source: {
+      id: "us-child-enrichment-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-child-enrichment.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "us-child-enrichment",
+      sourceId: "us-child-enrichment-source",
+      sourceLayerId: "resources",
+      circleColor: "#FCB76D",
+    })
+  },
+  "Emissions": {
     url: "https://www.epa.gov/air-emissions-inventories/national-emissions-inventory-nei",
     description: "Facilities emitting PM2.5, from National Emissions Inventory (NEI)",
     source: {
@@ -190,6 +205,92 @@ export const overlayRegistry = {
       sourceId: "nei-facilities-source",
       sourceLayerId: "resources",
       circleColor: "#ff6666",
+    })
+  },
+  "Exercise/Gyms": {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
+    source: {
+      id: "us-exercise-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-exercise.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "us-exercise",
+      sourceId: "us-exercise-source",
+      sourceLayerId: "resources",
+      circleColor: "#FCC1B9",
+    })
+  },
+  "Schools": {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
+    source: {
+      id: "us-schools-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-schools.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "us-schools",
+      sourceId: "us-schools-source",
+      sourceLayerId: "resources",
+      circleColor: "#C398A0",
+    })
+  },
+  "Supermarkets/Grocery": {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
+    source: {
+      id: "us-grocery-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-grocery.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "us-grocery",
+      sourceId: "us-grocery-source",
+      sourceLayerId: "resources",
+      circleColor: "#FCC1E5",
+    })
+  },
+  "Libraries": {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
+    source: {
+      id: "us-libraries-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-libraries.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "us-libraries",
+      sourceId: "us-libraries-source",
+      sourceLayerId: "resources",
+      circleColor: "#6BAABF",
+      // labelColor: "#FFFFFF",
+    })
+  },
+  Parks: {
+    url: "https://github.com/healthyregions/overture-poi-extract",
+    description: "Thematic extract from Overture Maps Foundation open data.",
+    source: {
+      id: "us-parks-source",
+      spec: {
+        type: "vector",
+        url: "pmtiles://https://raw.githubusercontent.com/healthyregions/overture-poi-extract/main/output/us-parks.pmtiles",
+      }
+    },
+    layers: makeClusteredLayerSet({
+      layerId: "us-parks",
+      sourceId: "us-parks-source",
+      sourceLayerId: "resources",
+      circleColor: "#24e8c8",
     })
   },
 };

--- a/src/components/map/helper/sources.tsx
+++ b/src/components/map/helper/sources.tsx
@@ -1,9 +1,0 @@
-// these are the sources for all overlay layers. multiple layers can be added to the map
-// that use the same source: for example a source for state boundaries can be displayed as a
-// polygon (fill) layer as well as a line (outline) layer
-export const overlaySources = {
-  "us-parks": {
-    type: "vector",
-    url: "pmtiles://https://herop-geodata.s3.us-east-2.amazonaws.com/sdohplace/overlays/us-parks.pmtiles",
-  },
-};

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store";
 import { setShowInfoPanel, setInfoPanelTab } from "@/store/slices/uiSlice";
+import { overlayRegistry } from "@/components/map/helper/layers";
 
 interface Props {
   children?: React.ReactNode;
@@ -275,16 +276,15 @@ export default function InfoPanel() {
           </List>
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={5}>
-          We provide a few map overlay layers that can be used as reference data
-          during your search.
+          We provide a few map overlay layers that can be used for contextual reference
+          during your data search. Please see the &quot;source&quot; link for more about each overlay.
           <List>
-            <ListItem>
-              Parks (
-              <Link href="https://overturemaps.org/">
-                Overture Maps foundation
-              </Link>
-              )
+            {Object.keys(overlayRegistry).map((key, index) => (
+            <ListItem key={index}>
+              {key}: {overlayRegistry[key].description}&ndash;
+              <Link href={overlayRegistry[key].url}>source</Link>
             </ListItem>
+            ))}
           </List>
             This is a feature we hope to expand in the future. Please don&apos;t
             hesitate to <Link href="/contact">get in touch</Link> if you have


### PR DESCRIPTION
To address #459 I've changes the way overlays are defined and added a "cluster" strategy to the layer creation.

![image](https://github.com/user-attachments/assets/5d9faa2e-c3b5-4451-95bb-5e7b0b985a38)

Importantly, this _also_ relies on having a pmtiles file source that has been created with some level of clustering. Currently, I'm using these arguments with tippecanoe to make the file:

```
tippecanoe nei-facilities.geojson -z10 --cluster-distance 10 --cluster-maxzoom g -r1 -d 20 --projection=EPSG:4326 -l resources --force -o nei-facilities.pmtiles
```

In the future we made need to tweak these settings, like the cluster distance and maxzoom, but the result is workable for now.

There is a click interaction that will zoom you in one level if you click on a clustered point, and there is a popup that will show if you click on a non-clustered point, and this now shows all properties of the feature by default.

![image](https://github.com/user-attachments/assets/d18ec36b-78cf-4dee-a321-3f1e24bc684f)