### PR TITLE
#471: Add more bottom margin to the filter panel when it is on

### DIFF
--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -18,8 +18,8 @@ import {
   resetFilters,
 } from "@/middleware/filterHelper";
 import ThemeIcons from "../helper/themeIcons";
-import {EventType} from "@/lib/event";
-import {usePlausible} from "next-plausible";
+import { EventType } from "@/lib/event";
+import { usePlausible } from "next-plausible";
 
 interface Props {
   schema: any;
@@ -153,7 +153,7 @@ const ResultsPanel = (props: Props): JSX.Element => {
         </Box>
 
         <Collapse
-          className={"relative w-full"}
+          className={`relative w-full ${showFilter ? "mb-4" : ""}`}
           in={showFilter}
           timeout={300}
           easing={"linear"}
@@ -194,13 +194,11 @@ const ResultsPanel = (props: Props): JSX.Element => {
                         <Box className="flex flex-col justify-center items-center mb-[1.5em]">
                           <SearchIcon className="text-strongorange mb-[0.15em]" />
                           <div className="text-s">No results</div>
-                          {
-                            plausible(EventType.ReceivedNoSearchResults, {
-                              props: {
-                                searchQuery: searchState.query
-                              }
-                            })
-                          }
+                          {plausible(EventType.ReceivedNoSearchResults, {
+                            props: {
+                              searchQuery: searchState.query,
+                            },
+                          })}
                         </Box>
                         <Box className="mb-[0.75em]">
                           <div className="text-s">


### PR DESCRIPTION
## PR for #471: Add Bottom Margin to Expandable Filter Panel
This PR introduces a bottom margin between the expandable filter panel and the first result item, improving visual separation. Previously, the panel and the first result appeared too close together:

<img width="551" alt="Screenshot 2025-03-04 at 9 43 37 AM" src="https://github.com/user-attachments/assets/72799534-9a04-4723-96b8-ab9a3524c811" />

## How to Test
1. Navigate to the search page and expand the filter panel.
2. You should now see a visible gap between the bottom of the panel and the first result item:
<img width="596" alt="Screenshot 2025-03-04 at 9 43 18 AM" src="https://github.com/user-attachments/assets/479c5676-cb73-4072-8928-7a472312a235" />