### PR TITLE
style: added spacing on result card and removed padding from item details

### DIFF
--- a/src/components/search/detailPanel/introCard.tsx
+++ b/src/components/search/detailPanel/introCard.tsx
@@ -23,7 +23,7 @@ const IntroCard = (props: Props): JSX.Element => {
   return (
     <div className={`container mx-auto shadow-none aspect-ratio`}>
       <div className="flex flex-col sm:flex-row border-t border-t-1 border-strongorange">
-        <div className="flex-1 w-full sm:w-2/3  sm:pl-3.5 sm:pr-6 sm:pt-5">
+        <div className="flex-1 w-full sm:w-2/3 sm:pr-6 sm:pt-5">
           <div className={`${classes.introCard}`}>
             <b>Keyword:</b>{" "}
             {props.resultItem.meta.keyword

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -265,7 +265,7 @@ const ResultCard = (props: Props): JSX.Element => {
 
         </Grid>
       </div>
-      <Grid spacing={0} container className="flex flex-col sm:flex-row px-2 mt-1">
+      <Grid spacing={2} container className="flex flex-col sm:flex-row px-2 mt-1">
         <Grid item xs={8}>
           <div className={`${classes.resultCard} truncate `}>
             Keywords:{" "}


### PR DESCRIPTION
## Problem
We would like to add some spacing on the Result Card and remove padding from the Item Details Intro Card

Closes #480 

## Approach
* style: added spacing on result card and removed padding from item details

## How to Test
1. Navigate to https://deploy-preview-484--cheerful-treacle-913a24.netlify.app/search
    * You should see results are listed on the left side
    * You should see that the space between the 2 columns at the bottom of each Result Card has been increased
2. Choose a result and click "Details"
    * You should see the Details View appear
    * You should see that the Intro Card section (just below the first orange horizontal line) is now aligned with the orange line