### PR TITLE
#507: Improve the click experience for "Show On Map" in result card

### DIFF
--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
-import { Checkbox, FormControlLabel, Grid, Typography } from "@mui/material";
+import { Grid } from "@mui/material";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import IconText from "../iconText";
@@ -341,7 +341,7 @@ const ResultCard = (props: Props): JSX.Element => {
         container
         className="flex flex-col sm:flex-row px-2 mt-1"
       >
-        <Grid item xs={8}>
+        <Grid item xs={8} sx={{ mt: "1em", pt: "0 !important" }}>
           <div className={`${classes.resultCard} truncate `}>
             Keywords:{" "}
             {props.resultItem.meta.keyword
@@ -355,7 +355,7 @@ const ResultCard = (props: Props): JSX.Element => {
               : ""}
           </div>
         </Grid>
-        <Grid item xs={4}>
+        <Grid item xs={4} sx={{ mt: "1em", pt: "0 !important" }}>
           <div className={`${classes.resultCard} truncate `}>
             Year:{" "}
             {props.resultItem.index_year?.length > 1

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
-import {Checkbox, FormControlLabel, Grid, Typography} from "@mui/material";
+import { Checkbox, FormControlLabel, Grid, Typography } from "@mui/material";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import IconText from "../iconText";
@@ -13,8 +13,8 @@ import { RootState } from "@/store";
 import { Tooltip } from "@mui/material";
 import { getScoreExplanation } from "../helper/FilterByScore";
 import { getAllScoresSelector } from "@/store/selectors/SearchSelector";
-import {EventType} from "@/lib/event";
-import {usePlausible} from "next-plausible";
+import { EventType } from "@/lib/event";
+import { usePlausible } from "next-plausible";
 
 interface Props {
   resultItem: SolrObject;
@@ -70,8 +70,24 @@ const useStyles = makeStyles((theme) => ({
       marginBottom: 0,
     },
   },
+  mapPreviewControl: {
+    padding: "6px 8px",
+    cursor: "pointer",
+    borderRadius: "4px",
+    transition: "background-color 0.2s",
+    "&:hover": {
+      backgroundColor: "rgba(0, 0, 0, 0.04)",
+    },
+  },
 }));
-const HighlightsTooltip = ({ q, spellcheck, highlights, score, avgScore, maxScore }) => {
+const HighlightsTooltip = ({
+  q,
+  spellcheck,
+  highlights,
+  score,
+  avgScore,
+  maxScore,
+}) => {
   const classes = useStyles();
   const filteredHighlights = highlights.filter(
     (highlight) => highlight.trim() !== ""
@@ -79,9 +95,26 @@ const HighlightsTooltip = ({ q, spellcheck, highlights, score, avgScore, maxScor
   const currentQuery = useSelector((state: RootState) => state.search.query);
   return highlights.length > 0 ? (
     <div>
-      <div className={classes.scoreExplain} style={{ paddingBottom: 8, borderBottom: `1px solid ${fullConfig.theme.colors["strongorange"]}` }}>
-        <span dangerouslySetInnerHTML={{ __html: getScoreExplanation(q, spellcheck, currentQuery, score, avgScore, maxScore) }} />
-        <p style={{paddingTop: 4}}>Information in this result includes:</p>
+      <div
+        className={classes.scoreExplain}
+        style={{
+          paddingBottom: 8,
+          borderBottom: `1px solid ${fullConfig.theme.colors["strongorange"]}`,
+        }}
+      >
+        <span
+          dangerouslySetInnerHTML={{
+            __html: getScoreExplanation(
+              q,
+              spellcheck,
+              currentQuery,
+              score,
+              avgScore,
+              maxScore
+            ),
+          }}
+        />
+        <p style={{ paddingTop: 4 }}>Information in this result includes:</p>
       </div>
       <ol className={classes.highlightsList}>
         {filteredHighlights.map((highlight, index) => (
@@ -95,8 +128,19 @@ const HighlightsTooltip = ({ q, spellcheck, highlights, score, avgScore, maxScor
     </div>
   ) : (
     <div>
-       <div className={classes.scoreExplain}>
-        <span dangerouslySetInnerHTML={{ __html: getScoreExplanation(q, spellcheck, currentQuery , score, avgScore, maxScore) }} />
+      <div className={classes.scoreExplain}>
+        <span
+          dangerouslySetInnerHTML={{
+            __html: getScoreExplanation(
+              q,
+              spellcheck,
+              currentQuery,
+              score,
+              avgScore,
+              maxScore
+            ),
+          }}
+        />
       </div>
     </div>
   );
@@ -109,12 +153,59 @@ const ResultCard = (props: Props): JSX.Element => {
   const mapPreview = useSelector((state: RootState) => state.ui.mapPreview);
   const { maxScore, avgScore } = useSelector(getAllScoresSelector);
 
+  const isInMapPreview = React.useMemo(() => {
+    return mapPreview.some((p) => p.lyrId === props.resultItem.id);
+  }, [mapPreview, props.resultItem.id]);
+
+  const handleMapPreviewToggle = React.useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!props.resultItem.meta.highlight_ids?.length) return;
+
+      if (isInMapPreview) {
+        dispatch(
+          setMapPreview(
+            mapPreview.filter((item) => item.lyrId != props.resultItem.id)
+          )
+        );
+      } else {
+        dispatch(
+          setMapPreview([
+            {
+              lyrId: props.resultItem.id,
+              filterIds: props.resultItem.meta.highlight_ids,
+            },
+          ])
+        );
+
+        plausible(EventType.ClickedMapPreview, {
+          props: {
+            resourceId: props.resultItem.id,
+          },
+        });
+      }
+    },
+    [dispatch, isInMapPreview, mapPreview, plausible, props.resultItem]
+  );
+
+  const handleShowDetails = React.useCallback(
+    (event) => {
+      dispatch(setShowDetailPanel(props.resultItem.id));
+      plausible(EventType.ClickedItemDetails, {
+        props: {
+          resourceId: props.resultItem.id,
+        },
+      });
+    },
+    [dispatch, plausible, props.resultItem.id]
+  );
+
   const cardContent = props.resultItem && (
     <div
       className={`container mx-auto p-3 bg-lightbisque shadow-none rounded aspect-ratio`}
-      onClick={() => {
-        dispatch(setShowDetailPanel(props.resultItem.id));
-      }}
+      onClick={handleShowDetails}
       style={{
         cursor: "pointer",
         border:
@@ -132,7 +223,11 @@ const ResultCard = (props: Props): JSX.Element => {
       }}
     >
       <div className="flex flex-col sm:flex-row items-center px-2">
-        <Grid container spacing={0} className="flex flex-col sm:flex-row items-center">
+        <Grid
+          container
+          spacing={0}
+          className="flex flex-col sm:flex-row items-center"
+        >
           <Grid item sm={10} className="items-start">
             <IconText
               roundBackground={true}
@@ -145,127 +240,107 @@ const ResultCard = (props: Props): JSX.Element => {
               labelClass={`text-l font-medium ${fullConfig.theme.fontFamily["sans"]}`}
               labelColor={fullConfig.theme.colors["almostblack"]}
             />
-            <div className={`${classes.resultCard} truncate ml-12`} style={{ marginTop: '-0.5rem'}}>
+            <div
+              className={`${classes.resultCard} truncate ml-12`}
+              style={{ marginTop: "-0.5rem" }}
+            >
               by{" "}
               {props.resultItem.meta.publisher
                 ? props.resultItem.meta.publisher[0]
                 : ""}
             </div>
           </Grid>
-          <Grid item sm={2} className=" order-1 sm:order-none sm:ml-auto items-center justify-center sm:justify-end font-bold">
-            <div className={'flex justify-end'}>
+          <Grid
+            item
+            sm={2}
+            className="order-1 sm:order-none sm:ml-auto items-center justify-center sm:justify-end font-bold"
+          >
+            <div className={"flex justify-end"}>
               <button
-                onClick={() => {
-                  dispatch(setShowDetailPanel(props.resultItem.id));
-                  plausible(EventType.ClickedItemDetails, {
-                    props: {
-                      resourceId: props.resultItem.id
-                    }
-                  });
-                }}
+                onClick={handleShowDetails}
                 style={{ color: fullConfig.theme.colors["frenchviolet"] }}
               >
                 Details <span className="ml-1">&#8594;</span>
               </button>
             </div>
 
-            <div className={'flex justify-end'}>
-              {/* Checkbox : Show coverage area on map */}
-              <FormControlLabel
-                className={'nomargin'}
-                disabled={!props.resultItem.meta.highlight_ids?.length}
-                title={!props.resultItem.meta.highlight_ids?.length ? 'No geographic areas have been defined for this dataset' : 'Preview the geographic areas that this dataset covers'}
-                label={<div style={{
-                  color: `${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["frenchviolet"] : fullConfig.theme.colors["darkgray"]}`,
-                  padding: 0,
-                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
-                  fontSize: "0.875rem" }}>
-                  {mapPreview.find(p => p.lyrId === props.resultItem.id) ? 'Remove preview' : 'Show on map'}
-              </div>}
-                onClick={(event) => {
-                  event.stopPropagation();
+            <div className={"flex justify-end"}>
+              <div
+                className={classes.mapPreviewControl}
+                onClick={handleMapPreviewToggle}
+                style={{
+                  cursor: props.resultItem.meta.highlight_ids?.length
+                    ? "pointer"
+                    : "default",
+                  opacity: props.resultItem.meta.highlight_ids?.length
+                    ? 1
+                    : 0.5,
                 }}
-                control={
-                  <Checkbox
-                    id={`sc-checkbox-${props.resultItem.id}`}
-                    value={props.resultItem.meta}
-                    style={{display: 'none'}}
-                    onChange={(event) => {
-                      if (event.target.checked) {
-                        dispatch(
-                          setMapPreview([
-                            {
-                              lyrId: props.resultItem.id,
-                              filterIds: props.resultItem.meta.highlight_ids,
-                            },
-                          ])
-                        );
-
-                        plausible(EventType.ClickedMapPreview, {
-                          props: {
-                            resourceId: props.resultItem.id
-                          }
-                        });
-                      } else {
-                        dispatch(
-                          setMapPreview(
-                            mapPreview.filter(
-                              (item) => item.lyrId != props.resultItem.id
-                            )
-                          )
-                        );
-                      }
-                    }}
-                    icon={
-                      <span
-                        style={{
-                          borderRadius: "4px",
-                          border: `2px solid ${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["frenchviolet"] : fullConfig.theme.colors["darkgray"]}`,
-                          width: "14px",
-                          height: "14px",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          backgroundColor: "transparent",
-                        }}
-                      ></span>
-                    }
-                    checkedIcon={
-                      <span
-                        style={{
-                          borderRadius: "4px",
-                          border: `2px solid ${fullConfig.theme.colors["frenchviolet"]}`,
-                          width: "14px",
-                          height: "14px",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          backgroundColor: `${fullConfig.theme.colors["frenchviolet"]}`,
-                        }}
-                      >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="white"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  style={{ width: "16px", height: "16px" }}
-                >
-                  <polyline points="20 6 9 17 4 12" />
-                </svg>
-              </span>
-                    }
-                  />
+                title={
+                  !props.resultItem.meta.highlight_ids?.length
+                    ? "No geographic areas have been defined for this dataset"
+                    : "Preview the geographic areas that this dataset covers"
                 }
-              />
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    color: `${
+                      props.resultItem.meta.highlight_ids?.length
+                        ? fullConfig.theme.colors["frenchviolet"]
+                        : fullConfig.theme.colors["darkgray"]
+                    }`,
+                    fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                    fontSize: "0.875rem",
+                  }}
+                >
+                  <span
+                    style={{
+                      borderRadius: "4px",
+                      border: `2px solid ${
+                        props.resultItem.meta.highlight_ids?.length
+                          ? fullConfig.theme.colors["frenchviolet"]
+                          : fullConfig.theme.colors["darkgray"]
+                      }`,
+                      width: "14px",
+                      height: "14px",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor: isInMapPreview
+                        ? `${fullConfig.theme.colors["frenchviolet"]}`
+                        : "transparent",
+                      marginRight: "8px",
+                    }}
+                  >
+                    {isInMapPreview && (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        style={{ width: "16px", height: "16px" }}
+                      >
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    )}
+                  </span>
+                  {isInMapPreview ? "Remove preview" : "Show on map"}
+                </div>
+              </div>
             </div>
           </Grid>
-
         </Grid>
       </div>
-      <Grid spacing={2} container className="flex flex-col sm:flex-row px-2 mt-1">
+      <Grid
+        spacing={2}
+        container
+        className="flex flex-col sm:flex-row px-2 mt-1"
+      >
         <Grid item xs={8}>
           <div className={`${classes.resultCard} truncate `}>
             Keywords:{" "}
@@ -284,7 +359,11 @@ const ResultCard = (props: Props): JSX.Element => {
           <div className={`${classes.resultCard} truncate `}>
             Year:{" "}
             {props.resultItem.index_year?.length > 1
-              ? `${Math.min(...props.resultItem.index_year.map(y => Number(y)))} - ${Math.max(...props.resultItem.index_year.map(y => Number(y)))}`
+              ? `${Math.min(
+                  ...props.resultItem.index_year.map((y) => Number(y))
+                )} - ${Math.max(
+                  ...props.resultItem.index_year.map((y) => Number(y))
+                )}`
               : props.resultItem.index_year}
           </div>
           <div className={`${classes.resultCard} truncate `}>
@@ -293,24 +372,18 @@ const ResultCard = (props: Props): JSX.Element => {
               ? props.resultItem.meta.spatial_resolution.join(", ")
               : ""}
           </div>
-          {/*<div className={`${classes.resultCard} truncate`}>
-            Resource:{" "}
-            {props.resultItem.resource_class
-              ? props.resultItem.resource_class.join(", ")
-              : ""}
-          </div>*/}
         </Grid>
       </Grid>
     </div>
   );
   return props.resultItem ? (
     (props.resultItem.highlights && props.resultItem.highlights.length > 0) ||
-    props.resultItem.q && !props.resultItem.q.includes('*') ? (
+    (props.resultItem.q && !props.resultItem.q.includes("*")) ? (
       <Tooltip
         title={
           <HighlightsTooltip
             q={props.resultItem.q}
-            spellcheck = {props.resultItem.spellcheck}
+            spellcheck={props.resultItem.spellcheck}
             highlights={props.resultItem.highlights || []}
             score={props.resultItem.score}
             avgScore={avgScore}


### PR DESCRIPTION
This PR addresses issue #507. It aims to resolve the problem where the 'Show On Map' link in the result card is too small, making it prone to mis-clicks since the surrounding area is also clickable.

To improve the click experience, I’ve introduced some UI changes, including adding a checkbox to indicate the button’s effect back. If the previous version is preferred, please let me know, and I’ll revert the changes.

## How to Test
1. Visit https://deploy-preview-510--cheerful-treacle-913a24.netlify.app/search and hover over a 'Show on Map' button. A shadow should appear to indicate the clickable area:
<img width="498" alt="Screenshot 2025-03-13 at 2 57 04 PM" src="https://github.com/user-attachments/assets/b6a9810e-c321-4ac7-b61a-e32f1012693a" />

2. Click the 'Show on Map' button. The map should update, and a checkmark should appear to confirm the button's effect:
<img width="1944" alt="Screenshot 2025-03-13 at 2 58 23 PM" src="https://github.com/user-attachments/assets/762299de-ca57-48a4-8f69-9d7a3755f642" />

3. Click another 'Show on Map' button. The map should update again, and the button's status should reflect the new selection:
<img width="2037" alt="Screenshot 2025-03-13 at 2 58 44 PM" src="https://github.com/user-attachments/assets/9d7b55d4-1117-4766-8dc6-943360f50080" />

4. Click the 'Remove Preview' button. The map overlay should be removed, confirming the click action.

To further improve the user experience, we may want to explore design changes such as increasing the button's font size to reduce accidental clicks between the result card (which triggers the detail view) and the 'Show on Map' button (which updates the map) in the future.