### PR TITLE
#490: Update AI-search help text

### DIFF
--- a/src/components/search/searchArea/enhancedSearch.tsx
+++ b/src/components/search/searchArea/enhancedSearch.tsx
@@ -133,7 +133,7 @@ const EnhancedSearchBox = ({ schema }: Props): JSX.Element => {
   const textFieldRef = React.useRef<HTMLInputElement>(null);
   const [isLocalLoading, setIsLocalLoading] = React.useState(false);
   const { showClearButton } = useSelector((state: RootState) => state.ui);
-  const maxLength = 50;
+  const maxLength = 100;
   const {
     aiSearch,
     query,
@@ -307,7 +307,7 @@ const EnhancedSearchBox = ({ schema }: Props): JSX.Element => {
               fullWidth
               placeholder={
                 aiSearch
-                  ? `Ask a research question...`
+                  ? `Ask a research question (max ${maxLength} characters)...`
                   : "Type keyword..."
               }
               className={`${classes.searchBox} bg-white`}

--- a/src/components/search/searchArea/helpText/aiSearchText.tsx
+++ b/src/components/search/searchArea/helpText/aiSearchText.tsx
@@ -11,8 +11,7 @@ export const AiSearchText = () => {
         className="pb-1"
         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
       >
-        We&apos;ve added an AI-powered search option that helps you find answers, not
-        just keywords!
+       Try our AI-powered search that helps you find data by simply asking a question.
       </Typography>
 
       <div className="my-3 p-3 bg-gray-50 rounded-lg">
@@ -76,90 +75,17 @@ export const AiSearchText = () => {
         className="pb-1"
         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
       >
-        Don&apos;t want to use AI? No problem! Our standard search mode is
-        always available and doesn&apos;t send any queries to AI systems.
+        Don&apos;t want to use AI? Our standard search mode is
+        always available and does not send any queries to AI systems.
       </Typography>
 
       <Typography
         className="pb-1"
         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
       >
-        We&apos;d love to hear your thoughts on this feature! Please{" "}
+        We would love to hear your thoughts on this feature. Please{" "}
         <Link href="/contact">get in touch</Link>.
       </Typography>
     </>
   );
-
-  //   <>
-  //     <Typography
-  //       className="pb-1"
-  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
-  //     >
-  //       We&apos;ve added an AI-powered search option that helps you find answers, not just keywords!
-  //     </Typography>
-
-  //     <div className="my-3 p-3 bg-gray-50 rounded-lg">
-  //       <Typography
-  //         className="font-medium mb-2"
-  //         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
-  //       >
-  //         See the difference:
-  //       </Typography>
-
-  //       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-  //         <div className="p-3 bg-white rounded border border-gray-200">
-  //           <Typography
-  //             className="font-medium mb-1"
-  //             sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
-  //           >
-  //             Standard Search:
-  //           </Typography>
-  //           <div className="italic text-sm mb-2">You type: "children food access limited"</div>
-  //           <div className="text-sm">
-  //             Looks for exact words "children," "food," "access," and "limited"
-  //             in our database
-  //           </div>
-  //         </div>
-
-  //         <div className="p-3 bg-white rounded border border-gray-200">
-  //           <Typography
-  //             className="font-medium mb-1"
-  //             sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
-  //           >
-  //             AI Search:
-  //           </Typography>
-  //           <div className="italic text-sm mb-2">You ask: "Where is children's food access the most limited?"</div>
-  //           <div className="text-sm">
-  //             Understands your question and finds areas with high childhood food insecurity,
-  //             food deserts affecting youth, and related health outcomes
-  //           </div>
-  //         </div>
-  //       </div>
-  //     </div>
-
-  //     <Typography
-  //       className="pb-1"
-  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
-  //     >
-  //       Our AI search helper takes your question and translates it into the best possible search terms.
-  //       We show you exactly how it interpreted your question right below the search box.
-  //     </Typography>
-
-  //     <Typography
-  //       className="pb-1"
-  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
-  //     >
-  //       Privacy note: AI search is optional. Standard keyword search doesn't send any information
-  //       to AI systems.
-  //     </Typography>
-
-  //     <Typography
-  //       className="pb-1"
-  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
-  //     >
-  //       We'd love to hear your thoughts on this feature! Please{" "}
-  //       <Link href="/contact">get in touch</Link>.
-  //     </Typography>
-  //   </>
-  // );
 };

--- a/src/components/search/searchArea/helpText/aiSearchText.tsx
+++ b/src/components/search/searchArea/helpText/aiSearchText.tsx
@@ -1,0 +1,165 @@
+import { Typography } from "@mui/material";
+import Link from "next/link";
+import tailwindConfig from "tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+
+export const AiSearchText = () => {
+  const fullConfig = resolveConfig(tailwindConfig);
+  return (
+    <>
+      <Typography
+        className="pb-1"
+        sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+      >
+        We&apos;ve added an AI-powered search option that helps you find answers, not
+        just keywords!
+      </Typography>
+
+      <div className="my-3 p-3 bg-gray-50 rounded-lg">
+        <Typography
+          className="font-medium mb-2"
+          sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+        >
+          See the difference:
+        </Typography>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="p-3 bg-white rounded border border-gray-200">
+            <Typography
+              className="font-medium mb-1"
+              sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+            >
+              Keyword Search:
+            </Typography>
+            <div className="italic text-sm mb-2">
+              You type: &quot;housing insecurity&quot;
+            </div>
+            <div className="text-sm">
+              Looks for exact words with prefix of &quot;housing
+              insecurity&quot; in our database when you begin to type, then
+              shows results as suggested terms.
+            </div>
+          </div>
+
+          <div className="p-3 bg-white rounded border border-gray-200">
+            <Typography
+              className="font-medium mb-1"
+              sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+            >
+              AI Search:
+            </Typography>
+            <div className="italic text-sm mb-2">
+              You ask: &quot;What could cause housing instability and poor
+              health outcomes?&quot;
+            </div>
+            <div className="text-sm">
+              Understands your question and finds information about
+              &quot;housing&quot;, &quot;economic stability&quot;, and
+              &quot;health outcomes&quot; within the Social Determinants of
+              Health context to help you answer your question.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Typography
+        className="pb-1"
+        sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+      >
+        Behind the scenes, our AI assistant reads your question, figures out
+        what information would best answer it, and then searches our database
+        accordingly. We show you this &quot;thinking process&quot; below the
+        search box so you can see how it interpreted your question.
+      </Typography>
+
+      <Typography
+        className="pb-1"
+        sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+      >
+        Don&apos;t want to use AI? No problem! Our standard search mode is
+        always available and doesn&apos;t send any queries to AI systems.
+      </Typography>
+
+      <Typography
+        className="pb-1"
+        sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+      >
+        We&apos;d love to hear your thoughts on this feature! Please{" "}
+        <Link href="/contact">get in touch</Link>.
+      </Typography>
+    </>
+  );
+
+  //   <>
+  //     <Typography
+  //       className="pb-1"
+  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+  //     >
+  //       We&apos;ve added an AI-powered search option that helps you find answers, not just keywords!
+  //     </Typography>
+
+  //     <div className="my-3 p-3 bg-gray-50 rounded-lg">
+  //       <Typography
+  //         className="font-medium mb-2"
+  //         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+  //       >
+  //         See the difference:
+  //       </Typography>
+
+  //       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+  //         <div className="p-3 bg-white rounded border border-gray-200">
+  //           <Typography
+  //             className="font-medium mb-1"
+  //             sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+  //           >
+  //             Standard Search:
+  //           </Typography>
+  //           <div className="italic text-sm mb-2">You type: "children food access limited"</div>
+  //           <div className="text-sm">
+  //             Looks for exact words "children," "food," "access," and "limited"
+  //             in our database
+  //           </div>
+  //         </div>
+
+  //         <div className="p-3 bg-white rounded border border-gray-200">
+  //           <Typography
+  //             className="font-medium mb-1"
+  //             sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+  //           >
+  //             AI Search:
+  //           </Typography>
+  //           <div className="italic text-sm mb-2">You ask: "Where is children's food access the most limited?"</div>
+  //           <div className="text-sm">
+  //             Understands your question and finds areas with high childhood food insecurity,
+  //             food deserts affecting youth, and related health outcomes
+  //           </div>
+  //         </div>
+  //       </div>
+  //     </div>
+
+  //     <Typography
+  //       className="pb-1"
+  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+  //     >
+  //       Our AI search helper takes your question and translates it into the best possible search terms.
+  //       We show you exactly how it interpreted your question right below the search box.
+  //     </Typography>
+
+  //     <Typography
+  //       className="pb-1"
+  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+  //     >
+  //       Privacy note: AI search is optional. Standard keyword search doesn't send any information
+  //       to AI systems.
+  //     </Typography>
+
+  //     <Typography
+  //       className="pb-1"
+  //       sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+  //     >
+  //       We'd love to hear your thoughts on this feature! Please{" "}
+  //       <Link href="/contact">get in touch</Link>.
+  //     </Typography>
+  //   </>
+  // );
+};

--- a/src/components/search/searchArea/helpText/aiSearchText.tsx
+++ b/src/components/search/searchArea/helpText/aiSearchText.tsx
@@ -75,7 +75,7 @@ export const AiSearchText = () => {
         className="pb-1"
         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
       >
-        Don&apos;t want to use AI? Our standard search mode is
+        Don&apos;t want to use AI? Our keyword search mode is
         always available and does not send any queries to AI systems.
       </Typography>
 

--- a/src/components/search/searchArea/helpText/communityAssetsText.tsx
+++ b/src/components/search/searchArea/helpText/communityAssetsText.tsx
@@ -1,0 +1,67 @@
+import { overlayRegistry } from "@/components/map/helper/layers";
+import { Typography, List, ListItem } from "@mui/material";
+import Link from "next/link";
+import tailwindConfig from "tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+
+export const CommunityAssetsText = () => {
+  const fullConfig = resolveConfig(tailwindConfig);
+  return (
+    <>
+      {" "}
+      <Typography
+        className="pb-1"
+        sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+      >
+        We provide a number of map overlay layers that can be used for
+        contextual reference about community assets during your data search.
+        This is a feature we hope to expand in the future, so please{" "}
+        <Link href="/contact">get in touch</Link> if you have ideas for more
+        layers you would like to see or contribute.
+      </Typography>
+      <Typography sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}>
+        <strong>Community asset layers:</strong>
+      </Typography>
+      <List
+        sx={{
+          listStyleType: "disc",
+          listStylePosition: "inside",
+        }}
+      >
+        {Object.keys(overlayRegistry).map((key, index) => (
+          <ListItem key={index}>
+            <span>
+              <strong>{key}:</strong> {overlayRegistry[key].description}
+              {/* [<Link href={overlayRegistry[key].url} target="_blank">learn more</Link>] */}
+            </span>
+          </ListItem>
+        ))}
+      </List>
+      <Typography
+        className="pb-1"
+        sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
+      >
+        Currently, all layers are filtered from the{" "}
+        <Link
+          href="https://docs.overturemaps.org/guides/places/"
+          target="_blank"
+        >
+          Places
+        </Link>{" "}
+        dataset published by the{" "}
+        <Link href="https://overturemaps.org" target="_blank">
+          Overture Maps Foundation
+        </Link>
+        . Visit{" "}
+        <Link
+          href="https://github.com/healthyregions/overture-poi-extract"
+          target="_blank"
+        >
+          healthyregions/overture-poi-extract
+        </Link>{" "}
+        for details about the filtering process we use, and to download the raw
+        data.
+      </Typography>
+    </>
+  );
+};

--- a/src/components/search/searchArea/helpText/geographyFilterText.tsx
+++ b/src/components/search/searchArea/helpText/geographyFilterText.tsx
@@ -1,0 +1,34 @@
+import { List, ListItem } from "@mui/material";
+
+export const GeographyFilterText = () => {
+  return (
+    <>
+      Some sources provide data at the state level, while others may provide
+      data at smaller resolutions like county or tract level. The interface
+      makes it easy to filter by this geography level, or &quot;spatial
+      resolution&quot;, allowing you to find only data relevant for your work.
+      <List
+        sx={{
+          listStyleType: "disc",
+          listStylePosition: "inside",
+        }}
+      >
+        <ListItem sx={{ display: "list-item" }}>
+          State (largest, most general level)
+        </ListItem>
+        <ListItem sx={{ display: "list-item" }}>
+          County (subdivision of a state)
+        </ListItem>
+        <ListItem sx={{ display: "list-item" }}>
+          Census Tract (smaller geographical unit),
+        </ListItem>
+        <ListItem sx={{ display: "list-item" }}>
+          Block Group (smallest unit, a subdivision of census tract)
+        </ListItem>
+        <ListItem sx={{ display: "list-item" }}>
+          ZIP Code Tabulation Area (ZCTA)
+        </ListItem>
+      </List>
+    </>
+  );
+};

--- a/src/components/search/searchArea/helpText/infoHelpText.tsx
+++ b/src/components/search/searchArea/helpText/infoHelpText.tsx
@@ -1,0 +1,40 @@
+import { List, ListItem } from "@mui/material";
+export const InfoHelpText = () => {
+  return (
+    <>
+      Welcome to our data discovery application. Here are a few ways for you to
+      get started:
+      <List>
+        <ListItem>
+          <span>
+            <strong>Search by terms:</strong> Use the main search bar to search
+            for a concept you are interested in. As you type, a dropdown will
+            appear with suggestions pulled directly from the datasets
+            themselves.
+          </span>
+        </ListItem>
+        <ListItem>
+          <span>
+            <strong>Filter by geography:</strong> Are you looking only for
+            county-level data? Use the &quot;County&quot; filter to only show
+            datasets at that level.
+          </span>
+        </ListItem>
+        <ListItem>
+          <span>
+            <strong>Filter by theme or year:</strong> Researching food access?
+            Only want the latest data? Click the &quot;Sort & Filter&quot;
+            button to narrow results by theme and date.
+          </span>
+        </ListItem>
+        <ListItem>
+          <span>
+            <strong>Filter by location:</strong> Only looking for datasets that
+            cover your state or city? Use the search box within the map to find
+            a place and filter for datasets that geographically overlap it.
+          </span>
+        </ListItem>
+      </List>
+    </>
+  );
+};

--- a/src/components/search/searchArea/helpText/keywordSearchText.tsx
+++ b/src/components/search/searchArea/helpText/keywordSearchText.tsx
@@ -1,0 +1,27 @@
+import { List, ListItem, Typography } from "@mui/material";
+import tailwindConfig from "tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+
+export const KeywordSearchText = () => {
+  const fullConfig = resolveConfig(tailwindConfig);
+  return (
+    <>
+      <Typography sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}>
+        As you type search terms into the main search box, you will notice that
+        suggestions appear below the input box. This suggestion list is pulled
+        straight from the data itself (we have tried to index a lot of
+        information about each record) but there may still be times that your
+        search turns up no results. In this case, it never hurts to try another
+        word for your topic, or even just go ahead with a theme filter and
+        browse through all results.
+      </Typography>
+      <List>
+        <ListItem>
+          Tip: If you have used the search bar to make your query, you will then
+          be able to hover each result to learn more about why that item matched
+          your query.
+        </ListItem>
+      </List>
+    </>
+  );
+};

--- a/src/components/search/searchArea/helpText/searchResultsText.tsx
+++ b/src/components/search/searchArea/helpText/searchResultsText.tsx
@@ -1,0 +1,48 @@
+import { List, ListItem, Typography } from "@mui/material";
+import tailwindConfig from "tailwind.config";
+import resolveConfig from "tailwindcss/resolveConfig";
+
+export const SearchResultsText = () => {
+  const fullConfig = resolveConfig(tailwindConfig);
+  return (
+    <>
+      <Typography sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}>
+        Once you have performed a search or set a filter, you will get a list of
+        the items matching your query. Each item will have a collection of
+        metadata associated with it, as well as actions for further exploration:
+      </Typography>
+      <List
+        sx={{
+          listStyleType: "disc",
+          listStylePosition: "inside",
+        }}
+      >
+        <ListItem sx={{ display: "list-item" }}>
+          <span>
+            <strong>Show on map:</strong> Display a preview of what areas the
+            dataset covers.
+          </span>
+        </ListItem>
+        <ListItem sx={{ display: "list-item" }}>
+          <span>
+            <strong>Details:</strong> Open the item details panel and learn more
+            about the dataset.
+          </span>
+        </ListItem>
+        <ListItem sx={{ display: "list-item" }}>
+          <span>
+            <strong>Access:</strong> Leave the discovery app and head to the
+            source location of this dataset, for download and further analysis.
+          </span>
+        </ListItem>
+        <ListItem sx={{ display: "list-item" }}>
+          <span>
+            <strong>Share:</strong> Get a shareable link you can send to
+            colleagues, the URL will bring them right to the same record you are
+            looking at.
+          </span>
+        </ListItem>
+      </List>
+    </>
+  );
+};

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { makeStyles } from "@mui/styles";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import CloseIcon from "@mui/icons-material/Close";
 import tailwindConfig from "tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
@@ -10,16 +9,17 @@ import {
   Tab,
   IconButton,
   Typography,
-  List,
-  ListItem,
   Divider,
-  Link,
 } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store";
 import { setShowInfoPanel, setInfoPanelTab } from "@/store/slices/uiSlice";
-import { overlayRegistry } from "@/components/map/helper/layers";
-
+import { AiSearchText } from "./helpText/aiSearchText";
+import { InfoHelpText } from "./helpText/infoHelpText";
+import { KeywordSearchText } from "./helpText/keywordSearchText";
+import { GeographyFilterText } from "./helpText/geographyFilterText";
+import { SearchResultsText } from "./helpText/searchResultsText";
+import { CommunityAssetsText } from "./helpText/communityAssetsText";
 interface Props {
   children?: React.ReactNode;
   index: number;
@@ -169,141 +169,22 @@ export default function InfoPanel() {
         ref={tabPanelRef}
       >
         <CustomTabPanel value={infoPanelTab} index={0}>
-          {/* Intro tab */}
-          Welcome to our data discovery application. Here are a few ways for you
-          to get started:
-          <List>
-            <ListItem><span>
-            <strong>Search by terms:</strong> Use the main search bar to search
-              for a concept you are interested in. As you type, a dropdown will
-              appear with suggestions pulled directly from the datasets
-              themselves.
-              </span>
-            </ListItem>
-            <ListItem><span>
-              <strong>Filter by geography:</strong> Are you looking only for county-level data?
-              Use the &quot;County&quot; filter to only show datasets at that
-              level.
-            </span>
-            </ListItem>
-            <ListItem><span>
-            <strong>Filter by theme or year:</strong> Researching food access? Only want the
-              latest data? Click the &quot;Sort & Filter&quot; button to narrow
-              results by theme and date.
-              </span>
-            </ListItem>
-            <ListItem><span>
-            <strong>Filter by location:</strong> Only looking for datasets that cover your
-              state or city? Use the search box within the map to find a place
-              and filter for datasets that geographically overlap it.
-              </span>
-            </ListItem>
-          </List>
+          <InfoHelpText />
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={1}>
-          <Typography sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>
-          As you type search terms into the main search box, you will notice
-          that suggestions appear below the input box. This suggestion list is
-          pulled straight from the data itself (we have tried to index a lot of
-          information about each record) but there may still be times that your
-          search turns up no results. In this case, it never hurts to try
-          another word for your topic, or even just go ahead with a theme filter
-          and browse through all results.
-          </Typography>
-          <List>
-            <ListItem>
-              Tip: If you have used the search bar to make your query, you will
-              then be able to hover each result to learn more about why that
-              item matched your query.
-            </ListItem>
-          </List>
+          <KeywordSearchText />
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={2}>
-          {/* AI search tab */}
-          <Typography className="pb-1" sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>In addition to a standard keyword search, we also have an an experimental AI search mode that
-          allows you to ask questions like <strong>Where is children&apos;s food access the most limited?</strong>{" "}
-          But how does this work?</Typography>
-          <Typography className="pb-1" sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>
-          When a question like this is submitted, we combine it with our
-          {" "}<Link href="https://github.com/healthyregions/SDOHPlace/blob/discovery_app/config/prompt/prompt_message.js" target={"_blank"}>
-          prepared prompt</Link> and send it to a large language model (LLM). The
-          LLM analyzes queries through semantic mapping and term relationship scoring to generate optimized
-          Solr search parameters and retrieve relevant results from our database, while also applying
-          scoring algorithms and SDOH domain knowledge to enhance search accuracy. The analytical process,
-          particularly query construction logic, is displayed below the search box to make the &quot;thinking&quot;
-          process clearer and eliminate potential doubts about the LLM&apos;s function.
-          </Typography>
-          <Typography className="pb-1" sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>No queries or information of any kind are sent to the LLM backend if you use the standard keyword search mode.</Typography>
-          <Typography className="pb-1" sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>We&apos;d love to hear your thoughts on this feature! Please <Link href="/contact">get in touch</Link>.</Typography>
+          <AiSearchText />
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={3}>
-          Some sources provide data at the state level, while others may provide
-          data at smaller resolutions like county or tract level. The interface
-          makes it easy to filter by this geography level, or &quot;spatial
-          resolution&quot;, allowing you to find only data relevant for your
-          work.
-          <List sx={{
-              listStyleType: 'disc',
-              listStylePosition: 'inside'
-            }}>
-            <ListItem sx={{ display: 'list-item' }}>State (largest, most general level)</ListItem>
-            <ListItem sx={{ display: 'list-item' }}>County (subdivision of a state)</ListItem>
-            <ListItem sx={{ display: 'list-item' }}>Census Tract (smaller geographical unit),</ListItem>
-            <ListItem sx={{ display: 'list-item' }}>
-              Block Group (smallest unit, a subdivision of census tract)
-            </ListItem>
-            <ListItem sx={{ display: 'list-item' }}>ZIP Code Tabulation Area (ZCTA)</ListItem>
-          </List>
+          <GeographyFilterText />
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={4}>
-        <Typography sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>
-          Once you have performed a search or set a filter, you will get a list
-          of the items matching your query. Each item will have a collection of
-          metadata associated with it, as well as actions for further
-          exploration:</Typography>
-          <List sx={{
-              listStyleType: 'disc',
-              listStylePosition: 'inside'
-            }}>
-            <ListItem sx={{ display: 'list-item' }}>
-              <span><strong>Show on map:</strong> Display a preview of what areas the
-              dataset covers.</span>
-            </ListItem>
-            <ListItem sx={{ display: 'list-item' }}>
-              <span><strong>Details:</strong> Open the item details panel and learn
-              more about the dataset.</span>
-            </ListItem>
-            <ListItem sx={{ display: 'list-item' }}>
-              <span><strong>Access:</strong> Leave the discovery app and head to
-              the source location of this dataset, for download and further
-              analysis.</span>
-            </ListItem>
-            <ListItem sx={{ display: 'list-item' }}>
-              <span><strong>Share:</strong> Get a shareable link you can send
-              to colleagues, the URL will bring them right to the same record
-              you are looking at.</span>
-            </ListItem>
-          </List>
+          <SearchResultsText />
         </CustomTabPanel>
         <CustomTabPanel value={infoPanelTab} index={5}>
-          <Typography className="pb-1" sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>We provide a number of map overlay layers that can be used for contextual reference about community assets during your data search. This is a feature we hope to expand in the future, so please{" "}
-            <Link href="/contact">get in touch</Link> if you have
-            ideas for more layers you would like to see or contribute.
-            </Typography>
-          <Typography sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}><strong>Community asset layers:</strong></Typography>
-          <List sx={{
-              listStyleType: 'disc',
-              listStylePosition: 'inside'
-            }}>
-            {Object.keys(overlayRegistry).map((key, index) => (
-            <ListItem key={index}><span>
-              <strong>{key}:</strong> {overlayRegistry[key].description}
-               {/* [<Link href={overlayRegistry[key].url} target="_blank">learn more</Link>] */}
-            </span>
-            </ListItem>
-            ))}
-          </List>
-          <Typography className="pb-1" sx={{fontFamily: fullConfig.theme.fontFamily['sans']}}>Currently, all layers are filtered from the <Link href="https://docs.overturemaps.org/guides/places/" target="_blank">Places</Link> dataset published by the <Link href="https://overturemaps.org" target="_blank">Overture Maps Foundation</Link>. Visit <Link href="https://github.com/healthyregions/overture-poi-extract" target="_blank">healthyregions/overture-poi-extract</Link> for details about the filtering process we use, and to download the raw data.</Typography>
+          <CommunityAssetsText />
         </CustomTabPanel>
       </Box>
     </div>


### PR DESCRIPTION
This PR addresses #490, refining the AI search help text for improved user-friendliness. During the revision, I also separated each help text component from the infoPanel for easier management and increased the character limit for AI-based questions to accommodate more complex queries.

## How to Test
1. Navigate to https://deploy-preview-505--cheerful-treacle-913a24.netlify.app/search and open the AI search (experimental) section.
<img width="1015" alt="Screenshot 2025-03-12 at 2 49 34 PM" src="https://github.com/user-attachments/assets/2337f509-79d8-4724-b0c9-4972dbad9b1f" />

2. Review the updated help text.