### PR TITLE
#496 agnostic scrollbar

### DIFF
--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -159,7 +159,7 @@ const ResultsPanel = (props: Props): JSX.Element => {
               {isLoading || isResetting || isInitialLoad ? (
                 renderLoadingState()
               ) : (
-                <div>
+                <div className="force-scrollbar">
                   {searchState.results.length > 0 ? (
                     <Box
                       height="100%"

--- a/src/components/search/searchArea/infoPanel.tsx
+++ b/src/components/search/searchArea/infoPanel.tsx
@@ -163,6 +163,7 @@ export default function InfoPanel() {
         </Tabs>
       </Box>
       <Box
+        className="force-scrollbar"
         sx={{
           transition: "left 0.3s linear",
         }}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -297,3 +297,46 @@ article table tbody tr:last-child {
 article table td {
   text-align: left;
 }
+
+/* Scrollbar */
+.force-scrollbar ::-webkit-scrollbar {
+    width: 5px;
+    height: 5px
+}
+
+.force-scrollbar ::-webkit-scrollbar-button {
+    width: 0;
+    height: 0
+}
+
+.force-scrollbar ::-webkit-scrollbar-thumb {
+    background: #dad8d8;
+    border: 0 none #fff;
+    border-radius: 0
+}
+
+.force-scrollbar ::-webkit-scrollbar-thumb:hover {
+    background: #dad8d8
+}
+
+.force-scrollbar ::-webkit-scrollbar-thumb:active {
+    background: #000
+}
+
+.force-scrollbar ::-webkit-scrollbar-track {
+    background: #f4f6f9;
+    border: 0 none #fff;
+    border-radius: 0
+}
+
+.force-scrollbar ::-webkit-scrollbar-track:hover {
+    background: #f4f6f9
+}
+
+.force-scrollbar ::-webkit-scrollbar-track:active {
+    background: #333
+}
+
+.force-scrollbar ::-webkit-scrollbar-corner {
+    background: 0 0
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -321,7 +321,7 @@ article table td {
 }
 
 .force-scrollbar ::-webkit-scrollbar-thumb:active {
-    background: #000
+    background:  #dad8d8;
 }
 
 .force-scrollbar ::-webkit-scrollbar-track {
@@ -331,11 +331,11 @@ article table td {
 }
 
 .force-scrollbar ::-webkit-scrollbar-track:hover {
-    background: #f4f6f9
+    background: #f4f6f9;
 }
 
 .force-scrollbar ::-webkit-scrollbar-track:active {
-    background: #333
+    background: #f4f6f9;
 }
 
 .force-scrollbar ::-webkit-scrollbar-corner {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -298,7 +298,8 @@ article table td {
   text-align: left;
 }
 
-/* Scrollbar */
+/* Force Scrollbar */
+
 .force-scrollbar ::-webkit-scrollbar {
     width: 5px;
     height: 5px
@@ -339,4 +340,14 @@ article table td {
 
 .force-scrollbar ::-webkit-scrollbar-corner {
     background: 0 0
+}
+
+/* for non-webkit browsers, but not work for Firefox */
+.force-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: #dad8d8 #f4f6f9;
+    scrollbar-gutter: stable;
+}
+.force-scrollbar {
+    -ms-overflow-style: scrollbar;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -342,12 +342,3 @@ article table td {
     background: 0 0
 }
 
-/* for non-webkit browsers, but not work for Firefox */
-.force-scrollbar {
-    scrollbar-width: thin;
-    scrollbar-color: #dad8d8 #f4f6f9;
-    scrollbar-gutter: stable;
-}
-.force-scrollbar {
-    -ms-overflow-style: scrollbar;
-}


### PR DESCRIPTION
This PR addresses issue #496. It applies the styling approach introduced by @shubhamk008 to add a permanent scrollbar to the result list and the help-information section. I have tested it on Chrome, Edge, and Safari on my MacBook.

Note that the WebKit-based solution does not work for Firefox (https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar). While a non-WebKit method can alter the scrollbar’s appearance (like https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scrollbars_styling), it does not ensure a permanently visible scrollbar. Instead, users can enable this feature manually in Firefox settings (https://connect.mozilla.org/t5/discussions/scrollbars-disappear-in-firefox-100/m-p/6358). If I missed any relevant resources, please let me know—I did some searches but couldn't find a proper solution.

However, when users hover over a scrollable section, a scrollbar briefly appears and disappears, indicating that scrolling is available. Hopefully, this helps improve usability.

## How to Test
1. Navigate to the search page. A scrollbar should be visible in the result list after the initial render.
<img width="1244" alt="Screenshot 2025-03-13 at 12 49 33 PM" src="https://github.com/user-attachments/assets/ba7ed9bd-62e4-4b4e-ae57-3638fdaa508e" />

2. Check the help text section. The scrollbar should be present for the vertically scrollable info panel.
<img width="1027" alt="Screenshot 2025-03-13 at 12 49 39 PM" src="https://github.com/user-attachments/assets/1a8cc711-2cd8-4595-b394-2ce4739173a8" />

3. Test across multiple browsers to verify the behavior.