### PR TITLE
#479 feat: added a dedicated page to list SDOH Guides

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ import Footer from "./homepage/footer";
 import React from "react";
 import PostLayout, { PostLayoutProps } from "./news/PostLayout";
 import ShowcaseLayout, { ShowcaseLayoutProps } from "./showcase/ShowcaseLayout";
-import GuideLayout, { GuideLayoutProps } from "./guides/GuideLayout";
+import GuidesLayout, { GuideLayoutProps } from "./guides/GuidesLayout";
 
 type Props = {
   type?: "news" | "showcase" | "guide";
@@ -57,9 +57,9 @@ export default function Layout({
                 </ShowcaseLayout>
               )}
               {type === "guide" && (
-                <GuideLayout {...guide_props}>
+                <GuidesLayout {...guide_props}>
                   {guide_props.children}
-                </GuideLayout>
+                </GuidesLayout>
               )}
             </div>
           </div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -124,7 +124,7 @@ const NavBar = (): JSX.Element => {
   const resourcesItems = [
     { title: "Data Discovery", url: "/search" },
     { title: "Community Toolkit", url: "https://toolkit.sdohplace.org", target: '_blank' },
-    //{ title: "SDOH Guides", url: "/guides" },
+    { title: "SDOH Guides", url: "/guides" },
   ];
 
   const communityItems = [

--- a/src/components/guides/GuidesItem.tsx
+++ b/src/components/guides/GuidesItem.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 export default function GuidesItem({ item }: Props) {
   return (
-    <Link href={"/showcase/" + item.slug} legacyBehavior>
+    <Link href={"/guides/" + item.slug} legacyBehavior>
       <a className={"no-underline"}>
         <div style={{ display: "flex" }}>
           <div>

--- a/src/components/guides/GuidesItem.tsx
+++ b/src/components/guides/GuidesItem.tsx
@@ -1,0 +1,36 @@
+import { GuidesContent } from "@/lib/guides";
+import Image from "next/image";
+import Link from "next/link";
+
+type Props = {
+  item: GuidesContent;
+};
+export default function GuidesItem({ item }: Props) {
+  return (
+    <Link href={"/showcase/" + item.slug} legacyBehavior>
+      <a className={"no-underline"}>
+        <div style={{ display: "flex" }}>
+          <div>
+            <Image src={item.featured_image} alt={item.title} width={200} height={25} />
+          </div>
+          <div style={{ paddingLeft: "2rem" }}>
+            <h2>{item.title}</h2>
+            <p>{item.author}</p>
+          </div>
+        </div>
+        <style jsx>
+          {`
+            a {
+              color: #222;
+              display: inline-block;
+            }
+            h2 {
+              margin: 0;
+              font-size: 2rem;
+            }
+          `}
+        </style>
+      </a>
+    </Link>
+  );
+}

--- a/src/components/guides/GuidesLayout.tsx
+++ b/src/components/guides/GuidesLayout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "@/public/styles/posts.module.css";
 import Author from "../news/Author";
 import Copyright from "../news/Copyright";
-import Date from "../news//Date";
+import DateComponent from "../news//Date";
 
 export type GuideLayoutProps = {
   title: string;
@@ -13,7 +13,7 @@ export type GuideLayoutProps = {
   body: any;
   children: React.ReactNode;
 };
-export default function GuideLayout({
+export default function GuidesLayout({
   title,
   last_updated,
   slug,
@@ -40,7 +40,7 @@ export default function GuideLayout({
             <h1 className={"guide-header"}>{title}</h1>
             <div className={"metadata"}>
               <div>
-                <Date date={last_updated} />
+                <DateComponent date={last_updated} />
               </div>
               <div>
                 <Author author={authorObject} />

--- a/src/components/guides/GuidesList.tsx
+++ b/src/components/guides/GuidesList.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { GuidesContent } from "../../lib/guides";
+import GuidesItem from "./GuidesItem";
+import Pagination from "../news/Pagination";
+
+type Props = {
+  posts: GuidesContent[];
+  pagination: {
+    current: number;
+    pages: number;
+  };
+};
+export default function GuidesList({ guides, pagination }: Props) {
+  return (
+    <>
+      <div className={"post-list"}>
+        <ul className={""}>
+          {guides.map((it, i) => (
+            <li key={i}>
+              <GuidesItem item={it} />
+            </li>
+          ))}
+        </ul>
+        {/* <Pagination
+          current={pagination.current}
+          pages={pagination.pages}
+          link={{
+            href: (page) => (page === 1 ? "/news" : "/news/page/[page]"),
+            as: (page) => (page === 1 ? null : "/news/page/" + page),
+          }}
+        /> */}
+      </div>
+    </>
+  );
+}

--- a/src/components/guides/GuidesList.tsx
+++ b/src/components/guides/GuidesList.tsx
@@ -4,7 +4,7 @@ import GuidesItem from "./GuidesItem";
 import Pagination from "../news/Pagination";
 
 type Props = {
-  posts: GuidesContent[];
+  guides: GuidesContent[];
   pagination: {
     current: number;
     pages: number;

--- a/src/components/showcase/ShowcaseItem.tsx
+++ b/src/components/showcase/ShowcaseItem.tsx
@@ -10,7 +10,7 @@ export default function ShowcaseItem({ item }: Props) {
     <Link href={"/showcase/" + item.slug} legacyBehavior>
       <a className={"no-underline"}>
         <div style={{ display: "flex" }}>
-          <div>
+          <div style={{minWidth:'200px'}}>
             <Image src={item.image} alt={item.title} width={200} height={25} />
           </div>
           <div style={{ paddingLeft: "2rem" }}>

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -5,20 +5,21 @@ import yaml from "js-yaml";
 
 const guidesDirectory = path.join(process.cwd(), "content/guides");
 
-export type GuideContent = {
+export type GuidesContent = {
   readonly last_updated: string;
   readonly title: string;
   readonly slug: string;
   readonly featured_image: string;
+  readonly author: string;
   //readonly body: string;
   readonly fullPath: string;
 };
 
-let guideCache: GuideContent[];
+let guidesCache: GuidesContent[];
 
-export function fetchGuideContent(): GuideContent[] {
-  if (guideCache) {
-    return guideCache;
+export function fetchGuidesContent(): GuidesContent[] {
+  if (guidesCache) {
+    return guidesCache;
   }
   // Get file names under /posts
   const fileNames = fs.readdirSync(guidesDirectory);
@@ -39,6 +40,7 @@ export function fetchGuideContent(): GuideContent[] {
         last_updated: string;
         title: string;
         featured_image: string;
+        author: string;
         slug: string;
         fullPath: string;
       };
@@ -48,24 +50,24 @@ export function fetchGuideContent(): GuideContent[] {
       return matterData;
     });
   // Sort posts by date
-  guideCache = allGuidesData.sort((a, b) => {
+  guidesCache = allGuidesData.sort((a, b) => {
     if (a.last_updated < b.last_updated) {
       return 1;
     } else {
       return -1;
     }
   });
-  return guideCache;
+  return guidesCache;
 }
 
 export function countGuides(): number {
-  return fetchGuideContent().length;
+  return fetchGuidesContent().length;
 }
 
-export function listGuideContent(
+export function listGuidesContent(
   page: number,
   limit: number
-): GuideContent[] {
-  return fetchGuideContent()
+): GuidesContent[] {
+  return fetchGuidesContent()
     .slice((page - 1) * limit, page * limit);
 }

--- a/src/pages/guides/[guide].tsx
+++ b/src/pages/guides/[guide].tsx
@@ -3,10 +3,9 @@ import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import remarkGfm from "remark-gfm";
 import matter from "gray-matter";
-import { fetchGuideContent } from "../../lib/guides";
+import { fetchGuidesContent } from "@/lib/guides";
 import fs from "fs";
 import yaml from "js-yaml";
-import { parseISO } from "date-fns";
 
 import InstagramEmbed from "react-instagram-embed";
 import YouTube from "react-youtube";
@@ -32,7 +31,7 @@ const slugToGuideContent = ((guideContents) => {
   const hash = {};
   guideContents.forEach((it) => (hash[it.slug] = it));
   return hash;
-})(fetchGuideContent());
+})(fetchGuidesContent());
 
 export default function Guide({
   title,
@@ -60,7 +59,7 @@ export default function Guide({
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = fetchGuideContent().map((it) => "/guides/" + it.slug);
+  const paths = fetchGuidesContent().map((it) => "/guides/" + it.slug);
   return {
     paths,
     fallback: false,

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -13,7 +13,7 @@ import {
 import { listTags, TagContent } from "@/lib/tags";
 
 type Props = {
-  posts: GuidesContent[];
+  guides: GuidesContent[];
   tags: TagContent[];
   pagination: {
     current: number;

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -1,0 +1,50 @@
+import { GetStaticProps } from "next";
+import Layout from "@/components/Layout";
+import Header from "@/components/meta/Header";
+import OpenGraphMeta from "@/components/meta/OpenGraphMeta";
+import TwitterCardMeta from "@/components/meta/TwitterCardMeta";
+import GuidesList from "@/components/guides/GuidesList";
+import config from "@/lib/config";
+import {
+  countGuides,
+  listGuidesContent,
+  GuidesContent
+} from "@/lib/guides";
+import { listTags, TagContent } from "@/lib/tags";
+
+type Props = {
+  posts: GuidesContent[];
+  tags: TagContent[];
+  pagination: {
+    current: number;
+    pages: number;
+  };
+};
+export default function Index({ guides, tags, pagination }: Props) {
+  const url = "/guides";
+  const title = "SDOH Guides";
+  return (
+    <Layout page_header={"SDOH Guides"}>
+      <Header url={url} title={title} />
+      <OpenGraphMeta url={url} title={title} />
+      <TwitterCardMeta url={url} title={title} />
+      <GuidesList guides={guides} pagination={pagination} />
+    </Layout>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const guides = listGuidesContent( 1, config.posts_per_page);
+  const tags = listTags();
+  const pagination = {
+    current: 1,
+    pages: Math.ceil(countGuides() / config.posts_per_page),
+  };
+  return {
+    props: {
+      guides,
+      tags,
+      pagination,
+    },
+  };
+};

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -31,7 +31,7 @@ export default function Index({ guides, tags, pagination }: Props) {
             <div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
                 <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
                     <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
-                        <div className="text-stone-900 text-xl max-md:max-w-full max-md:mt-10 mb-8">
+                        <div className="text-stone-900 text-xl max-md:max-w-full max-md:mt-10 mb-16">
                             <p>
                             While there exists a long and complex history studying the role of place, social context, and the built environment within health, current and common frameworks of the “social determinants of health” (SDOH) tend to be simplistic in application. The SDOH & Place Project works to build a community of practice around the definition & use of community-level SDOH data. To support these efforts, our SDOH Research Guides help focus and refine best practices and approaches in measuring distinct SDOH indicators or structural drivers of health at community or regional scales.
                             </p>

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -1,8 +1,7 @@
 import { GetStaticProps } from "next";
-import Layout from "@/components/Layout";
 import Header from "@/components/meta/Header";
-import OpenGraphMeta from "@/components/meta/OpenGraphMeta";
-import TwitterCardMeta from "@/components/meta/TwitterCardMeta";
+import NavBar from "@/components/NavBar";
+import TopLines from "@/components/TopLines";
 import GuidesList from "@/components/guides/GuidesList";
 import config from "@/lib/config";
 import {
@@ -11,7 +10,6 @@ import {
   GuidesContent
 } from "@/lib/guides";
 import { listTags, TagContent } from "@/lib/tags";
-import {Grid} from "@mui/material";
 
 type Props = {
   guides: GuidesContent[];
@@ -22,38 +20,33 @@ type Props = {
   };
 };
 export default function Index({ guides, tags, pagination }: Props) {
-  const url = "/guides";
-  const title = "SDOH Guides";
   return (
-    <Layout page_header={"SDOH Guides"}>
-      <Grid container spacing={8}>
-        <Grid item xs={4}>
-          <Header url={url} title={title} />
-
-          {/*
-          <OpenGraphMeta url={url} title={title} />
-          <TwitterCardMeta url={url} title={title} />
-          */}
-          <p>
-          While there exists a long and complex history studying
-          the role of place, social context, and the built environment within health,
-          current and common frameworks of the “social determinants of health” (SDoH)
-          tend to be simplistic in application. The SDOH & Place Project works to build
-          a community of practice around defining & using community-level social
-          determinants of health. To support these efforts, SDOH Research Guides help
-          focus and refine best practices and approaches in measuring distinct SDOH
-          indicators or structural drivers of health at community or regional scales.
-          </p><br />
-          <p>
-          The SDOH Guides are written by new and emerging scholars across the fields of SDOH research (ex. geography, social science, public health). Each guide takes a view on some SDOH topic, breaking down the jargon to clarify understanding and provide direct recommendations. The SDOH Guides will continue to be updated and changed, according to research directions that unfold.
-          </p>
-        </Grid>
-
-        <Grid item xs={12}>
-          <GuidesList guides={guides} pagination={pagination} />
-        </Grid>
-      </Grid>
-    </Layout>
+    <>
+    <Header url="/guides" title="SDOH Guides" />
+    <NavBar />
+    <TopLines />
+    <div className="flex flex-col pt-12">
+        <div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
+            <h1 className="font-fredoka">SDOH Guides</h1>
+            <div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
+                <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
+                    <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
+                        <div className="text-stone-900 text-xl max-md:max-w-full max-md:mt-10 mb-8">
+                            <p>
+                            While there exists a long and complex history studying the role of place, social context, and the built environment within health, current and common frameworks of the “social determinants of health” (SDoH) tend to be simplistic in application. The SDOH & Place Project works to build a community of practice around defining & using community-level social determinants of health. To support these efforts, SDOH Research Guides help focus and refine best practices and approaches in measuring distinct SDOH indicators or structural drivers of health at community or regional scales.
+                            </p>
+                            <br />
+                            <p>
+                            The SDOH Guides are written by new and emerging scholars across the fields of SDOH research (ex. geography, social science, public health). Each guide takes a view on some SDOH topic, breaking down the jargon to clarify understanding and provide direct recommendations. The SDOH Guides will continue to be updated and changed, according to research directions that unfold.
+                            </p>
+                        </div>
+                        <GuidesList guides={guides} pagination={pagination} />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    </>
   );
 }
 

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -22,12 +22,12 @@ type Props = {
 export default function Index({ guides, tags, pagination }: Props) {
   return (
     <>
-    <Header url="/guides" title="SDOH Research Guides" />
+    <Header url="/guides" title="SDOH Guides" />
     <NavBar />
     <TopLines />
     <div className="flex flex-col pt-12">
         <div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
-            <h1 className="font-fredoka">SDOH Research Guides</h1>
+            <h1 className="font-fredoka">SDOH Guides</h1>
             <div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
                 <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
                     <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -11,6 +11,7 @@ import {
   GuidesContent
 } from "@/lib/guides";
 import { listTags, TagContent } from "@/lib/tags";
+import {Grid} from "@mui/material";
 
 type Props = {
   guides: GuidesContent[];
@@ -25,10 +26,30 @@ export default function Index({ guides, tags, pagination }: Props) {
   const title = "SDOH Guides";
   return (
     <Layout page_header={"SDOH Guides"}>
-      <Header url={url} title={title} />
-      <OpenGraphMeta url={url} title={title} />
-      <TwitterCardMeta url={url} title={title} />
-      <GuidesList guides={guides} pagination={pagination} />
+      <Grid container spacing={8}>
+        <Grid item xs={4}>
+          <Header url={url} title={title} />
+
+          {/*
+          <OpenGraphMeta url={url} title={title} />
+          <TwitterCardMeta url={url} title={title} />
+          */}
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Proin et erat pellentesque augue consequat
+            tincidunt vulputate ut metus. In mollis, dolor a
+            molestie gravida, diam nunc tincidunt quam, id
+            faucibus magna nisi sollicitudin velit. Sed mollis bibendum ullamcorper. Proin placerat
+            dolor sed sagittis maximus. Pellentesque habitant
+            morbi tristique senectus et netus et malesuada
+            fames ac turpis egestas.
+          </p>
+        </Grid>
+
+        <Grid item xs={12}>
+          <GuidesList guides={guides} pagination={pagination} />
+        </Grid>
+      </Grid>
     </Layout>
   );
 }

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -22,22 +22,22 @@ type Props = {
 export default function Index({ guides, tags, pagination }: Props) {
   return (
     <>
-    <Header url="/guides" title="SDOH Guides" />
+    <Header url="/guides" title="SDOH Research Guides" />
     <NavBar />
     <TopLines />
     <div className="flex flex-col pt-12">
         <div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
-            <h1 className="font-fredoka">SDOH Guides</h1>
+            <h1 className="font-fredoka">SDOH Research Guides</h1>
             <div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
                 <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
                     <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
                         <div className="text-stone-900 text-xl max-md:max-w-full max-md:mt-10 mb-8">
                             <p>
-                            While there exists a long and complex history studying the role of place, social context, and the built environment within health, current and common frameworks of the “social determinants of health” (SDoH) tend to be simplistic in application. The SDOH & Place Project works to build a community of practice around defining & using community-level social determinants of health. To support these efforts, SDOH Research Guides help focus and refine best practices and approaches in measuring distinct SDOH indicators or structural drivers of health at community or regional scales.
+                            While there exists a long and complex history studying the role of place, social context, and the built environment within health, current and common frameworks of the “social determinants of health” (SDOH) tend to be simplistic in application. The SDOH & Place Project works to build a community of practice around the definition & use of community-level SDOH data. To support these efforts, our SDOH Research Guides help focus and refine best practices and approaches in measuring distinct SDOH indicators or structural drivers of health at community or regional scales.
                             </p>
                             <br />
                             <p>
-                            The SDOH Guides are written by new and emerging scholars across the fields of SDOH research (ex. geography, social science, public health). Each guide takes a view on some SDOH topic, breaking down the jargon to clarify understanding and provide direct recommendations. The SDOH Guides will continue to be updated and changed, according to research directions that unfold.
+                            The guides are written by new and emerging scholars across the fields of SDOH research, including geography, social science, public health. Each one takes a view on some SDOH topic, breaking down the jargon to clarify understanding and provide direct recommendations. The research guides will continue to be updated according to research directions that unfold.
                             </p>
                         </div>
                         <GuidesList guides={guides} pagination={pagination} />

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -33,7 +33,7 @@ export default function Index({ guides, tags, pagination }: Props) {
                     <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
                         <div className="text-stone-900 text-xl max-md:max-w-full max-md:mt-10 mb-16">
                             <p>
-                            While there exists a long and complex history studying the role of place, social context, and the built environment within health, current and common frameworks of the “social determinants of health” (SDOH) tend to be simplistic in application. The SDOH & Place Project works to build a community of practice around the definition & use of community-level SDOH data. To support these efforts, our SDOH Research Guides help focus and refine best practices and approaches in measuring distinct SDOH indicators or structural drivers of health at community or regional scales.
+                            While there exists a long and complex history studying the role of place, social context, and the built environment within health, current and common frameworks of the “social determinants of health” (SDOH) tend to be simplistic in application. The SDOH & Place Project works to build a community of practice around the definition & use of community-level SDOH data. To support these efforts, our SDOH Guides help focus and refine best practices and approaches in measuring distinct SDOH indicators or structural drivers of health at community or regional scales.
                             </p>
                             <br />
                             <p>

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -35,14 +35,17 @@ export default function Index({ guides, tags, pagination }: Props) {
           <TwitterCardMeta url={url} title={title} />
           */}
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing
-            elit. Proin et erat pellentesque augue consequat
-            tincidunt vulputate ut metus. In mollis, dolor a
-            molestie gravida, diam nunc tincidunt quam, id
-            faucibus magna nisi sollicitudin velit. Sed mollis bibendum ullamcorper. Proin placerat
-            dolor sed sagittis maximus. Pellentesque habitant
-            morbi tristique senectus et netus et malesuada
-            fames ac turpis egestas.
+          While there exists a long and complex history studying
+          the role of place, social context, and the built environment within health,
+          current and common frameworks of the “social determinants of health” (SDoH)
+          tend to be simplistic in application. The SDOH & Place Project works to build
+          a community of practice around defining & using community-level social
+          determinants of health. To support these efforts, SDOH Research Guides help
+          focus and refine best practices and approaches in measuring distinct SDOH
+          indicators or structural drivers of health at community or regional scales.
+          </p><br />
+          <p>
+          The SDOH Guides are written by new and emerging scholars across the fields of SDOH research (ex. geography, social science, public health). Each guide takes a view on some SDOH topic, breaking down the jargon to clarify understanding and provide direct recommendations. The SDOH Guides will continue to be updated and changed, according to research directions that unfold.
           </p>
         </Grid>
 

--- a/src/pages/showcase/index.tsx
+++ b/src/pages/showcase/index.tsx
@@ -1,6 +1,8 @@
 import { GetStaticProps } from "next";
 import Layout from "@/components/Layout";
 import Header from "@/components/meta/Header";
+import NavBar from "@/components/NavBar";
+import TopLines from "@/components/TopLines";
 import OpenGraphMeta from "@/components/meta/OpenGraphMeta";
 import TwitterCardMeta from "@/components/meta/TwitterCardMeta";
 import ShowcaseList from "@/components/showcase/ShowcaseList";
@@ -21,15 +23,25 @@ type Props = {
   };
 };
 export default function Index({ posts, tags, pagination }: Props) {
-  const url = "/showcase";
-  const title = "Showcase";
   return (
-    <Layout page_header={"Fellows Showcase"}>
-      <Header url={url} title={title} />
-      <OpenGraphMeta url={url} title={title} />
-      <TwitterCardMeta url={url} title={title} />
-      <ShowcaseList posts={posts} pagination={pagination} />
-    </Layout>
+    <>
+        <Header url="/showcase" title="Showcase" />
+        <NavBar />
+        <TopLines />
+        <div className="flex flex-col pt-12">
+            <div className="self-center flex w-full max-w-[1068px] flex-col px-5 max-md:max-w-full mt-[100px]">
+                <h1 className="font-fredoka">Fellows Showcase</h1>
+                <div className="self-center w-full mt-10 max-md:max-w-full max-md:mt-10">
+                    <div className="gap-5 flex max-md:flex-col max-md:items-stretch max-md:gap-0">
+                        <div className="flex flex-col items-stretch w-[92%] max-md:w-full max-md:ml-0">
+                            <div className="text-stone-900 text-xl max-md:max-w-full max-md:mt-10 mb-8"></div>
+                            <ShowcaseList posts={posts} pagination={pagination} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Problem
While they are listed on the homepage, we don't currently offer a page where we list our SDOH Guides (similar to the News and Showcase sections)

Fixes #479 

## Approach
* feat: added the `/guides` page that lists all SDOH Guides within DecapCMS
* fix: uncommented Resources > SDOH Guides in the NavBar
* TODO: need to determine what text to use for intro paragraph

![Screenshot 2025-04-18 at 5 13 42 PM](https://github.com/user-attachments/assets/b08369ab-3265-47b7-9600-854ef0e1e168)

## How to Test
1. Navigate to https://deploy-preview-539--cheerful-treacle-913a24.netlify.app/guides
    * You should see a page here that lists all existing Guides in the system
2. Click on a Guide (e.g. Public Transit Equity)
    * You should be brought to the Guide that you clicked
    * You should see the Guide contents rendered from markdown