### PR TITLE
fix: added null checks for Plausible events related to Search

### DIFF
--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -252,11 +252,13 @@ export default function DynamicMap(props: Props): JSX.Element {
         dispatch(setBbox(null));
       };
 
-      plausible(EventType.SubmittedLocationSearch, {
-        props: {
-          ...e.feature.properties
-        }
-      });
+      if (e?.feature?.properties) {
+        plausible(EventType.SubmittedLocationSearch, {
+          props: {
+            ...e.feature.properties
+          }
+        });
+      }
     },
     [dispatch]
   );

--- a/src/components/search/searchArea/enhancedSearch.tsx
+++ b/src/components/search/searchArea/enhancedSearch.tsx
@@ -178,14 +178,16 @@ const EnhancedSearchBox = ({ schema }: Props): JSX.Element => {
             })
           );
 
-          const searchEventType = aiSearch
-            ? EventType.SubmittedChatSearch
-            : EventType.SubmittedKeywordSearch;
-          plausible(searchEventType, {
-            props: {
-              searchQuery: searchValue,
-            },
-          });
+          if (searchValue) {
+            const searchEventType = aiSearch
+              ? EventType.SubmittedChatSearch
+              : EventType.SubmittedKeywordSearch;
+            plausible(searchEventType, {
+              props: {
+                searchQuery: searchValue,
+              },
+            });
+          }
         } finally {
           setIsLocalLoading(false);
         }


### PR DESCRIPTION
## Problem
On the Search view, GeoSearchControl fails to clear when user clicks the X button

An error appears in the console:
```
740.51aeb2356eba5b27.js:1 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'properties')
    at ns.<anonymous> (740.51aeb2356eba5b27.js:1:3999)
    at ns.fire (d94c0b71.5ec4673aaae53c8c.js:4:9879)
    at ea.<anonymous> (193.5f094c41bb516592.js:42:30141)
    at 193.5f094c41bb516592.js:21:81687
    at Array.forEach (<anonymous>)
    at 193.5f094c41bb516592.js:21:81673
    at e.$$.update (193.5f094c41bb516592.js:21:88453)
    at 193.5f094c41bb516592.js:21:44380
    at Ti (193.5f094c41bb516592.js:21:44498)
```

Fixes #464 

## Approach
* fix: only send Plausible event with extra data if there is extra data to send - otherwise, no-op and do not send the event 

## How to Test
1. Navigate to https://deploy-preview-466--cheerful-treacle-913a24.netlify.app/search
2. Enter a query into the GeoSearchControl (e.g. `Champaign County`)
    * You should see that the results are enumerated in a dropdown below the search box
3. Choose a search result
    * You should see that the map zooms in to highlight the chosen area
    * You should see that the contents of the search box are updated to reflect the chosen result
4. Click the X button in the GeoSearchControl
    * You should see that the search box is cleared of its contents
    * You should see that the map no longer highlights the area, but does not zoom out
    * Compare with https://discovery_app.dev.sdohplace.org/search?query=*
5. Without refreshing the page, enter a new search query into the GeoSearchControl
    * You should see that the search box still works, and autocomplete shows possible matches for the entered query