### PR TITLE
feat: rework the fellows page to support multiple cohorts

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -123,7 +123,7 @@ collections:
               - label: "Cohort"
                 name: "cohort"
                 widget: "select"
-                options: ["Spring 2024", "Fall 2024"]
+                options: ["Spring 2024", "Fall 2024", "Spring 2025"]
               - label: "Links"
                 name: "links"
                 widget: "list"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -107,6 +107,7 @@ collections:
             label_singular: "Fellow"
             widget: list
             summary: "{{name}} - {{cohort}}"
+            add_to_top: true
             fields:
               - label: "Name"
                 name: "name"

--- a/src/pages/advisory.tsx
+++ b/src/pages/advisory.tsx
@@ -212,7 +212,7 @@ const Advisory: NextPage = () => {
         </div>
         <div className="self-stretch flex flex-col mt-10 max-md:max-w-full max-md:mr-0.5 max-md:mt-10">
           <div className="self-center text-center w-full max-md:max-w-full mb-32 text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
-            <h2 className="font-fredoka">Past Advisory Board Members</h2>
+            <h2 className="font-fredoka">Project Launch Advisory</h2>
           </div>
         </div>
         <div className="bg-lightbisque self-stretch flex mt-0 w-full flex-col px-5 max-md:max-w-full">

--- a/src/pages/fellows.tsx
+++ b/src/pages/fellows.tsx
@@ -58,10 +58,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 // List/order to display the cohorts in this view
-const cohorts = [
-  //'Fall 2024',
-  'Spring 2024',
-];
+const cohorts = [];
 
 // Map of cohort to fellows in the cohort
 // This will be built up when the view loads
@@ -69,19 +66,44 @@ const fellows = {};
 
 const Fellows: NextPage = () => {
   const classes = useStyles();
-  // Merge all cohorts into our map (grouped by cohort)
-  cohorts.forEach((cohort: string) => {
-    console.log(`Computing ${cohort}...`);
-    const cohortFellows = fellowsData.fellows.filter(f => f.cohort === cohort);
-    console.log(`Found: ${fellows}...`);
-    fellows[cohort] = cohortFellows;
+  // Fellow all cohorts in the CMS system and group them by cohort
+  fellowsData.fellows.forEach((fellow) => {
+    const cohort = fellow.cohort;
+    fellows[cohort] = fellows[cohort] || [];
+    if (!fellows[cohort]?.includes(fellow)) {
+      fellows[cohort].push(fellow);
+    }
+
+    // Add to the list of cohorts if this is not already present
+    if (!cohorts.includes(cohort)) {
+      cohorts.push(cohort);
+    }
   });
-  console.log(`Cohorts: ${cohorts}`);
-  console.log(`Fellows: ${fellows}`);
+  console.log(`Cohorts:`, cohorts);
+  console.log(`Fellows:`, fellows);
   const [open, setOpen] = React.useState(false);
   const [modalData, setModalData] = React.useState(fellows[cohorts[0]]);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+
+  const sortByYearAndSeason = () => {
+    return cohorts.sort((c1, c2) => {
+      const [s1, y1] = c1.split(' ');
+      const [s2, y2] = c2.split(' ');
+
+      // Main comparison uses year
+      if (y1 > y2) { return 1; }
+      if (y2 < y1) { return -1; }
+
+      // Break ties in year using season
+      if (s1 > s2) { return 1; }
+      if (s2 < s1) { return -1; }
+
+      // Same year, same season => same cohort
+      return 0;
+    });
+  }
+
   return (
     <>
       <Header title={"Fellowship Program"} />
@@ -178,7 +200,7 @@ const Fellows: NextPage = () => {
           </div>
         </div>
         {
-          cohorts.map((cohort, index) =>
+          sortByYearAndSeason(cohorts).map((cohort, index) =>
             <div className="self-stretch flex flex-col mt-10 max-md:max-w-full max-md:mr-0.5 max-md:mt-10" key={`cohort-${cohort}-${index}`}>
               <div className="self-center text-center w-full max-md:max-w-full mb-32 text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
                 <h2 className="font-fredoka">{cohort} Fellow Cohort</h2>

--- a/src/pages/fellows.tsx
+++ b/src/pages/fellows.tsx
@@ -57,13 +57,29 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+// List/order to display the cohorts in this view
+const cohorts = [
+  //'Fall 2024',
+  'Spring 2024',
+];
+
+// Map of cohort to fellows in the cohort
+// This will be built up when the view loads
+const fellows = {};
+
 const Fellows: NextPage = () => {
   const classes = useStyles();
-  const fellowsList2024 = fellowsData.fellows.filter(
-    (fellow) => fellow.cohort == "Spring 2024"
-  );
+  // Merge all cohorts into our map (grouped by cohort)
+  cohorts.forEach((cohort: string) => {
+    console.log(`Computing ${cohort}...`);
+    const cohortFellows = fellowsData.fellows.filter(f => f.cohort === cohort);
+    console.log(`Found: ${fellows}...`);
+    fellows[cohort] = cohortFellows;
+  });
+  console.log(`Cohorts: ${cohorts}`);
+  console.log(`Fellows: ${fellows}`);
   const [open, setOpen] = React.useState(false);
-  const [modalData, setModalData] = React.useState(fellowsList2024[0]);
+  const [modalData, setModalData] = React.useState(fellows[cohorts[0]]);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   return (
@@ -97,28 +113,28 @@ const Fellows: NextPage = () => {
               <div className="flex flex-col items-stretch w-3/12 max-md:w-full max-md:ml-0">
                 <div className="flex flex-col max-md:mt-10">
                   <ProfileImage
-                    src={modalData.image}
-                    alt={modalData.name}
+                    src={modalData?.image}
+                    alt={modalData?.name}
                     rounded={false}
                   />
                   <div className="text-2xl font-bold leading-[133.333%] mt-6">
-                    {modalData.name}
+                    {modalData?.name}
                   </div>
                   <div className="text-lg font-medium leading-[177.778%] mt-2.5">
-                    {modalData.title}
+                    {modalData?.title}
                   </div>
-                  {modalData.links.map((link, index) => (
+                  {modalData?.links?.map((link, index) => (
                     <div
                       key={index}
                       className="text-lg font-medium leading-[177.778%] mt-2.5"
                     >
                       <a
-                        href={link.link_url}
+                        href={link?.link_url}
                         target="_blank"
                         rel="noreferrer"
                         className="text-salmonpink no-underline hover:underline"
                       >
-                        <Typography>{link.link_label}</Typography>
+                        <Typography>{link?.link_label}</Typography>
                       </a>
                     </div>
                   ))}
@@ -128,7 +144,7 @@ const Fellows: NextPage = () => {
                 <div className="text-lg font-medium leading-[177.778%] w-[848px] max-w-full max-md:mt-10">
                   <div
                     dangerouslySetInnerHTML={{
-                      __html: modalData.desc_long,
+                      __html: modalData?.desc_long,
                     }}
                   />
                 </div>
@@ -161,63 +177,69 @@ const Fellows: NextPage = () => {
             </div>
           </div>
         </div>
-        <div className="self-stretch flex flex-col mt-10 max-md:max-w-full max-md:mr-0.5 max-md:mt-10">
-          <div className="self-center text-center w-full max-md:max-w-full mb-32 text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
-            <h2 className="font-fredoka">2024 Fellow Cohort</h2>
-          </div>
-          <div className="bg-lightbisque self-stretch flex grow flex-col px-5 max-md:max-w-full">
-            <div className="self-center flex w-full max-w-[1246px] flex-col max-md:max-w-full">
-              <div
-                className="self-center flex w-full max-w-[1246px] flex-col mt-0.5 max-md:max-w-full"
-                style={{ marginTop: "-110px" }}
-              >
-                <div className="self-center w-full max-md:max-w-full">
-                  <div className="flex flex-wrap max-md:flex-col max-md:items-stretch max-md:gap-0">
-                    {fellowsList2024.map((item, index) => (
-                      <div
-                        key={index}
-                        className="flex flex-col items-stretch w-1/4 p-[25px] mb-[70px] max-md:w-full max-md:ml-0"
-                      >
-                        <div className="flex flex-col items-stretch w-full max-md:w-full max-md:ml-0">
-                          <div
-                            className="flex flex-col items-stretch mb-[30px] max-md:w-full max-md:ml-0"
-                            style={{ paddingRight: "100px" }}
-                          >
-                            <ProfileImage
-                              src={item.image}
-                              alt={item.name}
-                              rounded={true}
-                            />
-                          </div>
-                          <div className="flex grow flex-col max-md:mt-10">
-                            <div className="text-stone-900 text-2xl font-bold leading-[133.333%]">
-                              {item.name}
-                            </div>
-                            <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-1">
-                              {item.title}
-                            </div>
-                            <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-6">
-                              {item.desc_short}
-                            </div>
+        {
+          cohorts.map((cohort, index) =>
+            <div className="self-stretch flex flex-col mt-10 max-md:max-w-full max-md:mr-0.5 max-md:mt-10" key={`cohort-${cohort}-${index}`}>
+              <div className="self-center text-center w-full max-md:max-w-full mb-32 text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
+                <h2 className="font-fredoka">{cohort} Fellow Cohort</h2>
+              </div>
+              <div className="bg-lightbisque self-stretch flex grow flex-col px-5 max-md:max-w-full">
+                <div className="self-center flex w-full max-w-[1246px] flex-col max-md:max-w-full">
+                  <div
+                    className="self-center flex w-full max-w-[1246px] flex-col mt-0.5 max-md:max-w-full"
+                    style={{ marginTop: "-110px" }}
+                  >
+                    <div className="self-center w-full max-md:max-w-full">
+                      <div className="flex flex-wrap max-md:flex-col max-md:items-stretch max-md:gap-0">
+                        {
+                          fellows[cohort]?.map((fellow, index) =>
                             <div
-                              className={`text-frenchviolet text-left text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase ${classes.modalBtnStyle}`}
-                              onClick={() => {
-                                setModalData(item);
-                                handleOpen();
-                              }}
+                              key={`fellow-${cohort}-${index}`}
+                              className="flex flex-col items-stretch w-1/4 p-[25px] mb-[70px] max-md:w-full max-md:ml-0"
                             >
-                              Read More
+                              <div className="flex flex-col items-stretch w-full max-md:w-full max-md:ml-0">
+                                <div
+                                  className="flex flex-col items-stretch mb-[30px] max-md:w-full max-md:ml-0"
+                                  style={{ paddingRight: "100px" }}
+                                >
+                                  <ProfileImage
+                                    src={fellow.image}
+                                    alt={fellow.name}
+                                    rounded={true}
+                                  />
+                                </div>
+                                <div className="flex grow flex-col max-md:mt-10">
+                                  <div className="text-stone-900 text-2xl font-bold leading-[133.333%]">
+                                    {fellow.name}
+                                  </div>
+                                  <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-1">
+                                    {fellow.title}
+                                  </div>
+                                  <div className="text-stone-900 text-lg font-medium leading-[177.778%] mt-6">
+                                    {fellow.desc_short}
+                                  </div>
+                                  <div
+                                    className={`text-frenchviolet text-left text-[0.6875rem] leading-4 font-bold tracking-[0.03125rem] uppercase ${classes.modalBtnStyle}`}
+                                    onClick={() => {
+                                      setModalData(fellow);
+                                      handleOpen();
+                                    }}
+                                  >
+                                    Read More
+                                  </div>
+                                </div>
+                              </div>
                             </div>
-                          </div>
-                        </div>
+                          )
+                        }
                       </div>
-                    ))}
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          )
+        }
         <Footer />
       </div>
     </>

--- a/src/pages/fellows.tsx
+++ b/src/pages/fellows.tsx
@@ -57,36 +57,26 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-// List/order to display the cohorts in this view
-const cohorts = [];
-
-// Map of cohort to fellows in the cohort
-// This will be built up when the view loads
-const fellows = {};
-
 const Fellows: NextPage = () => {
+  // Map of cohort to fellows in the cohort
+  // This will be built up when the view loads
+  const fellows = {};
+
   const classes = useStyles();
   // Fellow all cohorts in the CMS system and group them by cohort
   fellowsData.fellows.forEach((fellow) => {
-    const cohort = fellow.cohort;
-    fellows[cohort] = fellows[cohort] || [];
-    if (!fellows[cohort]?.includes(fellow)) {
-      fellows[cohort].push(fellow);
-    }
-
-    // Add to the list of cohorts if this is not already present
-    if (!cohorts.includes(cohort)) {
-      cohorts.push(cohort);
-    }
+    // Add to the running list of fellows if this is not already present
+    fellows[fellow.cohort] = fellows[fellow.cohort] || [];
+    fellows[fellow.cohort]?.includes(fellow) || fellows[fellow.cohort].push(fellow);
   });
-  console.log(`Cohorts:`, cohorts);
-  console.log(`Fellows:`, fellows);
+  const [firstCohort] = Object.keys(fellows);
+
   const [open, setOpen] = React.useState(false);
-  const [modalData, setModalData] = React.useState(fellows[cohorts[0]]);
+  const [modalData, setModalData] = React.useState(fellows[firstCohort][0]);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
-  const sortByYearAndSeason = () => {
+  const sortByYearAndSeason = (cohorts) => {
     return cohorts.sort((c1, c2) => {
       const [s1, y1] = c1.split(' ');
       const [s2, y2] = c2.split(' ');
@@ -200,7 +190,7 @@ const Fellows: NextPage = () => {
           </div>
         </div>
         {
-          sortByYearAndSeason(cohorts).map((cohort, index) =>
+          sortByYearAndSeason(Object.keys(fellows)).map((cohort, index) =>
             <div className="self-stretch flex flex-col mt-10 max-md:max-w-full max-md:mr-0.5 max-md:mt-10" key={`cohort-${cohort}-${index}`}>
               <div className="self-center text-center w-full max-md:max-w-full mb-32 text-stone-900 max-w-[1246px] p-[25px] ml-18 max-md:ml-2.5">
                 <h2 className="font-fredoka">{cohort} Fellow Cohort</h2>


### PR DESCRIPTION
## Problem
Our current Fellows page only displays the Spring 2024 cohorts

We would like to update this view to display and organize fellows from multiple different cohorts

Fixes #364 

## Approach
* fix: reword the Advisory page - Past Advisory Board Members -> Project Launch Advisory
* feat: rework the Fellows page to support multiple cohorts

![Screenshot 2025-03-13 at 3 15 06 PM](https://github.com/user-attachments/assets/6e7c0d2e-9dd9-4345-9bd5-41568fbcd5c0)

![Screenshot 2025-03-13 at 3 15 20 PM](https://github.com/user-attachments/assets/d041c46c-2c92-4e09-b0e8-69e0f6f1d8a3)

![Screenshot 2025-03-13 at 3 15 33 PM](https://github.com/user-attachments/assets/b0fb9e73-e490-4637-ac84-7acf5278c9e5)

## How to Test
1. Navigate to https://deploy-preview-512--cheerful-treacle-913a24.netlify.app/fellows
    * You should see the view now displays Spring 2024 Fellows
    * Once we add Fall 2024, you should see them displayed above Spring 2024 (since they are more recent)
    * Similarly, once we add the Spring 2025 Cohorts, they will appear above the 2024 ones