### PR TITLE
#460: Append the suggested result to the end of the search result

### DIFF
--- a/src/components/search/helper/FilterByScore.tsx
+++ b/src/components/search/helper/FilterByScore.tsx
@@ -53,21 +53,22 @@ export function getScoreExplanation(
   avgScore: number,
   maxScore: number
 ): string {
-  if (!spellcheck || q === currentQuery) {
+  if (!q || q === "*" || currentQuery === "*") return;
+  if (!spellcheck && q === currentQuery) {
     q = q
       .replace(/,/g, '"')
       .replace(/"/g, " ")
       ;
     if (score > maxScore * 0.8) {
-      return `This is a strong match for <b>${q}...</b> in important fields like title and description.`;
+      return `This is a strong match for <b>${q}</b> in important fields like title and description.`;
     }
     if (score > avgScore) {
-      return `This is a good match for <b>${q}...</b> that contains your search terms across multiple fields.`;
+      return `This is a good match for <b>${q}</b> that contains your search terms across multiple fields.`;
     }
     if (score == avgScore) {
-      return `This is a moderate match for <b>${q}...</b>.`;
+      return `This is a moderate match for <b>${q}</b>.`;
     }
-    return `This is a broader match for <b>${q}...</b>.`;
+    return `This is a broader match for <b>${q}</b>.`;
   }
   return `You may find <b>${q}</b> in this result relevant for <i>${currentQuery}</i>.`;
 }

--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -56,12 +56,11 @@ const ResultsPanel = (props: Props): JSX.Element => {
       (v) => !searchState.results.some((t) => t.id === v.id)
     );
   }, [searchState.relatedResults, searchState.results]);
-  const showRelatedSection = React.useMemo(() => {
-    return (
-      isQuery && !isLoading && !isResetting && uniqueRelatedList.length > 0
-    );
-  }, [isQuery, isLoading, isResetting, uniqueRelatedList.length]);
-
+  // const showRelatedSection = React.useMemo(() => {
+  //   return (
+  //     isQuery && !isLoading && !isResetting && uniqueRelatedList.length > 0
+  //   );
+  // }, [isQuery, isLoading, isResetting, uniqueRelatedList.length]);
   const handleFilterToggle = () => {
     dispatch(setShowFilter(!showFilter));
   };
@@ -212,42 +211,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
                         </Box>
                       </div>
                     )
-                  )}
-
-                  {showRelatedSection && (
-                    <Box className="sm:my-[1.68em]">
-                      <div className="sm:mb-[1.5em] sm:flex-col">
-                        <div className="flex flex-grow sm:ml-[0.7em] items-center text-2xl">
-                          <span className="mr-4">
-                            You may be interested in...
-                          </span>
-                          <div
-                            className="flex-grow border-b-2 sm:mr-[2.3em]"
-                            style={{
-                              height: "1px",
-                              border: `1px solid ${fullConfig.theme.colors["strongorange"]}`,
-                            }}
-                          />
-                        </div>
-                        <Box
-                          height="100%"
-                          className="sm:mt-[0.875em]"
-                          sx={{
-                            overflowY: "scroll",
-                            paddingRight: "1em",
-                            maxHeight:
-                              SearchUIConfig.search.searchResults
-                                .relatedListHeight,
-                          }}
-                        >
-                          {uniqueRelatedList.map((result) => (
-                            <div key={result.id} className="mb-[0.75em]">
-                              <ResultCard resultItem={result} />
-                            </div>
-                          ))}
-                        </Box>
-                      </div>
-                    </Box>
                   )}
                 </div>
               )}

--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -6,7 +6,6 @@ import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import SearchIcon from "@mui/icons-material/Search";
 import { clearMapPreview, setShowFilter } from "@/store/slices/uiSlice";
-import { SearchUIConfig } from "@/components/searchUIConfig";
 import { Box, SvgIcon, CircularProgress, Fade, Collapse } from "@mui/material";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import React from "react";
@@ -18,8 +17,8 @@ import {
   resetFilters,
 } from "@/middleware/filterHelper";
 import ThemeIcons from "../helper/themeIcons";
-import {EventType} from "@/lib/event";
-import {usePlausible} from "next-plausible";
+import { EventType } from "@/lib/event";
+import { usePlausible } from "next-plausible";
 
 interface Props {
   schema: any;
@@ -56,11 +55,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
       (v) => !searchState.results.some((t) => t.id === v.id)
     );
   }, [searchState.relatedResults, searchState.results]);
-  // const showRelatedSection = React.useMemo(() => {
-  //   return (
-  //     isQuery && !isLoading && !isResetting && uniqueRelatedList.length > 0
-  //   );
-  // }, [isQuery, isLoading, isResetting, uniqueRelatedList.length]);
   const handleFilterToggle = () => {
     dispatch(setShowFilter(!showFilter));
   };
@@ -75,8 +69,8 @@ const ResultsPanel = (props: Props): JSX.Element => {
   const displayCount = React.useMemo(() => {
     if (isResetting) return previousCount;
     if (isLoading) return previousCount;
-    return searchState.results.length;
-  }, [isLoading, isResetting, previousCount, searchState.results.length]);
+    return searchState.results.length + uniqueRelatedList.length;
+  }, [isLoading, isResetting, previousCount, searchState.results.length, uniqueRelatedList.length]);
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const hasSearchParams = params.has("query") || params.has("ai_search");
@@ -89,7 +83,7 @@ const ResultsPanel = (props: Props): JSX.Element => {
       setPreviousCount(searchState.results.length);
     }
   }, [isLoading, searchState.results.length, isResetting]);
