### PR TITLE
#525: Add filter status to Pausible payload to check for no result search

### DIFF
--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -70,7 +70,13 @@ const ResultsPanel = (props: Props): JSX.Element => {
     if (isResetting) return previousCount;
     if (isLoading) return previousCount;
     return searchState.results.length + uniqueRelatedList.length;
-  }, [isLoading, isResetting, previousCount, searchState.results.length, uniqueRelatedList.length]);
+  }, [
+    isLoading,
+    isResetting,
+    previousCount,
+    searchState.results.length,
+    uniqueRelatedList.length,
+  ]);
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const hasSearchParams = params.has("query") || params.has("ai_search");
@@ -189,6 +195,13 @@ const ResultsPanel = (props: Props): JSX.Element => {
                           {plausible(EventType.ReceivedNoSearchResults, {
                             props: {
                               searchQuery: searchState.query,
+                              searchFilter: filterStatus.activeFilters,
+                              fullSearchStates:
+                                searchState.query +
+                                " || " +
+                                Object.entries(filterStatus.activeFilters)
+                                  .map(([key, value]) => `${key}: ${value}`)
+                                  .join(" || "),
                             },
                           })}
                         </Box>


### PR DESCRIPTION
This PR addresses issue #525 by adding filterStatus props to the payload passed to Pausible in the 'No Result' view.

As discussed in the ticket, most occurrences of "No Search Results" happen when multiple filters are applied, since the recommendation mechanism attempts to prevent 'No Result' views for single searches.

To enhance visibility into filter usage, this PR introduces two new props:

1. One represents filters as an array.
2. The other provides a more comprehensive string format.

Since it's unclear which format will perform better, both can be included initially. Once Pausible starts receiving results, we can remove any unnecessary props. With this change, we will be able to see the applied filters and their values when a user encounters a 'No Result' view.