### PR TITLE
feat: add banner for soft launch

### DIFF
--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -80,7 +80,7 @@ export default function DiscoveryArea({ schema }): JSX.Element {
         <Grid container className="container mx-auto py-[1em] px-4">
           <Banner>
             This platform is under development, feel free to
-            <BannerLink href={'#'} target={'_blank'}>share your feedback &rarr;</BannerLink>
+            <BannerLink href={'https://go.illinois.edu/DATA-DISCOVERY-FEEDBACK'} target={'_blank'}>share your feedback &rarr;</BannerLink>
           </Banner>
         </Grid>
       </Grid>

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import type { AppDispatch, RootState } from "../../store";
+import type { AppDispatch, RootState } from "@/store";
 import { Collapse, Grid } from "@mui/material";
 import SearchArea from "./searchArea";
 import DetailPanel from "./detailPanel";
@@ -12,6 +12,7 @@ import * as React from "react";
 import styled from "@emotion/styled";
 
 const BannerLink = styled.a`
+  margin-left: 0.25rem;
   :link { text-decoration: none; }
   :visited { text-decoration: none; }
   :hover { text-decoration: underline; }
@@ -70,12 +71,14 @@ export default function DiscoveryArea({ schema }): JSX.Element {
           <SearchArea schema={schema} header="Data Discovery" />
         </Grid>
       </Grid>
-      <Grid container spacing={0} className={'container mx-auto px-12 py-4 bg-lightbisque'}>
-        <Grid item xs={12}>
-          This platform is under development, feel free to{" "}
+
+      <Grid className="w-full px-[1em] sm:px-[2em] max-md:max-w-full shadow-none aspect-ratio bg-lightbisque">
+        <Grid container className="container mx-auto py-[1em] px-4">
+          This platform is under development, feel free to
           <BannerLink href={'#'} target={'_blank'}>share your feedback &rarr;</BannerLink>
         </Grid>
       </Grid>
+
       <Grid
         className="w-full px-[1em] sm:px-[2em] transition-all duration-300"
       >

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -17,7 +17,11 @@ const BannerLink = styled.a`
   :visited { text-decoration: none; }
   :hover { text-decoration: underline; }
   :active { text-decoration: underline; }
-`
+`;
+
+const Banner = styled.div`
+  font-size: 14px;
+`;
 
 const DynamicResultsPanel = dynamic(() => import("./resultsPanel"), {
   ssr: false,
@@ -74,8 +78,10 @@ export default function DiscoveryArea({ schema }): JSX.Element {
 
       <Grid className="w-full px-[1em] sm:px-[2em] max-md:max-w-full shadow-none aspect-ratio bg-lightbisque">
         <Grid container className="container mx-auto py-[1em] px-4">
-          This platform is under development, feel free to
-          <BannerLink href={'#'} target={'_blank'}>share your feedback &rarr;</BannerLink>
+          <Banner>
+            This platform is under development, feel free to
+            <BannerLink href={'#'} target={'_blank'}>share your feedback &rarr;</BannerLink>
+          </Banner>
         </Grid>
       </Grid>
 

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -73,7 +73,7 @@ export default function DiscoveryArea({ schema }): JSX.Element {
       <Grid container spacing={0} className={'container mx-auto px-12 py-4 bg-lightbisque'}>
         <Grid item xs={12}>
           This platform is under development, feel free to{" "}
-          <BannerLink href={'#'}>share your feedback &rarr;</BannerLink>
+          <BannerLink href={'#'} target={'_blank'}>share your feedback &rarr;</BannerLink>
         </Grid>
       </Grid>
       <Grid

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -9,6 +9,14 @@ import { initializeSearch, setSchema } from "@/store/slices/searchSlice";
 import MapPanel from "./mapPanel/mapPanelContent";
 import dynamic from "next/dynamic";
 import * as React from "react";
+import styled from "@emotion/styled";
+
+const BannerLink = styled.a`
+  :link { text-decoration: none; }
+  :visited { text-decoration: none; }
+  :hover { text-decoration: underline; }
+  :active { text-decoration: underline; }
+`
 
 const DynamicResultsPanel = dynamic(() => import("./resultsPanel"), {
   ssr: false,
@@ -57,11 +65,17 @@ export default function DiscoveryArea({ schema }): JSX.Element {
   }
   return (
     <Grid container>
-        <Grid className="w-full px-[1em] sm:px-[2em] sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
-          <Grid container className="container mx-auto pt-[2em] sm:pt-0">
-            <SearchArea schema={schema} header="Data Discovery" />
-          </Grid>
+      <Grid className="w-full px-[1em] sm:px-[2em] sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
+        <Grid container className="container mx-auto pt-[2em] sm:pt-0">
+          <SearchArea schema={schema} header="Data Discovery" />
         </Grid>
+      </Grid>
+      <Grid container spacing={0} className={'container mx-auto px-12 py-4 bg-lightbisque'}>
+        <Grid item xs={12}>
+          This platform is under development, feel free to{" "}
+          <BannerLink href={'#'}>share your feedback &rarr;</BannerLink>
+        </Grid>
+      </Grid>
       <Grid
         className="w-full px-[1em] sm:px-[2em] transition-all duration-300"
       >


### PR DESCRIPTION
## Problem
We would like to add a banner letting people know that this is a new platform and we are open to feedback and potential future directions

Fixes #478 

## Approach
* feat: added the banner as it appears in the [Figma designs](https://www.figma.com/design/vD6pC3DsFtGG2aCv4vWXtV/HEROP?node-id=3209-609&t=uwESnBJNhgvo3Afk-0)

TODO: banner URL does not currently work, but once form is live this link should work correctly
TODO: should banner URL be parameterized? not clear how often or if ever it would change in the future 🤔 

![Screenshot 2025-03-05 at 12 40 04 PM](https://github.com/user-attachments/assets/de07e41e-5b65-4f11-a1ae-373dc97e1614)

## How to Test
1. Navigate to https://deploy-preview-483--cheerful-treacle-913a24.netlify.app/search
    * You should see the banner now appears below the page header / search area
    * You should see a link is offered in the banner
2. Click the link in the banner
    * You should see that the [Feedback form](https://go.illinois.edu/DATA-DISCOVERY-FEEDBACK) opens in a new tab