### PR TITLE
#549, #542, #546: Fix the related term bug and update search box autocomplete behavior

### DIFF
--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -41,6 +41,7 @@ const IconTag = (props: Props): JSX.Element => {
       newSubjects = [...currentSubjects, sub];
     }
     if (props.themeOnly) {
+      dispatch(setQuery("*"));
       dispatch(batchResetFilters({
         schema: schema,
         query: "*",
@@ -50,7 +51,6 @@ const IconTag = (props: Props): JSX.Element => {
     } else {
       dispatch(setSubject(newSubjects));
     }
-    
     plausible(EventType.ChangedThemeFilter, {
       props: {
         themes: newSubjects.join(", "),

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -4,12 +4,13 @@ import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";
 import { AppDispatch, RootState } from "@/store";
 import { useDispatch, useSelector } from "react-redux";
-import { setSubject } from "@/store/slices/searchSlice";
+import { batchResetFilters, setQuery, setSubject } from "@/store/slices/searchSlice";
 import {clearMapPreview} from "@/store/slices/uiSlice";
 import {EventType} from "@/lib/event";
 import {usePlausible} from "next-plausible";
 
 interface Props {
+  themeOnly?: boolean;
   svgIcon: any;
   label: string;
   variant?: string;
@@ -31,7 +32,7 @@ const IconTag = (props: Props): JSX.Element => {
   const classes = useStyles();
   const dispatch = useDispatch<AppDispatch>();
   const plausible = usePlausible();
-  const { subject } = useSelector((state: RootState) => state.search);
+  const { subject, schema } = useSelector((state: RootState) => state.search);
   const handleSubjectClick = (sub: string) => {
     let currentSubjects = subject || [];
     let newSubjects: string[];
@@ -40,8 +41,17 @@ const IconTag = (props: Props): JSX.Element => {
     } else {
       newSubjects = [...currentSubjects, sub];
     }
-    dispatch(clearMapPreview());
-    dispatch(setSubject(newSubjects));
+    if (props.themeOnly) {
+      dispatch(batchResetFilters({
+        schema: schema,
+        query: "*",
+        preserveSubject: true,
+        subject: newSubjects
+      }));
+    } else {
+      dispatch(setSubject(newSubjects));
+    }
+    
     plausible(EventType.ChangedThemeFilter, {
       props: {
         themes: newSubjects.join(", "),

--- a/src/components/search/detailPanel/iconTag.tsx
+++ b/src/components/search/detailPanel/iconTag.tsx
@@ -5,7 +5,6 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import { AppDispatch, RootState } from "@/store";
 import { useDispatch, useSelector } from "react-redux";
 import { batchResetFilters, setQuery, setSubject } from "@/store/slices/searchSlice";
-import {clearMapPreview} from "@/store/slices/uiSlice";
 import {EventType} from "@/lib/event";
 import {usePlausible} from "next-plausible";
 

--- a/src/components/search/discoveryArea.tsx
+++ b/src/components/search/discoveryArea.tsx
@@ -50,11 +50,6 @@ export default function DiscoveryArea({ schema }): JSX.Element {
     setIsMounted(true);
   }, []);
 
-  useEffect(() => {
-    if (isMounted) {
-      dispatch(setSchema(schema));
-    }
-  }, [schema, dispatch, isMounted]);
   if (!isMounted) {
     return (
       <Grid container>

--- a/src/components/search/helper/SolrQueryBuilder.tsx
+++ b/src/components/search/helper/SolrQueryBuilder.tsx
@@ -44,7 +44,8 @@ export default class SolrQueryBuilder {
   }
 
   public fetchResult(
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    skipCache: boolean = false
   ): Promise<{ results: SolrObject[]; spellCheckSuggestion?: string }> {
     return new Promise((resolve, reject) => {
       const currentUrl = this.query.query;
@@ -68,7 +69,7 @@ export default class SolrQueryBuilder {
         return;
       }
       
-      if (requestCache.has(currentUrl)) {
+      if (!skipCache && requestCache.has(currentUrl)) {
         const cachedData = requestCache.get(currentUrl);
         const now = Date.now();
         // if there is a cached response and it is still within the cache TTL (2 seconds), use the cached response, otherwise remove the cached response

--- a/src/components/search/helper/SolrQueryBuilder.tsx
+++ b/src/components/search/helper/SolrQueryBuilder.tsx
@@ -5,6 +5,9 @@ import SRMatch from "../../search/helper/SpatialResolutionMatch.json";
 import { adaptiveScoreFilter, scoreConfig } from "./FilterByScore";
 import { parseSolrQuery } from "./ParsingMethods";
 
+const requestCache = new Map();
+const REQUEST_CACHE_TTL = 2000; // caching to resolve request duplicates
+
 export default class SolrQueryBuilder {
   private query: QueryObject = {
     solrUrl: process.env.NEXT_PUBLIC_SOLR_URL || "",
@@ -64,6 +67,19 @@ export default class SolrQueryBuilder {
         reject(new Error(`Invalid URL: ${currentUrl}`));
         return;
       }
+      
+      if (requestCache.has(currentUrl)) {
+        const cachedData = requestCache.get(currentUrl);
+        const now = Date.now();
+        // if there is a cached response and it is still within the cache TTL (2 seconds), use the cached response, otherwise remove the cached response
+        if (now - cachedData.timestamp < REQUEST_CACHE_TTL) {
+          resolve(JSON.parse(JSON.stringify(cachedData.data)));
+          return;
+        } else {
+          requestCache.delete(currentUrl);
+        }
+      }
+      // if there is no cached response, fetch the data from the server
       fetch(currentUrl, {
         method: "GET",
         headers: {
@@ -81,23 +97,37 @@ export default class SolrQueryBuilder {
         .then((text) => {
           try {
             const jsonResponse = JSON.parse(text);
-            const result = this.getSearchResult(jsonResponse);
             if (jsonResponse && jsonResponse["suggest"]) {
+              requestCache.set(currentUrl, {
+                data: jsonResponse,
+                timestamp: Date.now()
+              });
               resolve(jsonResponse);
               return;
             }
+            const result = this.getSearchResult(jsonResponse);
             if (!result || result.length === 0) {
               const spellcheck =
                 jsonResponse["spellcheck"]?.suggestions[1]?.suggestion;
               if (spellcheck) {
-                resolve({
+                const responseData = {
                   results: result,
                   spellCheckSuggestion: spellcheck[0],
+                };
+                requestCache.set(currentUrl, {
+                  data: responseData,
+                  timestamp: Date.now()
                 });
+                resolve(responseData);
                 return;
               }
             }
-            resolve({ results: result });
+            const responseData = { results: result };
+            requestCache.set(currentUrl, {
+              data: responseData,
+              timestamp: Date.now()
+            });
+            resolve(responseData);
           } catch (error) {
             console.error("Response parsing error:", error);
             if (text.startsWith("<!DOCTYPE") || text.startsWith("<html")) {

--- a/src/components/search/helper/themeIcons.tsx
+++ b/src/components/search/helper/themeIcons.tsx
@@ -6,6 +6,7 @@ import resolveConfig from "tailwindcss/resolveConfig";
 
 interface Props {
   variant?: string;
+  themeOnly?: boolean;
 }
 const fullConfig = resolveConfig(tailwindConfig);
 const useStyles = makeStyles((theme) => ({
@@ -34,6 +35,7 @@ const ThemeIcons = (props: Props): JSX.Element => {
     <>
       {iconData.map((label) => (
         <IconTag
+          themeOnly={props.themeOnly}
           key={label}
           svgIcon={IconMatch(label)}
           label={label}

--- a/src/components/search/resultsPanel/index.tsx
+++ b/src/components/search/resultsPanel/index.tsx
@@ -101,6 +101,15 @@ const ResultsPanel = (props: Props): JSX.Element => {
     searchState.results.length,
     uniqueRelatedList.length,
   ]);
+  const [hasCompletedSearch, setHasCompletedSearch] = React.useState(false);
+  
+  React.useEffect(() => {
+    if (isLoading) {
+      setHasCompletedSearch(false);
+    } else if (!isInitialLoad) {
+      setHasCompletedSearch(true);
+    }
+  }, [isLoading, isInitialLoad]);
 
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -155,6 +164,10 @@ const ResultsPanel = (props: Props): JSX.Element => {
     );
   };
 
+  const shouldShowResultsCount = React.useMemo(() => {
+    return !isLoading && !isResetting && hasCompletedSearch && displayCount > 0;
+  }, [isLoading, isResetting, hasCompletedSearch, displayCount]);
+
   return (
     <div
       className="results-panel"
@@ -166,7 +179,7 @@ const ResultsPanel = (props: Props): JSX.Element => {
             <div className="flex flex-col sm:flex-row flex-grow text-2xl">
               <Fade in={!isResetting} timeout={300}>
                 <div>
-                  {displayCount > 0 && (
+                  {shouldShowResultsCount && (
                     <Box>
                       {isQuery
                         ? `Results (${displayCount})`

--- a/src/middleware/createMiddleware.ts
+++ b/src/middleware/createMiddleware.ts
@@ -12,63 +12,51 @@ const isClient = typeof window !== "undefined";
 export const createMiddleware: Middleware = (store) => {
   let isInitializing = false;
   let pendingFetchTimer: NodeJS.Timeout | null = null;
-  
+
   return (next) => (action: AnyAction) => {
     if (!isClient) {
       return next(action);
     }
-    
     if (action.type === "search/initialize/pending") {
       isInitializing = true;
       initializeFromUrl(store);
       return next(action);
     }
-    
     if (action.type === "search/initialize/fulfilled") {
       isInitializing = false;
       return next(action);
     }
-    
-    // Handle batchResetFilters case specially
     if (action.type === batchResetFilters.type) {
       const result = next(action);
-      
-      // Clear any pending fetch timer
       if (pendingFetchTimer) {
         clearTimeout(pendingFetchTimer);
         pendingFetchTimer = null;
       }
-      
-      // Use the query from the action payload
       triggerResultsRelatesFetch(store, action.payload.query);
       return result;
     }
-    
     const result = next(action);
     const config = actionConfig[action.type];
-    
     if (config) {
       if (config.syncWithUrl) {
         syncToUrl(action, config);
       }
-      
       if (config.requiresFetch && !isInitializing) {
         const state = store.getState();
         if (!state.search.isSearching) {
-          // Clear any pending fetch timer
           if (pendingFetchTimer) {
             clearTimeout(pendingFetchTimer);
           }
-          
-          // Debounce the fetch request to avoid multiple consecutive fetches
           pendingFetchTimer = setTimeout(() => {
-            triggerResultsRelatesFetch(store, store.getState().search.query || "*");
+            triggerResultsRelatesFetch(
+              store,
+              store.getState().search.query || "*"
+            );
             pendingFetchTimer = null;
           }, 50);
         }
       }
     }
-    
     return result;
   };
 };
@@ -119,16 +107,18 @@ function syncToUrl(action: AnyAction, config: ActionConfig) {
   window.history.pushState({}, "", newUrl);
 }
 
-async function triggerResultsRelatesFetch(store: any, query: string, bypassSpellCheck = false) {
+async function triggerResultsRelatesFetch(
+  store: any,
+  query: string,
+  bypassSpellCheck = false
+) {
   const state = store.getState();
   if (!state.search.schema) return;
-  
   if (state.search.isSearching) return;
-  
   const filterQueries = generateFilterQueries(state.search);
   try {
     store.dispatch(setIsSearching(true));
-    
+
     if (state.search.aiSearch && (!query || query === "*")) {
       await store.dispatch(
         fetchSearchAndRelatedResults({

--- a/src/middleware/createMiddleware.ts
+++ b/src/middleware/createMiddleware.ts
@@ -32,6 +32,28 @@ export const createMiddleware: Middleware = (store) => {
         clearTimeout(pendingFetchTimer);
         pendingFetchTimer = null;
       }
+      // batch reset filters
+      const searchParams = new URLSearchParams(window.location.search);
+      if (action.payload.query === "*") {
+        searchParams.delete("query");
+      } else if (action.payload.query) {
+        searchParams.set("query", action.payload.query);
+      }
+      if (action.payload.preserveSubject && action.payload.subject) {
+        if (Array.isArray(action.payload.subject) && action.payload.subject.length > 0) {
+          searchParams.set("subject", action.payload.subject.join(","));
+        } else {
+          searchParams.delete("subject");
+        }
+      } else {
+        searchParams.delete("subject");
+      }
+      searchParams.delete("spatial_resolution");
+      searchParams.delete("bbox");
+      searchParams.delete("index_year");
+      const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+      window.history.pushState({}, "", newUrl);
+      
       triggerResultsRelatesFetch(store, action.payload.query);
       return result;
     }

--- a/src/middleware/createMiddleware.ts
+++ b/src/middleware/createMiddleware.ts
@@ -9,6 +9,11 @@ import { ActionConfig, actionConfig } from "./actionConfig";
 
 const isClient = typeof window !== "undefined";
 
+// Keep track of in-flight queries to prevent duplicates
+const inFlightQueries = new Map(); // queries that are currently being fetched but not yet completed
+const recentQueries = new Map(); // queries that were recently fetched and completed
+const RECENT_QUERY_TTL = 200;
+
 export const createMiddleware: Middleware = (store) => {
   let isInitializing = false;
   let pendingFetchTimer: NodeJS.Timeout | null = null;
@@ -40,7 +45,10 @@ export const createMiddleware: Middleware = (store) => {
         searchParams.set("query", action.payload.query);
       }
       if (action.payload.preserveSubject && action.payload.subject) {
-        if (Array.isArray(action.payload.subject) && action.payload.subject.length > 0) {
+        if (
+          Array.isArray(action.payload.subject) &&
+          action.payload.subject.length > 0
+        ) {
           searchParams.set("subject", action.payload.subject.join(","));
         } else {
           searchParams.delete("subject");
@@ -53,7 +61,7 @@ export const createMiddleware: Middleware = (store) => {
       searchParams.delete("index_year");
       const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
       window.history.pushState({}, "", newUrl);
-      
+
       triggerResultsRelatesFetch(store, action.payload.query);
       return result;
     }
@@ -137,10 +145,21 @@ async function triggerResultsRelatesFetch(
   const state = store.getState();
   if (!state.search.schema) return;
   if (state.search.isSearching) return;
-  const filterQueries = generateFilterQueries(state.search);
-  try {
-    store.dispatch(setIsSearching(true));
 
+  const filterQueries = generateFilterQueries(state.search);
+  const queryKey = `${query}:${JSON.stringify(filterQueries)}:${
+    state.search.sort.sortBy
+  }:${state.search.sort.sortOrder}`; // create a unique key for the query using all what we need to fetch the query
+  if (inFlightQueries.has(queryKey)) return; // if the query is already being fetched, don't fetch it again
+  if (recentQueries.has(queryKey)) {
+    const timestamp = recentQueries.get(queryKey);
+    if (Date.now() - timestamp < RECENT_QUERY_TTL) return; // if the query was recently fetched and completed within the last 200ms, don't fetch it again
+    recentQueries.delete(queryKey);
+  }
+  try {
+    inFlightQueries.set(queryKey, true); // add the query to the in-flight queries
+    recentQueries.set(queryKey, Date.now()); // add the query to the recent queries
+    store.dispatch(setIsSearching(true));
     if (state.search.aiSearch && (!query || query === "*")) {
       await store.dispatch(
         fetchSearchAndRelatedResults({
@@ -167,6 +186,14 @@ async function triggerResultsRelatesFetch(
   } catch (error) {
     console.error("Search failed:", error);
   } finally {
+    inFlightQueries.delete(queryKey); // remove the query from the in-flight queries
     store.dispatch(setIsSearching(false));
+    const now = Date.now();
+    Array.from(recentQueries.entries()).forEach(([key, timestamp]) => {
+      // remove the query from the recent queries if it was completed more than 200ms ago
+      if (now - timestamp > RECENT_QUERY_TTL) {
+        recentQueries.delete(key);
+      }
+    });
   }
 }

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -220,12 +220,12 @@ export const fetchSearchAndRelatedResults = createAsyncThunk(
       }
     }
     const relatedResults = [];
-    if (finalResults && finalResults.length > 0) {
+    if (validSuggestions.length > 0) {
       for (const suggestion of validSuggestions) {
         if (suggestion !== usedQuery) {
           const { results: suggestionResults } = await searchQueryBuilder
             .generalQuery(suggestion)
-            .fetchResult();
+            .fetchResult(undefined, true);
           relatedResults.push(...suggestionResults);
         }
       }

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -523,7 +523,6 @@ const searchSlice = createSlice({
       })
       .addCase(batchResetFilters, (state, action) => {
         state.bbox = null;
-        state.subject = [];
         state.spatialResolution = [];
         state.indexYear = [];
         state.filterQueries = [];
@@ -531,6 +530,11 @@ const searchSlice = createSlice({
         state.query = action.payload.query;
         state.sort.sortBy = "score";
         state.sort.sortOrder = "desc";
+        if (action.payload.preserveSubject && action.payload.subject) {
+          state.subject = action.payload.subject;
+        } else {
+          state.subject = [];
+        }
       });
   },
 });

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -451,65 +451,44 @@ const searchSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchSearchAndRelatedResults.pending, (state, action) => {
-        if (
-          state.currentRequestId === null ||
-          state.currentRequestId === action.meta.requestId ||
-          action.meta.arg.bypassSpellCheck
-        ) {
-          state.isSearching = true;
-          state.currentRequestId = action.meta.requestId;
-        }
+        state.isSearching = true;
+        state.currentRequestId = action.meta.requestId;
       })
       .addCase(fetchSearchAndRelatedResults.fulfilled, (state, action) => {
-        if (
-          state.currentRequestId === action.meta.requestId ||
-          action.meta.arg.bypassSpellCheck
-        ) {
-          state.results = generateSolrObjectList(
-            action.payload.searchResults || []
-          );
-          state.relatedResults = generateSolrObjectList(
-            action.payload.relatedResults || []
-          );
-          state.suggestions = action.payload.suggestions || [];
-          state.originalQuery = Array.isArray(action.payload.originalQuery)
-            ? action.payload.originalQuery.join(", ")
-            : action.payload.originalQuery;
-          state.usedQuery = Array.isArray(action.payload.usedQuery)
-            ? action.payload.usedQuery.join(", ")
-            : action.payload.usedQuery;
-          state.usedSpellCheck = action.payload.usedSpellCheck || false;
+        if (state.currentRequestId === action.meta.requestId) {
+          if (action.payload) {
+            state.results = generateSolrObjectList(action.payload.searchResults || []);
+            state.relatedResults = generateSolrObjectList(action.payload.relatedResults || []);
+            state.suggestions = action.payload.suggestions || [];
+            state.originalQuery = action.payload.originalQuery;
+            state.usedQuery = action.payload.usedQuery;
+            state.usedSpellCheck = action.payload.usedSpellCheck || false;
+          }
           state.isSearching = false;
-          state.currentRequestId = null;
         }
       })
       .addCase(fetchSearchAndRelatedResults.rejected, (state, action) => {
-        if (
-          state.currentRequestId === action.meta.requestId ||
-          action.meta.arg.bypassSpellCheck
-        ) {
+        if (state.currentRequestId === action.meta.requestId) {
           state.isSearching = false;
           state.results = [];
           state.relatedResults = [];
-          state.usedSpellCheck = false;
-          state.currentRequestId = null;
         }
       })
       .addCase(fetchSearchResults.pending, (state) => {
         state.isSearching = true;
-        state.results = [];
       })
       .addCase(fetchSearchResults.fulfilled, (state, action) => {
-        state.results = generateSolrObjectList(action.payload.results);
-        state.originalQuery = action.payload.originalQuery;
-        state.usedQuery = action.payload.usedQuery;
-        state.usedSpellCheck = action.payload.usedSpellCheck;
+        if (action.payload) {
+          state.results = generateSolrObjectList(action.payload.results || []);
+          state.originalQuery = action.payload.originalQuery;
+          state.usedQuery = action.payload.usedQuery;
+          state.usedSpellCheck = action.payload.usedSpellCheck || false;
+        }
         state.isSearching = false;
       })
       .addCase(fetchSearchResults.rejected, (state) => {
         state.isSearching = false;
         state.results = [];
-        state.usedSpellCheck = false;
       })
       .addCase(fetchSuggestions.pending, (state) => {})
       .addCase(fetchSuggestions.rejected, (state) => {
@@ -543,7 +522,6 @@ const searchSlice = createSlice({
         state.suggestions = [];
       })
       .addCase(batchResetFilters, (state, action) => {
-        // Reset all filter-related state
         state.bbox = null;
         state.subject = [];
         state.spatialResolution = [];

--- a/src/store/types/search.ts
+++ b/src/store/types/search.ts
@@ -91,4 +91,6 @@ export interface SolrSuggestResponse {
 export interface BatchResetFiltersPayload {
   schema: any;
   query: string;
+  preserveSubject?: boolean;
+  subject?: string[];
 }


### PR DESCRIPTION
This PR addresses issues #549, #542, and #546. It updates the default behavior of the autocomplete dropdown in the search box to prevent pre-selection when the user's mouse moves out of the dropdown area. It also fixes some bugs related to the "No Results" scenarios and includes general code optimizations.

## How to Test

1. #542: Go to the search page and type a keyword longer than two characters to trigger the autocomplete dropdown (e.g., "scocial").

2. Hover over a suggestion, then move your mouse out of the dropdown.

3. Previously, the first item would be automatically highlighted (shado
![Screenshot 2025-04-22 at 4 53 39 PM](https://github.com/user-attachments/assets/e372e3f5-f1bd-439d-a772-a2eee5cb3602)
wed), but now this is no longer the case.

4. Press Enter after moving your mouse out — the search should be performed using your typed input (e.g. "social"), not the first suggestion.
![Screenshot 2025-04-22 at 4 54 05 PM](https://github.com/user-attachments/assets/4eef7bb8-08c4-4149-a55b-e9a6d06edb95)


5. #546: Type a short term that doesn't trigger the dropdown (e.g., "sa"). Note that this term should not match any Solr suggestions but could still return related results.

6. Press Enter or click the arrow to search.

7. You should see a list of relevant results.
![Screenshot 2025-04-22 at 4 54 22 PM](https://github.com/user-attachments/assets/dc56ad57-753a-480d-b17d-14463fb82776)

8. Previously, this scenario incorrectly showed a "No Results" view with only the result count visible.

9. #549: Type a term that yields no direct or related results (e.g., "sj") and press Enter.

10. The "No Results" view should appear.

11. Click on a theme under the "Search for a theme instead?" suggestion.

12. The system should now correctly apply only the theme filter and return results
![Screenshot 2025-04-22 at 4 54 44 PM](https://github.com/user-attachments/assets/7022b16a-5e05-4cdb-9e2e-1ae8814ee9e4)
.

13. This fixes a bug where the original query and theme filter were combined, resulting in another "No Results" view.
