### PR TITLE
style: minor adjustments to Item Details

### DIFF
--- a/src/components/homepage/buttonwithicon/buttonwithicon.tsx
+++ b/src/components/homepage/buttonwithicon/buttonwithicon.tsx
@@ -6,6 +6,7 @@ import { makeStyles } from "@mui/styles";
 
 const fullConfig = resolveConfig(tailwindConfig);
 interface Props {
+  className?: string;
   svgIcon?: any;
   muiIcon?: any;
   label: string;
@@ -36,17 +37,18 @@ const useStyles = makeStyles((theme) => ({
       right: "1.5rem",
     },
     "& .button-content": {
+      textWrap: "pretty",
       position: "absolute",
       left: "4rem",
     },
-  },
+  }
 }));
 const ButtonWithIcon = (props: Props): JSX.Element => {
   const classes = useStyles();
   return (
     <div>
       <Button
-        className={props.endIcon ? classes.buttonWithEndIcon : ""}
+        className={props.className || ''}
         variant="contained"
         startIcon={
           props.svgIcon ? props.svgIcon : null
@@ -89,7 +91,7 @@ const ButtonWithIcon = (props: Props): JSX.Element => {
           },
         }}
       >
-        <span className="button-content">{props.label}</span>
+        <span className="buttonContent">{props.label}</span>
       </Button>
     </div>
   );

--- a/src/components/search/detailPanel/headerRow.tsx
+++ b/src/components/search/detailPanel/headerRow.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import DOMPurify from "dompurify";
 import CloseIcon from "@mui/icons-material/Close";
 import CopyAllIcon from "@mui/icons-material/CopyAll";
+import LaunchIcon from '@mui/icons-material/Launch';
 import { Box, Container, IconButton, Collapse } from "@mui/material";
 import ButtonWithIcon from "@/components/homepage/buttonwithicon";
 import { ParseReferenceLink } from "../helper/ParsingMethods";