-
+  console.log("searchState.results.length", searchState.results, "uniqueRelatedList", uniqueRelatedList);
   const renderLoadingState = () => (
     <Box className="flex flex-col w-full">
       <Box className="flex justify-center items-center h-64">
@@ -173,15 +167,15 @@ const ResultsPanel = (props: Props): JSX.Element => {
                       sx={{
                         overflowY: "scroll",
                         paddingRight: "1.25em",
-                        maxHeight:
-                          (isQuery && uniqueRelatedList.length > 0) ||
-                          showFilter
-                            ? SearchUIConfig.search.searchResults
-                                .resultListHeight
-                            : "100vh",
+                        maxHeight: "100vh",
                       }}
                     >
                       {searchState.results.map((result) => (
+                        <div key={result.id} className="mb-[0.75em]">
+                          <ResultCard resultItem={result} />
+                        </div>
+                      ))}
+                      {uniqueRelatedList.map((result) => (
                         <div key={result.id} className="mb-[0.75em]">
                           <ResultCard resultItem={result} />
                         </div>
@@ -193,13 +187,11 @@ const ResultsPanel = (props: Props): JSX.Element => {
                         <Box className="flex flex-col justify-center items-center mb-[1.5em]">
                           <SearchIcon className="text-strongorange mb-[0.15em]" />
                           <div className="text-s">No results</div>
-                          {
-                            plausible(EventType.ReceivedNoSearchResults, {
-                              props: {
-                                searchQuery: searchState.query
-                              }
-                            })
-                          }
+                          {plausible(EventType.ReceivedNoSearchResults, {
+                            props: {
+                              searchQuery: searchState.query,
+                            },
+                          })}
                         </Box>
                         <Box className="mb-[0.75em]">
                           <div className="text-s">

--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -83,7 +83,6 @@ const ResultsPanel = (props: Props): JSX.Element => {
       setPreviousCount(searchState.results.length);
     }
   }, [isLoading, searchState.results.length, isResetting]);
-  console.log("searchState.results.length", searchState.results, "uniqueRelatedList", uniqueRelatedList);
   const renderLoadingState = () => (
     <Box className="flex flex-col w-full">
       <Box className="flex justify-center items-center h-64">

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -205,14 +205,17 @@ export const fetchSearchAndRelatedResults = createAsyncThunk(
         relatedResults.push(...suggestionResults);
       }
     }
-    return {
-      searchResults: finalResults.map((result) => ({
+    finalResults = finalResults.map((result) => ({
         ...result,
         years: Array.isArray(result.years)
           ? result.years
           : Array.from(result.years || []),
-      })),
-      relatedResults,
+      }));
+    // #460: Append related results (you may interested in...) to the end of the search results
+    finalResults.push(...relatedResults);
+    return {
+      searchResults: finalResults,
+      relatedResults: [],
       suggestions: validSuggestions,
       originalQuery: query,
       usedQuery,

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -103,7 +103,6 @@ export const performChatGptSearch = createAsyncThunk(
       const uniqueResults = Array.from(
         new Map(combinedResults.map((item) => [item.id, item])).values()
       );
-
       return {
         searchResults: uniqueResults,
         relatedResults: [],
@@ -111,7 +110,7 @@ export const performChatGptSearch = createAsyncThunk(
         originalQuery: question,
         usedQuery: analysis.suggestedQueries.join(", "),
         usedSpellCheck: false,
-        analysis
+        analysis,
       };
     } catch (error) {
       throw new Error(`ChatGPT search failed: ${error.message}`);
@@ -206,20 +205,18 @@ export const fetchSearchAndRelatedResults = createAsyncThunk(
       }
     }
     finalResults = finalResults.map((result) => ({
-        ...result,
-        years: Array.isArray(result.years)
-          ? result.years
-          : Array.from(result.years || []),
-      }));
-    // #460: Append related results (you may interested in...) to the end of the search results
-    finalResults.push(...relatedResults);
+      ...result,
+      years: Array.isArray(result.years)
+        ? result.years
+        : Array.from(result.years || []),
+    }));
     return {
       searchResults: finalResults,
-      relatedResults: [],
+      relatedResults: relatedResults,
       suggestions: validSuggestions,
       originalQuery: query,
       usedQuery,
-      usedSpellCheck
+      usedSpellCheck,
     };
   }
 );


### PR DESCRIPTION
## PR for #460: Merging Related Results with Search Results

This PR integrates the "You may be interested in..." related results section that we currently have in prod into the main search results section, reducing unnecessary scrolling for users.

## How to Test
1. Navigate to https://deploy-preview-467--cheerful-treacle-913a24.netlify.app/search and search for "mean".
- You should see 17 (5+12) results in total, which matches the combined number of search results and related suggestions in the production environment (https://discovery_app.dev.sdohplace.org/search?query=mean).
- Screenshot:
<img width="1283" alt="Screenshot 2025-02-27 at 5 44 03 PM" src="https://github.com/user-attachments/assets/2df694a3-74a5-4c78-a0fd-40c21fd724cb" />

2. Review the Results
- Skim through the list to verify that the related results are now seamlessly integrated.
- The tooltip text for "You may be interested in..." suggestions has been updated to:`You may find <b>${q}</b> in this result relevant for <i>${currentQuery}</i>.`:
<img width="1514" alt="Screenshot 2025-02-27 at 5 45 39 PM" src="https://github.com/user-attachments/assets/596cecd5-8f05-4bbf-956a-7dc841fcf393" />

3. Test with Other Search Terms
- Try different keywords to ensure the feature works as expected.
- Note: This update applies only to keyword-based searches, not AI-driven searches.