### PR TITLE
fix: null object pattern - use empty array if tags are undefined/null

### DIFF
--- a/src/pages/news/[post].tsx
+++ b/src/pages/news/[post].tsx
@@ -84,7 +84,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       dateString: data.date,
       slug: slug,
       description: "",
-      tags: data.tags,
+      tags: data.tags || [],
       author: data.author,
       source: mdxSource,
     },


### PR DESCRIPTION
## Problem
This problem was located in #461 

When creating a new post, if `tags` are not defined in the frontmatter then the build/publish step can fail

For example:
https://github.com/healthyregions/SDOHPlace/pull/461/files#diff-0a533058926c6579ba4e5f979149f98902edf0d0aab98da670a6d891c2b96256R1-R10

## Approach
* fix: fallback to empty array if undefined/null tags are encountered

## How to Test
1. Create a post without specifying any `tags`
2. Click Publish and verify that the build completes successfully