### PR TITLE
#540 feat: decorative images in markdown

### DIFF
--- a/content/guides/public-transit-equity.mdx
+++ b/content/guides/public-transit-equity.mdx
@@ -79,7 +79,9 @@ We can use certain signs to check if the system treats everyone fairly instead o
 
 ### Preparation of Origin and Destination Points
 
-![](/images/prep.svg)
+<div class="decorative-image">
+    ![](/images/prep.svg)
+</div>
 
 The origin and destinations provide a sense of the population, geographical and multiple resources or opportunities of interest. The spatial location of the origin/destination can be a point location such as bus stops or train stations or the centroid of the geographical boundaries such as a city, census tract, census block group etc.
 
@@ -92,7 +94,9 @@ You can access or calculate the **centroid** using GIS software or programming l
 
 ### Choosing the Right Measure
 
-![](/images/lens.svg)
+<div class="decorative-image">
+    ![](/images/lens.svg)
+</div>
 
 When we talk about how far one place is from another or how easy it is to get there, we use different methods and measures to compute distance and access. For the most part, the way we do it depends on how we think about distance and the specific community we are looking at or a combination of both. These methods are at the heart of both web-based and desktop GIS tools like QGIS and ArcGIS Pro, as well as advanced open-source tools like the r5r package in R. They help us understand and plan for things like emergency services, and community development
 
@@ -121,7 +125,9 @@ NB: The three methods are restrictive. Here, the probability of choosing the nea
 <details>
 <summary>Container-Based Measures</summary>
 
-![](/images/cumulative.svg)
+<div class="decorative-image">
+    ![](/images/cumulative.svg)
+</div>
 
 Acknowledging individual differences can complicate accessibility calculations and may require additional data, computational, and technical support. A number of transit equity measures simplify this complexity by using container-based measures which assess accessibility by grouping all the opportunities within predefined geographic areas commonly referred to as "containers" - neighborhoods, census tracts, or block groups. These measures assume that everyone within the container shares similar characteristics and that the area's attributes can represent the experiences of its residents, which makes it easier to analyze and compare.
 
@@ -175,7 +181,9 @@ Limitations of Gravity Measure:
 
 ### Setting Parameters to Calculate Access
 
-![](/images/success.svg)
+<div class="decorative-image">
+    ![](/images/success.svg)
+</div>
 
 When setting up your accessibility analysis, it is important to carefully define each parameter to ensure that the results are meaningful and accurate:
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,7 +9,13 @@
 /* animation for icons on mobile navbar */
 .animate-fade-in{animation:opac 1.4s}@keyframes opac{from{opacity:0} to{opacity:1}}
 
-
+/* Support decorative images in rendered markdown */
+/* Smaller screens will still use 100% width */
+@media (min-width: 769px) {
+  .decorative-image {
+    width: 50%;
+  }
+}
 
 /*  WIP: Scalable background image for top lines?
 


### PR DESCRIPTION
## Problem
Currently, images use 100% of the page width

But some of these images are purely decorative and don't need to draw that much of the user's focus

Fixes #540 

## Approach
* feat: allow users to specify which images are decorative - these will be given 50% width (on large screens only)
    * smaller screens should still use 100% width
    * we could also add a "Decorative Image" widget that would add this div/class around the given image, which might ease user experience a bit if folks aren't as familiar with HTML

For example:
```
<div className="decorative-image">
![](/images/prep.svg)
</div>
```

On larger screens, this will render as:
![Screenshot 2025-04-22 at 10 52 29 AM](https://github.com/user-attachments/assets/8d9dac99-9f65-4033-b691-359063b5ed61)

On smaller screens, this will render as:
![Screenshot 2025-04-22 at 10 52 12 AM](https://github.com/user-attachments/assets/db244dd6-b019-4c35-8956-e9a0aded9617)

## How to Test
~~I'm not sure how to offer a test case via Netlify, as I believe DecapCMS will create a new branch/PR for each change
But to use the new class, it would need to use this branch.~~

### Viewing the Preview
1. Navigate to https://deploy-preview-550--cheerful-treacle-913a24.netlify.app/guides/public-transit-equity
2. Scroll down to the section titled "Spatial Approaches to Calculating Public Transit Access at the Community Level"
    * On desktop (> 769px): you should see that the image slightly below this header takes up only 50% of the screen
    * On mobile (<= 769px): you should see that the image slightly below this header still takes up 100% of the screen

### Testing Locally
1. Checkout and run this branch locally: `git fetch --all && git checkout feature/lambert8/support-decorative-images-in-markdown`
4. Navigate to http://localhost:3000/guides/public-transit-equity
    * You should see that images take 100% of the page width here
5. Edit one or more images to be inside of a `<div className="decorative-image">    </div>` block
    * To avoid needing to publish, create a PR, etc, you can simply edit your local `.mdx` file directly
6. Refresh http://localhost:3000/guides/public-transit-equity
    * You should see that images take 50% of the page width here on larger screens
    * You should see that images still take 100% of the page width here on smaller screens