@@ -87,13 +88,14 @@ const HeaderRow = (props: Props): JSX.Element => {
             {React.cloneElement(props.headerIcon, { fontSize: "inherit" })}
           </div>
           <Box
-            sx={{ display: "inline" }}
+            sx={{ display: "inline",
+            marginTop: "0.75rem"}}
             className={`text-4xl leading-10 ml-[0.5em] ${classes.introCard}`}
           >
             {props.resultItem.title}
           </Box>
         </div>
-        <div className="flex items-start justify-center sm:justify-end md:mt-4 sm:mt-0 order-1 sm:order-none flex-none">
+        <div className="flex items-start justify-center sm:justify-end order-1 sm:order-none flex-none">
           <div className="mr-7">
             <ButtonWithIcon
               label={"Share"}
@@ -108,14 +110,16 @@ const HeaderRow = (props: Props): JSX.Element => {
             />
           </div>
           <ButtonWithIcon
+            className={'max-w-min'}
             label={"Go to Resource"}
             borderRadius={"0.25rem"}
             width={"100%"}
             justifyContent="space-between"
             fillColor={"frenchviolet"}
             labelColor={"white"}
+            endIcon={<LaunchIcon />}
             noBox={true}
-            disabled={links.homepageUrl ? false : true}
+            disabled={!links.homepageUrl}
             onClick={() => {
               window.open(links.homepageUrl, "_blank").focus();
               plausible(EventType.ClickedGoToResource, {

--- a/src/components/search/detailPanel/headerRow.tsx
+++ b/src/components/search/detailPanel/headerRow.tsx
@@ -78,8 +78,8 @@ const HeaderRow = (props: Props): JSX.Element => {
           Back to map view
         </a>
       </div>
-      <div className="flex flex-col sm:mb-7 sm:flex-row items-center">
-        <div className="flex flex-col sm:flex-row items-center flex-grow">
+      <div className="flex flex-col sm:mb-7 sm:flex-row items-start">
+        <div className="flex flex-col sm:flex-row items-start flex-grow">
           <div
             className="flex items-center sm:text-[4em]"
             style={{ color: fullConfig.theme.colors["strongorange"] }}

--- a/src/components/search/detailPanel/introCard.tsx
+++ b/src/components/search/detailPanel/introCard.tsx
@@ -49,7 +49,7 @@ const IntroCard = (props: Props): JSX.Element => {
               : ""}
           </div>
         </div>
-        <div className="flex-1 w-full sm:w-1/3 sm:pl-6 sm:pr-2.25 sm:pt-5 bg-lightbisque">
+        <div className="flex-1 w-full sm:w-1/3 sm:pl-6 p-5 bg-lightbisque">
           <div className={`${classes.introCard}`}>
             <b>Year:</b>{" "}
             {props.resultItem.index_year

--- a/src/components/search/detailPanel/introCard.tsx
+++ b/src/components/search/detailPanel/introCard.tsx
@@ -49,7 +49,7 @@ const IntroCard = (props: Props): JSX.Element => {
               : ""}
           </div>
         </div>
-        <div className="flex-1 w-full sm:w-1/3  sm:pl-6 sm:pr-2.25 sm:pt-5 bg-lightbisque">
+        <div className="flex-1 w-full sm:w-1/3 sm:pl-6 sm:pr-2.25 sm:pt-5 bg-lightbisque">
           <div className={`${classes.introCard}`}>
             <b>Year:</b>{" "}
             {props.resultItem.index_year
@@ -59,7 +59,7 @@ const IntroCard = (props: Props): JSX.Element => {
           <div className={`${classes.introCard}`}>
             <b>Spatial Resolution:</b>{" "}
             {props.resultItem.meta.spatial_resolution
-              ? props.resultItem.meta.spatial_resolution.join(",")
+              ? props.resultItem.meta.spatial_resolution.join(", ")
               : ""}
           </div>
           <div className={`${classes.introCard}`}>

--- a/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
+++ b/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
@@ -23,7 +23,6 @@ const useStyles = makeStyles((theme) => ({
     color: `${fullConfig.theme.colors["almostblack"]}`,
     fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
     fontSize: "0.875rem",
-    marginLeft: "0.25rem",
   },
   link: {
     color: `${fullConfig.theme.colors["frenchviolet"]}`,
@@ -74,26 +73,26 @@ const Link = ({ value }) => {
     return (
       <div className="container">
         <b className="text-s">More links:</b>
-        <List>
+        <ul className={'py-2'}>
           {links.downloadUrl && (
-            <ListItem><a
+            <li><a
               href={String(links.downloadUrl)}
               className={`${classes.paragraphCard} ${classes.link}`}
-            >Data Download (Official)</a></ListItem>)
+            >Data Download (Official)</a></li>)
           }
           {links.archiveUrl && (
-            <ListItem><a
+            <li><a
               href={String(links.archiveUrl)}
               className={`${classes.paragraphCard} ${classes.link}`}
-            >Data Archival Copy</a></ListItem>)
+            >Data Archival Copy</a></li>)
           }
           {links.dataDictionaryUrl && (
-            <ListItem><a
+            <li><a
               href={String(links.dataDictionaryUrl)}
               className={`${classes.paragraphCard} ${classes.link}`}
-            >Technical Documentation</a></ListItem>)
+            >Technical Documentation</a></li>)
           }
-        </List>
+        </ul>
       </div>
     )
   } else {


### PR DESCRIPTION
## Problem
We have another set of small styling changes that we would like to apply to the Discovery App search page

Fixes #480 
Fixes #498 

## Approach
* style: search/headerRow align icon/buttons with start of div
* style: search/introCard add bottom padding on right side to match the top
* style: search/paragraphCard remove left padding on More links section
* style: search/headerRow added External Link (aka Launch) icon to "Go to Resources" button

### Case 1: short title, right side > left side
![Screenshot_2025-03-12_at_12_45_39_PM](https://github.com/user-attachments/assets/c2b464e8-cda7-4a35-98e9-ede1b3d9e6f6)

### Case 2: long title, left side > right side
![Screenshot_2025-03-12_at_12_45_50_PM](https://github.com/user-attachments/assets/7cdc9fc7-f441-4f7d-a24e-3078083f9ea9)

## How to Test
1. Navigate to https://deploy-preview-504--cheerful-treacle-913a24.netlify.app/search
    * You should see the Discovery App search page is loaded
    * You should see search results listed on the left side
2. Choose a search result and click the "Details ->" button
    * You should see the right panel change to the Item Details view for the selected search result
    * You should see the styling changes described in this PR (see above for screenshots of examples)
3. Repeat to view various different datasets and look for differences when more or less text is present