### PR TITLE
#472,#481,#482, #488: adjust filter mechanism to avoid possible racing condition and minor bug fixes

### DIFF
--- a/src/components/map/dynamicMap.tsx
+++ b/src/components/map/dynamicMap.tsx
@@ -31,6 +31,7 @@ import GeoSearchControl from "./geoSearchControl";
 import { clearMapPreview } from "@/store/slices/uiSlice";
 import {EventType} from "@/lib/event";
 import {usePlausible} from "next-plausible";
+import { debounce } from "@mui/material";
 
 const apiKey = process.env.NEXT_PUBLIC_MAPTILER_API_KEY;
 
@@ -201,7 +202,7 @@ export default function DynamicMap(props: Props): JSX.Element {
   }, []);
 
   const setBboxOnMoveEnd = useCallback(
-    (event: ViewStateChangeEvent) => {
+     debounce((event: ViewStateChangeEvent) => {
       const bounds = event.target.getBounds();
       const newBbox: [number, number, number, number] = [
         Math.round(bounds._sw.lng * 1000) / 1000,
@@ -210,8 +211,7 @@ export default function DynamicMap(props: Props): JSX.Element {
         Math.round(bounds._ne.lat * 1000) / 1000,
       ];
       dispatch(setBbox(newBbox));
-    },
-    [dispatch]
+    }, 300),[dispatch]
   );
 
   const handleGeoSearchSelection = useCallback(

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "../../store";
-import { Collapse, Grid } from "@mui/material";
+import { Grid } from "@mui/material";
 import SearchArea from "./searchArea";
 import DetailPanel from "./detailPanel";
 import { initializeSearch, setSchema } from "@/store/slices/searchSlice";
@@ -23,19 +23,15 @@ const DynamicResultsPanel = dynamic(() => import("./resultsPanel"), {
 
 export default function DiscoveryArea({ schema }): JSX.Element {
   const dispatch = useDispatch<AppDispatch>();
-  const { showDetailPanel } = useSelector(
-    (state: RootState) => state.ui
-  );
+  const { showDetailPanel } = useSelector((state: RootState) => state.ui);
   const { results, relatedResults } = useSelector(
     (state: RootState) => state.search
   );
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
-    if (isMounted && typeof window !== "undefined") {
-      const urlParams = new URLSearchParams(window.location.search);
-      dispatch(initializeSearch({ schema, urlParams }));
-    }
+    if (isMounted && typeof window !== "undefined")
+      dispatch(initializeSearch({ schema }));
   }, [schema, dispatch, isMounted]);
 
   useEffect(() => {
@@ -58,14 +54,12 @@ export default function DiscoveryArea({ schema }): JSX.Element {
   }
   return (
     <Grid container>
-        <Grid className="w-full px-[1em] sm:px-[2em] sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
-          <Grid container className="container mx-auto pt-[2em] sm:pt-0">
-            <SearchArea schema={schema} header="Data Discovery" />
-          </Grid>
+      <Grid className="w-full px-[1em] sm:px-[2em] sm:mt-32 max-md:max-w-full shadow-none aspect-ratio bg-lightviolet">
+        <Grid container className="container mx-auto pt-[2em] sm:pt-0">
+          <SearchArea schema={schema} header="Data Discovery" />
         </Grid>
-      <Grid
-        className="w-full px-[1em] sm:px-[2em] transition-all duration-300"
-      >
+      </Grid>
+      <Grid className="w-full px-[1em] sm:px-[2em] transition-all duration-300">
         <Grid container className="container mx-auto pt-[1.5rem]">
           <Grid item xs={12} sm={6}>
             <DynamicResultsPanel schema={schema} />

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -66,7 +66,11 @@ export default function DiscoveryArea({ schema }): JSX.Element {
           <Grid item xs={12} sm={6} className="sm:ml-[0.5em]">
             <MapPanel
               resultsList={results}
-              showMap={showDetailPanel ? "none" : "block"}
+              showMap={
+                showDetailPanel && (results && results.find((r) => r.id === showDetailPanel))
+                  ? "none"
+                  : "block"
+              }
               schema={schema}
             />
             {showDetailPanel && showDetailPanel.length > 0 && (

--- a/src/components/search/filterPanel/sortOptions.tsx
+++ b/src/components/search/filterPanel/sortOptions.tsx
@@ -1,17 +1,18 @@
 import { AppDispatch, RootState } from "@/store";
-import { setSortBy, setSortOrder } from "@/store/slices/searchSlice";
+import { setSort } from "@/store/slices/searchSlice";
 import { Box } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 
 export const SortOptions = () => {
   const dispatch = useDispatch<AppDispatch>();
-  const { sortBy, sortOrder, isSearching } = useSelector(
+  const { sort, isSearching, initializing } = useSelector(
     (state: RootState) => state.search
   );
 
-  const handleSort = (newSortBy: string, newSortOrder: string) => {
-    dispatch(setSortBy(newSortBy));
-    dispatch(setSortOrder(newSortOrder));
+  const handleSort = (field: string, direction: string) => {
+    if (isSearching || initializing) return;
+    if (isSearching || initializing) return;
+    dispatch(setSort({ field, direction }));
   };
 
   return (
@@ -22,7 +23,7 @@ export const SortOptions = () => {
             isSearching ? "opacity-50" : ""
           }`}
           style={{
-            textDecoration: !sortBy && !sortOrder ? "underline" : "none",
+            textDecoration: sort.sortBy === "score" ? "underline" : "none",
           }}
           onClick={() => handleSort("score", "desc")}
         >
@@ -35,7 +36,7 @@ export const SortOptions = () => {
           }`}
           style={{
             textDecoration:
-              sortBy === "issued" && sortOrder === "desc"
+              sort.sortBy !== "score" && sort.sortOrder === "desc"
                 ? "underline"
                 : "none",
           }}
@@ -50,7 +51,9 @@ export const SortOptions = () => {
           }`}
           style={{
             textDecoration:
-              sortBy === "issued" && sortOrder === "asc" ? "underline" : "none",
+              sort.sortBy !== "score" && sort.sortOrder !== "desc"
+                ? "underline"
+                : "none",
           }}
           onClick={() => handleSort("date_issued", "asc")}
         >

--- a/src/components/search/filterPanel/sortOptions.tsx
+++ b/src/components/search/filterPanel/sortOptions.tsx
@@ -40,7 +40,7 @@ export const SortOptions = () => {
                 ? "underline"
                 : "none",
           }}
-          onClick={() => handleSort("date_issued", "desc")}
+          onClick={() => handleSort("index_year", "desc")}
         >
           Recent first
         </span>
@@ -55,7 +55,7 @@ export const SortOptions = () => {
                 ? "underline"
                 : "none",
           }}
-          onClick={() => handleSort("date_issued", "asc")}
+          onClick={() => handleSort("index_year", "asc")}
         >
           Oldest first
         </span>

--- a/src/components/search/filterPanel/yearRangeSlider.tsx
+++ b/src/components/search/filterPanel/yearRangeSlider.tsx
@@ -2,8 +2,6 @@ import { AppDispatch, RootState } from "@/store";
 import { setIndexYear } from "@/store/slices/searchSlice";
 import {
   Box,
-  debounce,
-  makeStyles as muiMakeStyles,
   Slider,
   SxProps,
   Theme,
@@ -38,21 +36,15 @@ export const YearRangeSlider = ({
   const indexYear = useSelector((state: RootState) => state.search.indexYear);
   const [yearRange, setYearRange] = useState([minRange, maxRange]);
   const timeoutRef = useRef<NodeJS.Timeout>();
-
   useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const yearParam = searchParams.get("index_year");
-    if (yearParam) {
-      const [start, end] = yearParam.split("-").map(Number);
-      setYearRange([start, end]);
-    } else if (indexYear && indexYear.length > 0) {
-      setYearRange([
-        Math.min(...indexYear.map(Number)),
-        Math.max(...indexYear.map(Number)),
-      ]);
-    } else {
+    if (!indexYear || indexYear.length === 0) {
       setYearRange([minRange, maxRange]);
+      return;
     }
+    const years = indexYear.map(Number);
+    const min = Math.min(...years);
+    const max = Math.max(...years);
+    setYearRange([min, max]);
   }, [indexYear, minRange, maxRange]);
 
   const marks = useMemo(

--- a/src/components/search/searchArea/enhancedSearch.tsx
+++ b/src/components/search/searchArea/enhancedSearch.tsx
@@ -140,8 +140,7 @@ const EnhancedSearchBox = ({ schema }: Props): JSX.Element => {
     inputValue,
     suggestions,
     filterQueries,
-    sortBy,
-    sortOrder,
+    sort,
     thoughts,
     isSearching,
   } = useSelector((state: RootState) => state.search);
@@ -172,8 +171,8 @@ const EnhancedSearchBox = ({ schema }: Props): JSX.Element => {
               query: searchValue,
               filterQueries,
               schema,
-              sortBy,
-              sortOrder,
+              sortBy: sort.sortBy,
+              sortOrder: sort.sortOrder,
               bypassSpellCheck: false,
             })
           );
@@ -191,7 +190,7 @@ const EnhancedSearchBox = ({ schema }: Props): JSX.Element => {
         }
       }
     },
-    [dispatch, filterQueries, schema, sortBy, sortOrder, aiSearch, plausible]
+    [dispatch, filterQueries, schema, sort.sortBy, sort.sortOrder, aiSearch, plausible]
   );
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();

--- a/src/components/search/searchArea/spellCheckMessage.tsx
+++ b/src/components/search/searchArea/spellCheckMessage.tsx
@@ -11,8 +11,7 @@ const SpellCheckMessage = () => {
     usedSpellCheck,
     filterQueries,
     schema,
-    sortBy,
-    sortOrder
+    sort
   } = useSelector((state: RootState) => state.search);
   if (!usedSpellCheck) return null;
   const handleOriginalSearch = () => {
@@ -22,8 +21,8 @@ const SpellCheckMessage = () => {
         query: originalQuery,
         filterQueries,
         schema,
-        sortBy,
-        sortOrder,
+        sortBy: sort.sortBy,
+        sortOrder: sort.sortOrder,
         bypassSpellCheck: true
       })
     );

--- a/src/middleware/actionConfig.ts
+++ b/src/middleware/actionConfig.ts
@@ -42,7 +42,7 @@ export const actionConfig: Record<string, ActionConfig> = {
   "search/setBbox": {
     param: "bbox",
     syncWithUrl: true,
-    requiresFetch: false,
+    requiresFetch: true,
     isFilter: true,
     transform: {
       toUrl: (value: number[]) => value.join(","),
@@ -96,17 +96,11 @@ export const actionConfig: Record<string, ActionConfig> = {
   "search/setSchema": {
     param: "schema",
     syncWithUrl: false,
-    requiresFetch: true,
+    requiresFetch: false,
     isFilter: false,
   },
-  "search/setSortBy": {
-    param: "sortBy",
-    syncWithUrl: false,
-    requiresFetch: true,
-    isFilter: false,
-  },
-  "search/setSortOrder": {
-    param: "sortOrder",
+  "search/setSort": {
+    param: "sort",
     syncWithUrl: false,
     requiresFetch: true,
     isFilter: false,

--- a/src/middleware/createMiddleware.ts
+++ b/src/middleware/createMiddleware.ts
@@ -1,100 +1,64 @@
 import { AnyAction, Middleware } from "redux";
 import {
+  batchResetFilters,
   fetchSearchAndRelatedResults,
-  fetchSearchResults,
-  performChatGptSearch,
   setIsSearching,
 } from "@/store/slices/searchSlice";
 import { generateFilterQueries } from "./filterHelper";
 import { ActionConfig, actionConfig } from "./actionConfig";
 
 const isClient = typeof window !== "undefined";
-const isValidBbox = (bbox: number[] | undefined): boolean => {
-  return Boolean(bbox && bbox.length === 4);
-};
 
-export const createMiddleware: Middleware =
-  (store) => (next) => (action: AnyAction) => {
+
+export const createMiddleware: Middleware = (store) => {
+  let isInitializing = false;
+  return (next) => (action: AnyAction) => {
     if (!isClient) {
       return next(action);
     }
-    if (
-      action.type === "search/clearSearch/pending" ||
-      action.type === "search/clearSearch/fulfilled"
-    ) {
+    if (action.type === "search/initialize/pending") {
+      isInitializing = true;
+      initializeFromUrl(store);
+      return next(action);
+    }
+    if (action.type === "search/initialize/fulfilled") {
+      isInitializing = false;
+      return next(action);
+    }
+    if (action.type === batchResetFilters.type) {
       const result = next(action);
-      if (action.type === "search/clearSearch/fulfilled") {
-        const searchParams = new URLSearchParams(window.location.search);
-        searchParams.delete("query");
-        const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
-        window.history.pushState({}, "", newUrl);
-      }
+      triggerResultsRelatesFetch(store, action.payload.query);
       return result;
     }
-    /**
-     * filter reset
-     */
-    if (
-      action.type === "search/atomicResetAndFetch/pending" ||
-      action.type === "search/atomicResetAndFetch/fulfilled"
-    ) {
-      const result = next(action);
-      if (action.type === "search/atomicResetAndFetch/fulfilled") {
-        const searchParams = new URLSearchParams(window.location.search);
-        Object.entries(actionConfig)
-          .filter(([_, config]) => config.syncWithUrl)
-          .forEach(([_, config]) => {
-            searchParams.delete(config.param);
-          });
-        const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
-        window.history.pushState({}, "", newUrl);
-      }
-      return result;
-    }
-    /**
-     * Page initialization actions
-     */
-     if (
-       action.type === "search/initialize/pending" ||
-       action.type === "search/initialize/fulfilled"
-     ) {
-       return next(action);
-     }
-     if (action.type === "search/setSchema") {
-       return next(action);
-     }
-    /**
-     * Handle bbox
-     */
-    if (action.type === "search/setBbox") {
-      const result = next(action);
-      const config = actionConfig[action.type];
-      if (config.syncWithUrl) {
-        syncToUrl(action, config);
-      }
-      triggerResultsRelatesFetch(store, store.getState().search.query || "*");
-      return result;
-    }
-    /**
-     * Non-initialization actions
-     */
     const result = next(action);
     const config = actionConfig[action.type];
     if (config) {
       if (config.syncWithUrl) {
         syncToUrl(action, config);
       }
-      if (config.requiresFetch) {
+      if (config.requiresFetch && !isInitializing) {
         triggerResultsRelatesFetch(store, store.getState().search.query || "*");
       }
     }
     return result;
   };
+};
 
 function initializeFromUrl(store: any) {
   const params = new URLSearchParams(window.location.search);
   Object.entries(actionConfig)
-    .filter(([_, config]) => config.syncWithUrl)
+    .filter(([_, config]) => config.syncWithUrl && !config.isFilter)
+    .forEach(([actionType, config]) => {
+      const value = params.get(config.param);
+      if (value !== null) {
+        store.dispatch({
+          type: actionType,
+          payload: config.transform ? config.transform.fromUrl(value) : value,
+        });
+      }
+    });
+  Object.entries(actionConfig)
+    .filter(([_, config]) => config.syncWithUrl && config.isFilter)
     .forEach(([actionType, config]) => {
       const value = params.get(config.param);
       if (value !== null) {
@@ -108,7 +72,13 @@ function initializeFromUrl(store: any) {
 
 function syncToUrl(action: AnyAction, config: ActionConfig) {
   const searchParams = new URLSearchParams(window.location.search);
-  if (action.payload && action.payload.toString().length) {
+  if (
+    action.payload !== undefined &&
+    action.payload !== null &&
+    (typeof action.payload !== "object" ||
+      (Array.isArray(action.payload) && action.payload.length > 0) ||
+      Object.keys(action.payload).length > 0)
+  ) {
     const paramValue = config.transform
       ? config.transform.toUrl(action.payload)
       : action.payload;
@@ -120,32 +90,31 @@ function syncToUrl(action: AnyAction, config: ActionConfig) {
   window.history.pushState({}, "", newUrl);
 }
 
-async function triggerResultsRelatesFetch(store: any, query: string) {
+async function triggerResultsRelatesFetch(store: any, query: string, bypassSpellCheck = false) {
   const state = store.getState();
   if (!state.search.schema) return;
-
-  store.dispatch(setIsSearching(true));
+  const filterQueries = generateFilterQueries(state.search);
   try {
     if (state.search.aiSearch && (!query || query === "*")) {
       await store.dispatch(
         fetchSearchAndRelatedResults({
           query: "*",
-          filterQueries: generateFilterQueries(state.search),
+          filterQueries: filterQueries,
           schema: state.search.schema,
-          sortBy: state.search.sortBy,
-          sortOrder: state.search.sortOrder,
-          bypassSpellCheck: false,
+          sortBy: state.search.sort.sortBy,
+          sortOrder: state.search.sort.sortOrder,
+          bypassSpellCheck,
         })
       );
     } else {
       await store.dispatch(
         fetchSearchAndRelatedResults({
-          query: query || "*",
-          filterQueries: generateFilterQueries(state.search),
+          query: query,
+          filterQueries: filterQueries,
           schema: state.search.schema,
-          sortBy: state.search.sortBy,
-          sortOrder: state.search.sortOrder,
-          bypassSpellCheck: false,
+          sortBy: state.search.sort.sortBy,
+          sortOrder: state.search.sort.sortOrder,
+          bypassSpellCheck,
         })
       );
     }

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -1,46 +1,59 @@
-import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk, createAction } from "@reduxjs/toolkit";
 import SolrQueryBuilder from "../../components/search/helper/SolrQueryBuilder";
 import { generateSolrObjectList } from "meta/helper/solrObjects";
-import { initialState, SolrSuggestResponse } from "@/store/types/search";
+import {
+  BatchResetFiltersPayload,
+  initialState,
+  SolrSuggestResponse,
+} from "@/store/types/search";
 import { generateFilterQueries } from "@/middleware/filterHelper";
 import { setShowClearButton } from "./uiSlice";
 import { RootState } from "..";
-import { parseSolrQuery } from "@/components/search/helper/ParsingMethods";
 
 export const initializeSearch = createAsyncThunk(
   "search/initialize",
-  async (
-    { schema, urlParams }: { schema: any; urlParams: URLSearchParams },
-    { dispatch }
-  ) => {
-    const searchParams = {
-      aiSearch: urlParams.get("ai_search") === "true",
-      query: urlParams.get("query") || "*",
-    };
+  async ({ schema }: { schema: any }, { dispatch, getState }) => {
+    dispatch(setInitializing(true));
     dispatch(setSchema(schema));
-    dispatch(setAISearch(searchParams.aiSearch));
-    dispatch(setQuery(searchParams.query));
-    if (searchParams.query && searchParams.query !== "*") {
-      if (searchParams.aiSearch) {
-        return dispatch(
-          performChatGptSearch({
-            question: searchParams.query,
-            filterQueries: [],
-            schema,
-          })
-        ).unwrap();
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const state = getState() as RootState;
+      const filterQueries = generateFilterQueries(state.search);
+      const hasRealQuery = state.search.query && state.search.query !== "*";
+      const hasActiveFilters = filterQueries.length > 0;
+      if (hasRealQuery || hasActiveFilters) {
+        if (state.search.aiSearch && hasRealQuery) {
+          await dispatch(
+            performChatGptSearch({
+              question: state.search.query,
+              filterQueries,
+              schema,
+            })
+          ).unwrap();
+        } else {
+          await dispatch(
+            fetchSearchAndRelatedResults({
+              query: state.search.query || "*",
+              filterQueries,
+              schema,
+              bypassSpellCheck: false,
+            })
+          ).unwrap();
+        }
       } else {
-        return dispatch(
+        await dispatch(
           fetchSearchAndRelatedResults({
-            query: searchParams.query,
+            query: "*",
             filterQueries: [],
             schema,
             bypassSpellCheck: false,
           })
         ).unwrap();
       }
+      return { success: true };
+    } finally {
+      dispatch(setInitializing(false));
     }
-    return null;
   }
 );
 
@@ -103,7 +116,6 @@ export const performChatGptSearch = createAsyncThunk(
       const uniqueResults = Array.from(
         new Map(combinedResults.map((item) => [item.id, item])).values()
       );
-
       return {
         searchResults: uniqueResults,
         relatedResults: [],
@@ -111,7 +123,7 @@ export const performChatGptSearch = createAsyncThunk(
         originalQuery: question,
         usedQuery: analysis.suggestedQueries.join(", "),
         usedSpellCheck: false,
-        analysis
+        analysis,
       };
     } catch (error) {
       throw new Error(`ChatGPT search failed: ${error.message}`);
@@ -136,9 +148,13 @@ export const fetchSearchAndRelatedResults = createAsyncThunk(
       sortOrder?: string;
       bypassSpellCheck: boolean;
     },
-    { dispatch, getState }
+    { dispatch, getState, requestId }
   ) => {
     const state = getState() as RootState;
+    const currentRequestId = state.search.currentRequestId;
+    if (currentRequestId !== requestId && !bypassSpellCheck) {
+      return;
+    }
     const isAISearch = state.search.aiSearch;
     const searchQueryBuilder = new SolrQueryBuilder();
     searchQueryBuilder.setSchema(schema);
@@ -216,7 +232,7 @@ export const fetchSearchAndRelatedResults = createAsyncThunk(
       suggestions: validSuggestions,
       originalQuery: query,
       usedQuery,
-      usedSpellCheck
+      usedSpellCheck,
     };
   }
 );
@@ -244,7 +260,6 @@ export const fetchSearchResults = createAsyncThunk(
     const searchQueryBuilder = new SolrQueryBuilder();
     searchQueryBuilder.setSchema(schema);
     searchQueryBuilder.combineQueries(query, filterQueries, sortBy, sortOrder);
-
     const { results, spellCheckSuggestion } =
       await searchQueryBuilder.fetchResult();
     if (spellCheckSuggestion) {
@@ -323,6 +338,7 @@ export const atomicResetAndFetch = createAsyncThunk(
     return { schema };
   }
 );
+
 export const clearSearch = createAsyncThunk(
   "search/clearSearch",
   async (_, { dispatch, getState }) => {
@@ -337,13 +353,17 @@ export const clearSearch = createAsyncThunk(
           query: "*",
           filterQueries: generateFilterQueries(state.search),
           schema: state.search.schema,
-          sortBy: state.search.sortBy,
-          sortOrder: state.search.sortOrder,
+          sortBy: state.search.sort.sortBy,
+          sortOrder: state.search.sort.sortOrder,
           bypassSpellCheck: true,
         })
       );
     }
   }
+);
+
+export const batchResetFilters = createAction<BatchResetFiltersPayload>(
+  "search/batchResetFilters"
 );
 
 const searchSlice = createSlice({
@@ -359,11 +379,10 @@ const searchSlice = createSlice({
     setFilterQueries: (state, action) => {
       state.filterQueries = action.payload;
     },
-    setSortBy: (state, action) => {
-      state.sortBy = action.payload;
-    },
-    setSortOrder: (state, action) => {
-      state.sortOrder = action.payload;
+    setSort: (state, action) => {
+      const { field, direction } = action.payload;
+      state.sort.sortBy = field;
+      state.sort.sortOrder = direction;
     },
     setBbox: (state, action) => {
       state.bbox = action.payload;
@@ -424,40 +443,56 @@ const searchSlice = createSlice({
     setIsSearching: (state, action) => {
       state.isSearching = action.payload;
     },
+    setInitializing: (state, action) => {
+      state.initializing = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder
-      .addCase(fetchSearchAndRelatedResults.pending, (state) => {
-        state.isSearching = true;
-        state.results = [];
-        state.relatedResults = [];
+      .addCase(fetchSearchAndRelatedResults.pending, (state, action) => {
+        if (
+          state.currentRequestId === null ||
+          state.currentRequestId === action.meta.requestId ||
+          action.meta.arg.bypassSpellCheck
+        ) {
+          state.isSearching = true;
+          state.currentRequestId = action.meta.requestId;
+        }
       })
       .addCase(fetchSearchAndRelatedResults.fulfilled, (state, action) => {
-        const searchResults = action.payload.searchResults || [];
-        const relatedResults = action.payload.relatedResults || [];
-        state.results = generateSolrObjectList(searchResults);
-        state.relatedResults = generateSolrObjectList(relatedResults);
-        state.results =
-          searchResults.length > 0 ? generateSolrObjectList(searchResults) : [];
-        state.relatedResults =
-          relatedResults.length > 0
-            ? generateSolrObjectList(relatedResults)
-            : [];
-        state.suggestions = action.payload.suggestions || [];
-        state.originalQuery = Array.isArray(action.payload.originalQuery)
-          ? action.payload.originalQuery.join(", ")
-          : action.payload.originalQuery;
-        state.usedQuery = Array.isArray(action.payload.usedQuery)
-          ? action.payload.usedQuery.join(", ")
-          : action.payload.usedQuery;
-        state.usedSpellCheck = action.payload.usedSpellCheck || false;
-        state.isSearching = false;
+        if (
+          state.currentRequestId === action.meta.requestId ||
+          action.meta.arg.bypassSpellCheck
+        ) {
+          state.results = generateSolrObjectList(
+            action.payload.searchResults || []
+          );
+          state.relatedResults = generateSolrObjectList(
+            action.payload.relatedResults || []
+          );
+          state.suggestions = action.payload.suggestions || [];
+          state.originalQuery = Array.isArray(action.payload.originalQuery)
+            ? action.payload.originalQuery.join(", ")
+            : action.payload.originalQuery;
+          state.usedQuery = Array.isArray(action.payload.usedQuery)
+            ? action.payload.usedQuery.join(", ")
+            : action.payload.usedQuery;
+          state.usedSpellCheck = action.payload.usedSpellCheck || false;
+          state.isSearching = false;
+          state.currentRequestId = null;
+        }
       })
-      .addCase(fetchSearchAndRelatedResults.rejected, (state) => {
-        state.isSearching = false;
-        state.results = [];
-        state.relatedResults = [];
-        state.usedSpellCheck = false;
+      .addCase(fetchSearchAndRelatedResults.rejected, (state, action) => {
+        if (
+          state.currentRequestId === action.meta.requestId ||
+          action.meta.arg.bypassSpellCheck
+        ) {
+          state.isSearching = false;
+          state.results = [];
+          state.relatedResults = [];
+          state.usedSpellCheck = false;
+          state.currentRequestId = null;
+        }
       })
       .addCase(fetchSearchResults.pending, (state) => {
         state.isSearching = true;
@@ -488,8 +523,8 @@ const searchSlice = createSlice({
       .addCase(atomicResetAndFetch.fulfilled, (state, action) => {
         state.spatialResolution = null;
         state.subject = null;
-        state.sortBy = null;
-        state.sortOrder = null;
+        state.sort.sortBy = "score";
+        state.sort.sortOrder = "desc";
         state.filterQueries = [];
         state.schema = action.payload.schema;
       })
@@ -505,6 +540,18 @@ const searchSlice = createSlice({
         state.usedSpellCheck = false;
         state.spellCheck = null;
         state.suggestions = [];
+      })
+      .addCase(batchResetFilters, (state, action) => {
+        // Reset all filter-related state
+        state.bbox = null;
+        state.subject = [];
+        state.spatialResolution = [];
+        state.indexYear = [];
+        state.filterQueries = [];
+        state.schema = action.payload.schema;
+        state.query = action.payload.query;
+        state.sort.sortBy = "score";
+        state.sort.sortOrder = "desc";
       });
   },
 });
@@ -515,8 +562,7 @@ export const {
   setInputValue,
   setThoughts,
   setFilterQueries,
-  setSortBy,
-  setSortOrder,
+  setSort,
   setBbox,
   setVisOverlays,
   setSubject,
@@ -529,6 +575,7 @@ export const {
   setAISearch,
   resetQuerySearch,
   setIsSearching,
+  setInitializing,
 } = searchSlice.actions;
 
 export default searchSlice.reducer;

--- a/src/store/types/search.ts
+++ b/src/store/types/search.ts
@@ -15,9 +15,11 @@ export interface SearchState {
   thoughts: string;
 
   // sort
-  sortBy: string;
-  sortOrder: string;
-
+  sort: {
+    sortBy: string;
+    sortOrder: string;
+  };
+  
   // filter
   filterQueries: any[];
   subject: string[];
@@ -29,6 +31,8 @@ export interface SearchState {
   bbox: [number, number, number, number] | null;
 
   // status
+  currentRequestId: string;
+  initializing: boolean;
   isLoading: boolean;
   isSearching: boolean;
   isSuggesting: boolean;
@@ -45,8 +49,11 @@ export const initialState: SearchState = {
   results: [],
   relatedResults: [],
   suggestions: [],
-  sortBy: "",
-  sortOrder: "desc",
+  // sort
+  sort: {
+    sortBy: "score",
+    sortOrder: "desc",
+  },
   bbox: null,
   subject: [],
   spatialResolution: [],
@@ -57,6 +64,8 @@ export const initialState: SearchState = {
   usedQuery: "",
   usedSpellCheck: false,
   // status
+  currentRequestId: null,
+  initializing: false,
   isLoading: false,
   isSearching: false,
   isSuggesting: false,
@@ -77,4 +86,9 @@ export interface SolrSuggestResponse {
       };
     };
   };
+}
+
+export interface BatchResetFiltersPayload {
+  schema: any;
+  query: string;
 }


### PR DESCRIPTION
This PR fixes #472, #481, #482 and #488. It addresses occasional race conditions that occur when triggering filters, as well as an occasional double-trigger of data fetching during initialization. To resolve these issues, I have implemented a request ID mechanism and adjusted the trigger points for fetch activities, as well as re-organized reset filter methods. These changes should help prevent unintended behavior.

## How to Test
1. Navigate to the search page and test the three sort options. They should function correctly, with the appropriate underline highlighting the current sorting option for #482:
![Screenshot 2025-03-06 at 3 48 14 PM](https://github.com/user-attachments/assets/e6abb469-f461-42b2-ba16-2d73786fcdf4)

*(Compare this to the current behavior at https://discovery_app.dev.sdohplace.org/search)

2. Perform various filtering actions to verify they work as expected. Then, copy the URL (or use the 'Share' function), paste it into a new tab, and ensure the new page reflects the same state.
Note: The map does not yet sync with the URL, so it always loads in its initial state. Additionally, sorting does not persist via URL, so the default sorting order remains 'Relavence'.

3. Repeat step 2 multiple times to confirm that issues #472 and #481 are resolved.

4. #488 Fix: Start a fresh search, then click "Details" for **10-minute walk service areas (10MWSA)** to open the detail panel. Next, apply a filter by theme: "Demographics."

<img width="1710" alt="Screenshot 2025-03-07 at 12 18 59 PM" src="https://github.com/user-attachments/assets/3eb543f3-c42f-4611-bafc-71ce261561c1" />


You should notice that the map view reappears because **10-minute walk service areas (10MWSA)** is not included in the filtered results. For comparison, check https://discovery_app.dev.sdohplace.org/search?show=herop-jxbloa&subject=Demographics&query=* to see the difference.