### PR TITLE
[WIP] #513 Allow user to hide the tooltip when hovering on result

### DIFF
--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -1,12 +1,21 @@
 "use client";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState, AppDispatch, store } from "@/store";
+import { setShowTooltips } from "@/store/slices/uiSlice";
 import { makeStyles } from "@mui/styles";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import SearchIcon from "@mui/icons-material/Search";
 import { clearMapPreview, setShowFilter } from "@/store/slices/uiSlice";
-import { Box, SvgIcon, CircularProgress, Fade, Collapse } from "@mui/material";
+import {
+  Box,
+  SvgIcon,
+  CircularProgress,
+  Fade,
+  Collapse,
+  FormControlLabel,
+  Checkbox,
+} from "@mui/material";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import React from "react";
 import ResultCard from "./resultCard";
@@ -46,6 +55,10 @@ const ResultsPanel = (props: Props): JSX.Element => {
   );
   const [isResetting, setIsResetting] = React.useState(false);
   const [isInitialLoad, setIsInitialLoad] = React.useState(true);
+  const showTooltips = useSelector((state: RootState) => state.ui.showTooltips);
+  const showDetailPanel = useSelector(
+    (state: RootState) => state.ui.showDetailPanel
+  );
 
   const uniqueRelatedList = React.useMemo(() => {
     const uniqueResults = searchState.relatedResults.filter(
@@ -70,7 +83,13 @@ const ResultsPanel = (props: Props): JSX.Element => {
     if (isResetting) return previousCount;
     if (isLoading) return previousCount;
     return searchState.results.length + uniqueRelatedList.length;
-  }, [isLoading, isResetting, previousCount, searchState.results.length, uniqueRelatedList.length]);
+  }, [
+    isLoading,
+    isResetting,
+    previousCount,
+    searchState.results.length,
+    uniqueRelatedList.length,
+  ]);
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const hasSearchParams = params.has("query") || params.has("ai_search");
@@ -101,7 +120,13 @@ const ResultsPanel = (props: Props): JSX.Element => {
       </Box>
     </Box>
   );
-
+  React.useEffect(() => {
+    if (showDetailPanel) {
+      dispatch(setShowTooltips(false));
+    } else if (showDetailPanel === null && !isInitialLoad) {
+      dispatch(setShowTooltips(true));
+    }
+  }, [showDetailPanel, dispatch, isInitialLoad]);
   return (
     <div
       className="results-panel"
@@ -123,11 +148,40 @@ const ResultsPanel = (props: Props): JSX.Element => {
                 </div>
               </Fade>
             </div>
+
             {filterStatus.hasActiveFilters && !isLoading && !isResetting && (
               <div className="flex flex-col sm:flex-row items-enter justify-center mr-4 cursor-pointer text-uppercase">
                 <div className="text-frenchviolet" onClick={handleClearFilters}>
                   Clear All
                 </div>
+              </div>
+            )}
+
+            {isQuery && !isInitialLoad && (
+              <div className="flex sm:justify-end items-center mt-0 order-1 sm:order-none flex-none ml-2 mr-4">
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={showTooltips}
+                      onChange={(e) =>
+                        dispatch(setShowTooltips(e.target.checked))
+                      }
+                      sx={{
+                        color: fullConfig.theme.colors["frenchviolet"],
+                        "&.Mui-checked": {
+                          color: fullConfig.theme.colors["frenchviolet"],
+                        },
+                      }}
+                      size="small"
+                    />
+                  }
+                  label={
+                    <div className="flex items-center text-frenchviolet">
+                      Result Previews
+                    </div>
+                  }
+                  labelPlacement="start"
+                />
               </div>
             )}
 

--- a/src/components/search/resultsPanel/resultCard.tsx
+++ b/src/components/search/resultsPanel/resultCard.tsx
@@ -1,7 +1,13 @@
 "use client";
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
-import {Checkbox, FormControlLabel, Grid, Typography} from "@mui/material";
+import {
+  Checkbox,
+  FormControlLabel,
+  Grid,
+  hexToRgb,
+  Typography,
+} from "@mui/material";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import IconText from "../iconText";
@@ -13,8 +19,8 @@ import { RootState } from "@/store";
 import { Tooltip } from "@mui/material";
 import { getScoreExplanation } from "../helper/FilterByScore";
 import { getAllScoresSelector } from "@/store/selectors/SearchSelector";
-import {EventType} from "@/lib/event";
-import {usePlausible} from "next-plausible";
+import { EventType } from "@/lib/event";
+import { usePlausible } from "next-plausible";
 
 interface Props {
   resultItem: SolrObject;
@@ -36,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: "4px",
   },
   tooltip: {
-    backgroundColor: "white !important",
+    backgroundColor: "rgba(255, 255, 255, 0.9) !important",
     color: `${fullConfig.theme.colors["almostblack"]}`,
     maxWidth: 500,
     fontSize: "0.875rem",
@@ -82,7 +88,14 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: "auto",
   },
 }));
