### PR TITLE
fix: remove "shadow element" that appears when Overlays dropdown is open

### DIFF
--- a/src/components/search/mapPanel/mapPanelContent.tsx
+++ b/src/components/search/mapPanel/mapPanelContent.tsx
@@ -155,6 +155,7 @@ const MapPanelContent = (props: Props): JSX.Element => {
             id="basic-menu"
             className="flex items-center sm:justify-end mt-0 order-1 sm:order-none flex-none text-l-500 sm:mr-[2.3em]"
             style={{
+              margin: 0,
               boxShadow: "#aaaaaa 6px 12px 16px -8px",
             }}
             anchorEl={overlaysMenuAnchorEl}


### PR DESCRIPTION
## Problem
On the Discovery App (Search view), when the Overlays dropdown is open we see a mysterious shadow element appear all the way down the right side of the app

We want to hide/remove this element when the dropdown is open

Fixes #462 

## Approach
* fix: remove the shadow element that appears when the Overlays dropdown is open

## How to Test
1. Navigate to https://deploy-preview-465--cheerful-treacle-913a24.netlify.app/search
2. Click the Overlays dropdown on the top-right
    * You should see that the dropdown opens to show the Overlays that we offer
    * You should not see a shadow / extra box appear over the scroll bar on the right
    * Compare with https://discovery_app.dev.sdohplace.org/search?query=*