### PR TITLE
#470: Fix show detail

### DIFF
--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -30,7 +30,6 @@ export default function DiscoveryArea({ schema }): JSX.Element {
     (state: RootState) => state.search
   );
   const [isMounted, setIsMounted] = useState(false);
-
   useEffect(() => {
     if (isMounted && typeof window !== "undefined") {
       const urlParams = new URLSearchParams(window.location.search);

--- a/src/middleware/createMiddleware.ts
+++ b/src/middleware/createMiddleware.ts
@@ -54,15 +54,16 @@ export const createMiddleware: Middleware =
     /**
      * Page initialization actions
      */
-     if (
-       action.type === "search/initialize/pending" ||
-       action.type === "search/initialize/fulfilled"
-     ) {
-       return next(action);
-     }
-     if (action.type === "search/setSchema") {
-       return next(action);
-     }
+    if (action.type === "search/initialize/pending") {
+      initializeFromUrl(store);
+      return next(action);
+    }
+    if (
+      action.type === "search/initialize/fulfilled" ||
+      action.type === "search/setSchema"
+    ) {
+      return next(action);
+    }
     /**
      * Handle bbox
      */


### PR DESCRIPTION
This PR fixes issue #470, resolving a bug that prevented the detail view from appearing when users copied and pasted a URL containing the `show=` parameter.

## How to Test
1. Navigate to the search page and click "Details" on any result item to open the detail view.
2. Click "Share" to generate a shared link, then copy and paste the URL into a new tab or window.
3. The detail view should be displayed by default on the newly opened page.