-const HighlightsTooltip = ({ q, spellcheck, highlights, score, avgScore, maxScore }) => {
+const HighlightsTooltip = ({
+  q,
+  spellcheck,
+  highlights,
+  score,
+  avgScore,
+  maxScore,
+}) => {
   const classes = useStyles();
   const filteredHighlights = highlights.filter(
     (highlight) => highlight.trim() !== ""
@@ -90,9 +103,26 @@ const HighlightsTooltip = ({ q, spellcheck, highlights, score, avgScore, maxScor
   const currentQuery = useSelector((state: RootState) => state.search.query);
   return highlights.length > 0 ? (
     <div>
-      <div className={classes.scoreExplain} style={{ paddingBottom: 8, borderBottom: `1px solid ${fullConfig.theme.colors["strongorange"]}` }}>
-        <span dangerouslySetInnerHTML={{ __html: getScoreExplanation(q, spellcheck, currentQuery, score, avgScore, maxScore) }} />
-        <p style={{paddingTop: 4}}>Information in this result includes:</p>
+      <div
+        className={classes.scoreExplain}
+        style={{
+          paddingBottom: 8,
+          borderBottom: `1px solid ${fullConfig.theme.colors["strongorange"]}`,
+        }}
+      >
+        <span
+          dangerouslySetInnerHTML={{
+            __html: getScoreExplanation(
+              q,
+              spellcheck,
+              currentQuery,
+              score,
+              avgScore,
+              maxScore
+            ),
+          }}
+        />
+        <p style={{ paddingTop: 4 }}>Information in this result includes:</p>
       </div>
       <ol className={classes.highlightsList}>
         {filteredHighlights.map((highlight, index) => (
@@ -106,8 +136,19 @@ const HighlightsTooltip = ({ q, spellcheck, highlights, score, avgScore, maxScor
     </div>
   ) : (
     <div>
-       <div className={classes.scoreExplain}>
-        <span dangerouslySetInnerHTML={{ __html: getScoreExplanation(q, spellcheck, currentQuery , score, avgScore, maxScore) }} />
+      <div className={classes.scoreExplain}>
+        <span
+          dangerouslySetInnerHTML={{
+            __html: getScoreExplanation(
+              q,
+              spellcheck,
+              currentQuery,
+              score,
+              avgScore,
+              maxScore
+            ),
+          }}
+        />
       </div>
     </div>
   );
@@ -117,53 +158,58 @@ const ResultCard = (props: Props): JSX.Element => {
   const classes = useStyles();
   const plausible = usePlausible();
   const { showDetailPanel } = useSelector((state: RootState) => state.ui);
+  const showTooltips = useSelector((state: RootState) => state.ui.showTooltips);
   const mapPreview = useSelector((state: RootState) => state.ui.mapPreview);
   const { maxScore, avgScore } = useSelector(getAllScoresSelector);
-  
+
   const isInMapPreview = React.useMemo(() => {
-    return mapPreview.some(p => p.lyrId === props.resultItem.id);
+    return mapPreview.some((p) => p.lyrId === props.resultItem.id);
   }, [mapPreview, props.resultItem.id]);
-  
-  const handleMapPreviewToggle = React.useCallback((event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    
-    if (!props.resultItem.meta.highlight_ids?.length) return;
-    
-    if (isInMapPreview) {
-      dispatch(
-        setMapPreview(
-          mapPreview.filter(
-            (item) => item.lyrId != props.resultItem.id
+
+  const handleMapPreviewToggle = React.useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!props.resultItem.meta.highlight_ids?.length) return;
+
+      if (isInMapPreview) {
+        dispatch(
+          setMapPreview(
+            mapPreview.filter((item) => item.lyrId != props.resultItem.id)
           )
-        )
-      );
-    } else {
-      dispatch(
-        setMapPreview([
-          {
-            lyrId: props.resultItem.id,
-            filterIds: props.resultItem.meta.highlight_ids,
+        );
+      } else {
+        dispatch(
+          setMapPreview([
+            {
+              lyrId: props.resultItem.id,
+              filterIds: props.resultItem.meta.highlight_ids,
+            },
+          ])
+        );
+
+        plausible(EventType.ClickedMapPreview, {
+          props: {
+            resourceId: props.resultItem.id,
           },
-        ])
-      );
-      
-      plausible(EventType.ClickedMapPreview, {
-        props: {
-          resourceId: props.resultItem.id
-        }
-      });
-    }
-  }, [dispatch, isInMapPreview, mapPreview, plausible, props.resultItem]);
-  
-  const handleShowDetails = React.useCallback((event) => {
-    dispatch(setShowDetailPanel(props.resultItem.id));
-    plausible(EventType.ClickedItemDetails, {
-      props: {
-        resourceId: props.resultItem.id
+        });
       }
-    });
-  }, [dispatch, plausible, props.resultItem.id]);
+    },
+    [dispatch, isInMapPreview, mapPreview, plausible, props.resultItem]
+  );
+
+  const handleShowDetails = React.useCallback(
+    (event) => {
+      dispatch(setShowDetailPanel(props.resultItem.id));
+      plausible(EventType.ClickedItemDetails, {
+        props: {
+          resourceId: props.resultItem.id,
+        },
+      });
+    },
+    [dispatch, plausible, props.resultItem.id]
+  );
 
   const cardContent = props.resultItem && (
     <div
@@ -186,7 +232,11 @@ const ResultCard = (props: Props): JSX.Element => {
       }}
     >
       <div className="flex flex-col sm:flex-row items-center px-2">
-        <Grid container spacing={0} className="flex flex-col sm:flex-row items-center">
+        <Grid
+          container
+          spacing={0}
+          className="flex flex-col sm:flex-row items-center"
+        >
           <Grid item sm={10} className="items-start">
             <IconText
               roundBackground={true}
@@ -199,15 +249,22 @@ const ResultCard = (props: Props): JSX.Element => {
               labelClass={`text-l font-medium ${fullConfig.theme.fontFamily["sans"]}`}
               labelColor={fullConfig.theme.colors["almostblack"]}
             />
-            <div className={`${classes.resultCard} truncate ml-12`} style={{ marginTop: '-0.5rem'}}>
+            <div
+              className={`${classes.resultCard} truncate ml-12`}
+              style={{ marginTop: "-0.5rem" }}
+            >
               by{" "}
               {props.resultItem.meta.publisher
                 ? props.resultItem.meta.publisher[0]
                 : ""}
             </div>
           </Grid>
-          <Grid item sm={2} className="order-1 sm:order-none sm:ml-auto items-center justify-center sm:justify-end font-bold">
-            <div className={'flex justify-end'}>
+          <Grid
+            item
+            sm={2}
+            className="order-1 sm:order-none sm:ml-auto items-center justify-center sm:justify-end font-bold"
+          >
+            <div className={"flex justify-end"}>
               <button
                 onClick={handleShowDetails}
                 style={{ color: fullConfig.theme.colors["frenchviolet"] }}
@@ -216,30 +273,47 @@ const ResultCard = (props: Props): JSX.Element => {
               </button>
             </div>
 
-            <div className={'flex justify-end'}>
-              <div 
+            <div className={"flex justify-end"}>
+              <div
                 className={classes.mapPreviewControl}
                 onClick={handleMapPreviewToggle}
                 style={{
-                  cursor: props.resultItem.meta.highlight_ids?.length ? 'pointer' : 'default',
-                  opacity: props.resultItem.meta.highlight_ids?.length ? 1 : 0.5,
+                  cursor: props.resultItem.meta.highlight_ids?.length
+                    ? "pointer"
+                    : "default",
+                  opacity: props.resultItem.meta.highlight_ids?.length
+                    ? 1
+                    : 0.5,
                 }}
-                title={!props.resultItem.meta.highlight_ids?.length ? 'No geographic areas have been defined for this dataset' : 'Preview the geographic areas that this dataset covers'}
+                title={
+                  !props.resultItem.meta.highlight_ids?.length
+                    ? "No geographic areas have been defined for this dataset"
+                    : "Preview the geographic areas that this dataset covers"
+                }
               >
-                <div style={{
-                  color: `${props.resultItem.meta.highlight_ids?.length ? fullConfig.theme.colors["frenchviolet"] : fullConfig.theme.colors["darkgray"]}`,
-                  fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
-                  fontSize: "0.875rem"
-                }}>
-                  {isInMapPreview ? 'Remove preview' : 'Show on map'}
+                <div
+                  style={{
+                    color: `${
+                      props.resultItem.meta.highlight_ids?.length
+                        ? fullConfig.theme.colors["frenchviolet"]
+                        : fullConfig.theme.colors["darkgray"]
+                    }`,
+                    fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
+                    fontSize: "0.875rem",
+                  }}
+                >
+                  {isInMapPreview ? "Remove preview" : "Show on map"}
                 </div>
               </div>
             </div>
           </Grid>
-
         </Grid>
       </div>
-      <Grid spacing={2} container className="flex flex-col sm:flex-row px-2 mt-1">
+      <Grid
+        spacing={2}
+        container
+        className="flex flex-col sm:flex-row px-2 mt-1"
+      >
         <Grid item xs={8}>
           <div className={`${classes.resultCard} truncate `}>
             Keywords:{" "}
@@ -258,7 +332,11 @@ const ResultCard = (props: Props): JSX.Element => {
           <div className={`${classes.resultCard} truncate `}>
             Year:{" "}
             {props.resultItem.index_year?.length > 1
-              ? `${Math.min(...props.resultItem.index_year.map(y => Number(y)))} - ${Math.max(...props.resultItem.index_year.map(y => Number(y)))}`
+              ? `${Math.min(
+                  ...props.resultItem.index_year.map((y) => Number(y))
+                )} - ${Math.max(
+                  ...props.resultItem.index_year.map((y) => Number(y))
+                )}`
               : props.resultItem.index_year}
           </div>
           <div className={`${classes.resultCard} truncate `}>
@@ -272,13 +350,14 @@ const ResultCard = (props: Props): JSX.Element => {
     </div>
   );
   return props.resultItem ? (
-    (props.resultItem.highlights && props.resultItem.highlights.length > 0) ||
-    props.resultItem.q && !props.resultItem.q.includes('*') ? (
+    showTooltips &&
+    ((props.resultItem.highlights && props.resultItem.highlights.length > 0) ||
+      (props.resultItem.q && !props.resultItem.q.includes("*"))) ? (
       <Tooltip
         title={
           <HighlightsTooltip
             q={props.resultItem.q}
-            spellcheck = {props.resultItem.spellcheck}
+            spellcheck={props.resultItem.spellcheck}
             highlights={props.resultItem.highlights || []}
             score={props.resultItem.score}
             avgScore={avgScore}

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -14,6 +14,7 @@ interface UIState {
   showClearButton: boolean;
   showSharedLink: boolean;
   mapPreview: MapPreviewLyr[];
+  showTooltips: boolean;
 }
 
 const initialState: UIState = {
@@ -25,6 +26,7 @@ const initialState: UIState = {
   showClearButton: false,
   showSharedLink: false,
   mapPreview: [],
+  showTooltips: true
 };
 
 const uiSlice = createSlice({
@@ -58,6 +60,9 @@ const uiSlice = createSlice({
     setMapPreview: (state, action) => {
       state.mapPreview = action.payload;
     },
+    setShowTooltips: (state, action) => {
+      state.showTooltips = action.payload;
+    },
   },
 });
 
@@ -70,7 +75,8 @@ export const {
   setShowClearButton,
   setShowSharedLink,
   setMapPreview,
-  clearMapPreview
+  clearMapPreview,
+  setShowTooltips
 } = uiSlice.actions;
 
 export default uiSlice.reducer;


### PR DESCRIPTION
This PR provides a potential solution for #513, but there’s no need to merge it before the soft launch. We can discuss the approach and explore if there’s a better way to handle it later.

To ensure users can read the data details after performing a search (#513), I’ve added a checkbox to toggle the result preview display. By default, it automatically turns on when the map view is shown and off when the data view is displayed. However, users still have the flexibility to enable or disable it as needed.

## How to Test
1. Navigate to the search page and conduct a search. The "Result Preview" checkbox will appear at the top of the result list, checked by default. Hover over a result item to see the result preview tooltip:
<img width="1525" alt="Screenshot 2025-03-13 at 7 00 50 PM" src="https://github.com/user-attachments/assets/f054aec3-aac5-47a6-9706-6ebcbff21c70" />

2. Now click on any item to display the data view. The result preview will automatically turn off. Hovering over a result item will no longer show the result preview:
<img width="1671" alt="Screenshot 2025-03-13 at 7 01 47 PM" src="https://github.com/user-attachments/assets/22410b7b-3c0f-4901-80c7-04bd253a0014" />

3. You can switch back to map view or manually check the "Result Preview" checkbox. The result preview tooltip will reappear when hovering over a result item.

Note: The "Result Preview" checkbox will not be available when no search has been performed, as there’s no keyword-based data to display.

@Makosak please feel free to test and let us know your thoughts.