### PR TITLE
#517: Update ai-search help text to explain current limitation

### DIFF
--- a/src/components/search/searchArea/helpText/aiSearchText.tsx
+++ b/src/components/search/searchArea/helpText/aiSearchText.tsx
@@ -106,15 +106,10 @@ export const AiSearchText = () => {
             fontSize: "0.8em",
           }}
         >
-          When you include location terms in your questions (like Chicago), our
-          AI will find location-relevant results, but this isn&apos;t yet
-          connected to the map display and the filter panel. The AI translates
-          locations into geographic boundaries for searching, though these
-          filters aren&apos;t visible in the map interface.{" "}
-          <b>
-            We&apos;re working to fully integrate these features in our next
-            update.
-          </b>
+          While AI results will translate location names like &quot;Chicago&quot;
+          into a geographic filter, this filter will not be visually depicted in
+          the map interface and the filter panel. We&apos;re working toward
+          better integration in our next update.
         </Typography>
       </div>
     </>

--- a/src/components/search/searchArea/helpText/aiSearchText.tsx
+++ b/src/components/search/searchArea/helpText/aiSearchText.tsx
@@ -11,7 +11,8 @@ export const AiSearchText = () => {
         className="pb-1"
         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
       >
-       Try our AI-powered search that helps you find data by simply asking a question.
+        Try our AI-powered search that helps you find data by simply asking a
+        question.
       </Typography>
 
       <div className="my-3 p-3 bg-gray-50 rounded-lg">
@@ -48,14 +49,14 @@ export const AiSearchText = () => {
               AI Search:
             </Typography>
             <div className="italic text-sm mb-2">
-              You ask: &quot;What could cause housing instability and poor
-              health outcomes?&quot;
+              You ask: &quot;What health outcomes are linked to housing
+              instability in Chicago?&quot;
             </div>
             <div className="text-sm">
               Understands your question and finds information about
-              &quot;housing&quot;, &quot;economic stability&quot;, and
-              &quot;health outcomes&quot; within the Social Determinants of
-              Health context to help you answer your question.
+              &quot;housing&quot;, &quot;health outcomes&quot;, and location
+              references within the Social Determinants of Health context to
+              help you answer your question with answers filtered by location.
             </div>
           </div>
         </div>
@@ -75,8 +76,8 @@ export const AiSearchText = () => {
         className="pb-1"
         sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}
       >
-        Don&apos;t want to use AI? Our keyword search mode is
-        always available and does not send any queries to AI systems.
+        Don&apos;t want to use AI? Our keyword search mode is always available
+        and does not send any queries to AI systems.
       </Typography>
 
       <Typography
@@ -86,6 +87,36 @@ export const AiSearchText = () => {
         We would love to hear your thoughts on this feature. Please{" "}
         <Link href="/contact">get in touch</Link>.
       </Typography>
+
+      <div className="my-3 mx-3 p-2 bg-yellow-50 rounded-lg border border-yellow-200">
+        <Typography
+          className="mb-2"
+          sx={{
+            fontFamily: fullConfig.theme.fontFamily["sans"],
+            fontSize: "0.8em",
+            fontWeight: "bold",
+          }}
+        >
+          Note About Location Search:
+        </Typography>
+        <Typography
+          className="pb-1"
+          sx={{
+            fontFamily: fullConfig.theme.fontFamily["sans"],
+            fontSize: "0.8em",
+          }}
+        >
+          When you include location terms in your questions (like Chicago), our
+          AI will find location-relevant results, but this isn&apos;t yet
+          connected to the map display and the filter panel. The AI translates
+          locations into geographic boundaries for searching, though these
+          filters aren&apos;t visible in the map interface.{" "}
+          <b>
+            We&apos;re working to fully integrate these features in our next
+            update.
+          </b>
+        </Typography>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
This PR addresses issue #517. It clarifies that AI-Search results are filtered by location when specified in the user's query. However, this filtering is not yet visually reflected on the map or filter panel, which may confuse some users when they see filtered results without corresponding map updates.

## How to Test
1. Navigate to the search page and open the help panel for AI-Search.
2. An additional explanation should now appear at the end of the help text:
<img width="745" alt="Screenshot 2025-03-14 at 11 41 01 AM" src="https://github.com/user-attachments/assets/3dcf107a-392e-4f07-9cdf-6b9ff69ce1ff" />



