### PR TITLE
#541 feat: add generic Panel component for markdown editor

### DIFF
--- a/content/guides/public-transit-equity.mdx
+++ b/content/guides/public-transit-equity.mdx
@@ -79,7 +79,9 @@ We can use certain signs to check if the system treats everyone fairly instead o
 
 ### Preparation of Origin and Destination Points
 
-![](/images/prep.svg)
+<div class="decorative-image">
+    ![](/images/prep.svg)
+</div>
 
 The origin and destinations provide a sense of the population, geographical and multiple resources or opportunities of interest. The spatial location of the origin/destination can be a point location such as bus stops or train stations or the centroid of the geographical boundaries such as a city, census tract, census block group etc.
 
@@ -92,7 +94,9 @@ You can access or calculate the **centroid** using GIS software or programming l
 
 ### Choosing the Right Measure
 
-![](/images/lens.svg)
+<div class="decorative-image">
+    ![](/images/lens.svg)
+</div>
 
 When we talk about how far one place is from another or how easy it is to get there, we use different methods and measures to compute distance and access. For the most part, the way we do it depends on how we think about distance and the specific community we are looking at or a combination of both. These methods are at the heart of both web-based and desktop GIS tools like QGIS and ArcGIS Pro, as well as advanced open-source tools like the r5r package in R. They help us understand and plan for things like emergency services, and community development
 
@@ -121,7 +125,9 @@ NB: The three methods are restrictive. Here, the probability of choosing the nea
 <details>
 <summary>Container-Based Measures</summary>
 
-![](/images/cumulative.svg)
+<div class="decorative-image">
+    ![](/images/cumulative.svg)
+</div>
 
 Acknowledging individual differences can complicate accessibility calculations and may require additional data, computational, and technical support. A number of transit equity measures simplify this complexity by using container-based measures which assess accessibility by grouping all the opportunities within predefined geographic areas commonly referred to as "containers" - neighborhoods, census tracts, or block groups. These measures assume that everyone within the container shares similar characteristics and that the area's attributes can represent the experiences of its residents, which makes it easier to analyze and compare.
 
@@ -175,7 +181,9 @@ Limitations of Gravity Measure:
 
 ### Setting Parameters to Calculate Access
 
-![](/images/success.svg)
+<div class="decorative-image">
+    ![](/images/success.svg)
+</div>
 
 When setting up your accessibility analysis, it is important to carefully define each parameter to ensure that the results are meaningful and accurate:
 

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -396,6 +396,26 @@ collections:
         time_format: "HH:mm" # e.g. 21:07
         format: "LLL"
         picker_utc: false
+      - label: "Social Determinant Theme"
+        name: "theme"
+        widget: "select"
+        multiple: false
+        # See src/components/search/helper/themeIcons.tsx for copy/paste list
+        options: [
+          "Demographics",
+          "Economic Stability",
+          "Employment",
+          "Education",
+          "Food Environment",
+          "Health and Healthcare",
+          "Housing",
+          "Natural Environment",
+          "Neighborhood and Built Environment",
+          "Physical Activity and Lifestyle",
+          "Safety",
+          "Social and Community Context",
+          "Transportation and Infrastructure",
+        ]
       - label: Author
         name: "author"
         widget: string

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -396,26 +396,6 @@ collections:
         time_format: "HH:mm" # e.g. 21:07
         format: "LLL"
         picker_utc: false
-      - label: "Social Determinant Theme"
-        name: "theme"
-        widget: "select"
-        multiple: false
-        # See src/components/search/helper/themeIcons.tsx for copy/paste list
-        options: [
-          "Demographics",
-          "Economic Stability",
-          "Employment",
-          "Education",
-          "Food Environment",
-          "Health and Healthcare",
-          "Housing",
-          "Natural Environment",
-          "Neighborhood and Built Environment",
-          "Physical Activity and Lifestyle",
-          "Safety",
-          "Social and Community Context",
-          "Transportation and Infrastructure",
-        ]
       - label: Author
         name: "author"
         widget: string

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -32,14 +32,16 @@
       CMS.registerPreviewStyle("/styles/posts.module.css");
 
       const toPanelHtml = (data, parse) => {
+        // Include style tags for raw HTML and override with JSX style for React mode
+        // This allows us to support both the preview in DecapCMS + the rendered markdown in SDOH
         return `
-<div class='sdoh-panel' style='background-color:${data.backgroundColor}'>
+<div class='sdoh-panel' style='background-color:${data.backgroundColor}' style={{ backgroundColor: '${data.backgroundColor}' }}>
 <h4 class='sdoh-panel-header'>${data.title}</h4>
 <div class='sdoh-panel-content'>
 <img class='sdoh-panel-image' src='${data.image}' />
 <div class='sdoh-panel-body'>
 <span class='sdoh-panel-markdown'>${parse ? marked.parse(data.content || '') : data.content}</span>
-<br>
+<br/>
 <a class='sdoh-panel-link' href='${data.link}'>${data.linkText || data.link}</a>
 </div></div></div>`;
       };
@@ -91,7 +93,7 @@
         // newline becomes \n*
         // () matches a value
         // ? makes it optional
-        pattern: /<div class='sdoh-panel' style='background-color:([^']+)?'>\n*<h4 class='sdoh-panel-header'>(.*?)<\/h4>\n*<div class='sdoh-panel-content'>\n*<img class='sdoh-panel-image' src='([^']+)?' \/>\n*<div class='sdoh-panel-body'>\n*<span class='sdoh-panel-markdown'>(.+?)<\/span>\n*<br>\n*<a class='sdoh-panel-link' href='([^']+)?'>(.*?)<\/a>\n*<\/div>\n*<\/div>\n*<\/div>/ms,
+        pattern: /<div class='sdoh-panel' style='background-color:([^']+)?' style={{ backgroundColor: '.*' }}>\n*<h4 class='sdoh-panel-header'>(.*?)<\/h4>\n*<div class='sdoh-panel-content'>\n*<img class='sdoh-panel-image' src='([^']+)?' \/>\n*<div class='sdoh-panel-body'>\n*<span class='sdoh-panel-markdown'>(.+?)<\/span>\n*<br\/>\n*<a class='sdoh-panel-link' href='([^']+)?'>(.*?)<\/a>\n*<\/div>\n*<\/div>\n*<\/div>/ms,
         //pattern: /<div\s+class='sdoh-panel'\s+style='background-color:([^']+)?'>\n*<h4\s+class='sdoh-panel-header'>\n*(.*?)\n*<\/h4>\n*<div\s+class='sdoh-panel-content'>\n*<img\s+class='sdoh-panel-image'\s+src='([^']+)?'\s+\/>\n*(.*?)\n*<\/div>\n*(<a\s+class='sdoh-panel-link'\s+href='([^']+)?'\s+>(.*?)<\/a>)?\n*<\/div>/,
         //pattern: /<details(\sname='([^']+)?')?>\n*<summary>\n*(.*?)\n*<\/summary>\n*(.*?)\n*<\/details>/ms,
         fromBlock: (match) => {

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -31,6 +31,89 @@
       );
       CMS.registerPreviewStyle("/styles/posts.module.css");
 
+      const toPanelHtml = (data, parse) => {
+        return `
+<div class='sdoh-panel' style='background-color:${data.backgroundColor}'>
+<h4 class='sdoh-panel-header'>${data.title}</h4>
+<div class='sdoh-panel-content'>
+<img class='sdoh-panel-image' src='${data.image}' />
+<div class='sdoh-panel-body'>
+<span class='sdoh-panel-markdown'>${parse ? marked.parse(data.content || '') : data.content}</span>
+<br>
+<a class='sdoh-panel-link' href='${data.link}'>${data.linkText || data.link}</a>
+</div></div></div>`;
+      };
+
+      // Register custom Editor Component: Link Panel
+      CMS.registerEditorComponent({
+        id: 'panel',
+        label: 'Panel',
+        fields: [
+          {
+            name: 'title',
+            label: 'Title',
+            widget: 'string',
+            required: true
+          },
+          {
+            name: 'content',
+            label: 'Content',
+            widget: 'markdown',
+            // exclude panel from being nested inside another panel
+            editor_components: [ "image", "code-block" ],
+            required: true
+          },
+          {
+            name: 'link',
+            label: 'Link',
+            widget: 'string'
+          },
+          {
+            name: 'linkText',
+            label: 'Link Text',
+            widget: 'string'
+          },
+          {
+            name: 'image',
+            label: 'Image',
+            widget: 'image',
+            allow_multiple: false
+          },
+          {
+            name: 'backgroundColor',
+            label: 'Background Color',
+            widget: 'color'
+          }
+        ],
+
+        // These are used to populate the custom widget in the markdown editor in the CMS.
+        // space becomes \s+
+        // newline becomes \n*
+        // () matches a value
+        // ? makes it optional
+        pattern: /<div class='sdoh-panel' style='background-color:([^']+)?'>\n*<h4 class='sdoh-panel-header'>(.*?)<\/h4>\n*<div class='sdoh-panel-content'>\n*<img class='sdoh-panel-image' src='([^']+)?' \/>\n*<div class='sdoh-panel-body'>\n*<span class='sdoh-panel-markdown'>(.+?)<\/span>\n*<br>\n*<a class='sdoh-panel-link' href='([^']+)?'>(.*?)<\/a>\n*<\/div>\n*<\/div>\n*<\/div>/ms,
+        //pattern: /<div\s+class='sdoh-panel'\s+style='background-color:([^']+)?'>\n*<h4\s+class='sdoh-panel-header'>\n*(.*?)\n*<\/h4>\n*<div\s+class='sdoh-panel-content'>\n*<img\s+class='sdoh-panel-image'\s+src='([^']+)?'\s+\/>\n*(.*?)\n*<\/div>\n*(<a\s+class='sdoh-panel-link'\s+href='([^']+)?'\s+>(.*?)<\/a>)?\n*<\/div>/,
+        //pattern: /<details(\sname='([^']+)?')?>\n*<summary>\n*(.*?)\n*<\/summary>\n*(.*?)\n*<\/details>/ms,
+        fromBlock: (match) => {
+          console.log('Matches: ', match);
+          return {
+            backgroundColor: match[1],
+            title: match[2],
+            image: match[3],
+            content: match[4],
+            link: match[5],
+            linkText: match[6],
+          };
+        },
+
+        // This is used to serialize the data from the custom widget to the markdown document.
+        toBlock: (data) => toPanelHtml(data, false),
+
+        // Preview output for this component. Can either be a string or a React component
+        // (component gives better render performance)
+        toPreview: (data) => toPanelHtml(data, true),
+      });
+
       // Register custom Editor Component: Toggle Section
       CMS.registerEditorComponent({
         // Internal id of the component
@@ -49,7 +132,7 @@
             name: 'content',
             label: 'Content',
             widget: 'markdown',
-            // exclude toggle-section from being nested inside of another toggle-section
+            // exclude toggle-section from being nested inside another toggle-section
             editor_components: [ "image", "code-block" ],
             required: true
           },

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -30,7 +30,8 @@
         "https://fonts.googleapis.com/css2?family=Nunito:wght@300;400&display=swap"
       );
       CMS.registerPreviewStyle("/styles/posts.module.css");
-      // Register custom Editor Components
+
+      // Register custom Editor Component: Toggle Section
       CMS.registerEditorComponent({
         // Internal id of the component
         id: "toggle-section",
@@ -75,7 +76,7 @@
         //
         // This is used to populate the custom widget in the markdown editor in the CMS.
         fromBlock: function(match) {
-          console.log('Matches: ', match);
+          //console.log('Matches: ', match);
           return {
             title: match[3],
             content: match[4],
@@ -166,9 +167,30 @@ ${marked.parse(data.content)}
       var GuidePreview = createClass({
         render: function () {
           var entry = this.props.entry;
+          var sdohGuideTheme = entry.getIn(["data", "theme"]);
           return h(
             "div",
             { className: "container" },
+            !sdohGuideTheme ? "" : h("div", { className: "sdoh-theme-banner" },
+              h('h4', { className: "sdoh-theme-banner-header" }, `Looking for data on ${sdohGuideTheme}?`),
+              h("div", { className: "sdoh-theme-banner-content" },
+                h('img', {
+                  className: "sdoh-theme-banner-logo",
+                  src: "/images/place-project-logo.png"
+                }),
+                h("span", {},
+                  h("p", { className: "sdoh-theme-banner-caption" },
+                    'Our Data Discovery platform helps you search for data on ',
+                    h("strong", {}, sdohGuideTheme),
+                    ' along with 12 other social determinants of health. Search for KEYWORD 1, KEYWORD 2, KEYWORD 3, etc. on the platform for your analysis. More text comes here. More text comes here.'
+                  ),
+                  h("a", {
+                    className: "sdoh-theme-banner-link",
+                    href: `/search?subject=${encodeURIComponent(sdohGuideTheme)}`
+                  }, `Search for ${sdohGuideTheme} on Data Discovery →`),
+                ),
+              ),
+            ),
             h("h1", {}, entry.getIn(["data", "title"])),
             h(
               "div",

--- a/public/styles/posts.module.css
+++ b/public/styles/posts.module.css
@@ -189,12 +189,12 @@
   margin: 1.5em 0;
 }
 
-.sdoh-theme-banner {
+.sdoh-panel {
   padding: 1rem 2rem;
   border-radius: 10px;
-  background-color: #ECE6F0;
+  /*background-color: #ECE6F0;*/
 
-  .sdoh-theme-banner-header {
+  .sdoh-panel-header {
     font-family: Nunito;
     font-weight: 700;
     font-size: 14pt;
@@ -202,22 +202,28 @@
     letter-spacing: 0;
     margin: 0;
   }
-  .sdoh-theme-banner-content {
+  .sdoh-panel-content {
     display: flex;
     flex-direction: row;
     margin: 0.5rem 0 1rem 0;
 
-    .sdoh-theme-banner-logo {
+    .sdoh-panel-image {
       width: 7rem;
       height: 7rem;
       margin: 0 2rem 1rem 0;
     }
-    .sdoh-theme-banner-link {
-      width: 7rem;
-      height: 7rem;
-      color: #7E1CC4;
-      font-weight: bolder;
-      text-decoration: none;
+    .sdoh-panel-body {
+      display: flex;
+      flex-direction: column;
+      .sdoh-panel-markdown {
+
+      }
+      .sdoh-panel-link {
+        width: 7rem;
+        color: #7E1CC4;
+        font-weight: bolder;
+        text-decoration: none;
+      }
     }
   }
 }

--- a/public/styles/posts.module.css
+++ b/public/styles/posts.module.css
@@ -188,3 +188,36 @@
   font-size: 1rem;
   margin: 1.5em 0;
 }
+
+.sdoh-theme-banner {
+  padding: 1rem 2rem;
+  border-radius: 10px;
+  background-color: #ECE6F0;
+
+  .sdoh-theme-banner-header {
+    font-family: Nunito;
+    font-weight: 700;
+    font-size: 14pt;
+    line-height: 100%;
+    letter-spacing: 0;
+    margin: 0;
+  }
+  .sdoh-theme-banner-content {
+    display: flex;
+    flex-direction: row;
+    margin: 0.5rem 0 1rem 0;
+
+    .sdoh-theme-banner-logo {
+      width: 7rem;
+      height: 7rem;
+      margin: 0 2rem 1rem 0;
+    }
+    .sdoh-theme-banner-link {
+      width: 7rem;
+      height: 7rem;
+      color: #7E1CC4;
+      font-weight: bolder;
+      text-decoration: none;
+    }
+  }
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ import Footer from "./homepage/footer";
 import React from "react";
 import PostLayout, { PostLayoutProps } from "./news/PostLayout";
 import ShowcaseLayout, { ShowcaseLayoutProps } from "./showcase/ShowcaseLayout";
-import GuideLayout, { GuideLayoutProps } from "./guides/GuideLayout";
+import GuidesLayout, { GuideLayoutProps } from "./guides/GuidesLayout";
 
 type Props = {
   type?: "news" | "showcase" | "guide";
@@ -57,9 +57,9 @@ export default function Layout({
                 </ShowcaseLayout>
               )}
               {type === "guide" && (
-                <GuideLayout {...guide_props}>
+                <GuidesLayout {...guide_props}>
                   {guide_props.children}
-                </GuideLayout>
+                </GuidesLayout>
               )}
             </div>
           </div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -124,7 +124,7 @@ const NavBar = (): JSX.Element => {
   const resourcesItems = [
     { title: "Data Discovery", url: "/search" },
     { title: "Community Toolkit", url: "https://toolkit.sdohplace.org", target: '_blank' },
-    //{ title: "SDOH Guides", url: "/guides" },
+    { title: "SDOH Guides", url: "/guides" },
   ];
 
   const communityItems = [

--- a/src/components/guides/GuidesItem.tsx
+++ b/src/components/guides/GuidesItem.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 export default function GuidesItem({ item }: Props) {
   return (
-    <Link href={"/showcase/" + item.slug} legacyBehavior>
+    <Link href={"/guides/" + item.slug} legacyBehavior>
       <a className={"no-underline"}>
         <div style={{ display: "flex" }}>
           <div>

--- a/src/components/guides/GuidesItem.tsx
+++ b/src/components/guides/GuidesItem.tsx
@@ -1,0 +1,36 @@
+import { GuidesContent } from "@/lib/guides";
+import Image from "next/image";
+import Link from "next/link";
+
+type Props = {
+  item: GuidesContent;
+};
+export default function GuidesItem({ item }: Props) {
+  return (
+    <Link href={"/showcase/" + item.slug} legacyBehavior>
+      <a className={"no-underline"}>
+        <div style={{ display: "flex" }}>
+          <div>
+            <Image src={item.featured_image} alt={item.title} width={200} height={25} />
+          </div>
+          <div style={{ paddingLeft: "2rem" }}>
+            <h2>{item.title}</h2>
+            <p>{item.author}</p>
+          </div>
+        </div>
+        <style jsx>
+          {`
+            a {
+              color: #222;
+              display: inline-block;
+            }
+            h2 {
+              margin: 0;
+              font-size: 2rem;
+            }
+          `}
+        </style>
+      </a>
+    </Link>
+  );
+}

--- a/src/components/guides/GuidesLayout.tsx
+++ b/src/components/guides/GuidesLayout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "@/public/styles/posts.module.css";
 import Author from "../news/Author";
 import Copyright from "../news/Copyright";
-import Date from "../news//Date";
+import DateComponent from "../news//Date";
 
 export type GuideLayoutProps = {
   title: string;
@@ -13,7 +13,7 @@ export type GuideLayoutProps = {
   body: any;
   children: React.ReactNode;
 };
-export default function GuideLayout({
+export default function GuidesLayout({
   title,
   last_updated,
   slug,
@@ -40,7 +40,7 @@ export default function GuideLayout({
             <h1 className={"guide-header"}>{title}</h1>
             <div className={"metadata"}>
               <div>
-                <Date date={last_updated} />
+                <DateComponent date={last_updated} />
               </div>
               <div>
                 <Author author={authorObject} />

--- a/src/components/guides/GuidesList.tsx
+++ b/src/components/guides/GuidesList.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { GuidesContent } from "../../lib/guides";
+import GuidesItem from "./GuidesItem";
+import Pagination from "../news/Pagination";
+
+type Props = {
+  posts: GuidesContent[];
+  pagination: {
+    current: number;
+    pages: number;
+  };
+};
+export default function GuidesList({ guides, pagination }: Props) {
+  return (
+    <>
+      <div className={"post-list"}>
+        <ul className={""}>
+          {guides.map((it, i) => (
+            <li key={i}>
+              <GuidesItem item={it} />
+            </li>
+          ))}
+        </ul>
+        {/* <Pagination
+          current={pagination.current}
+          pages={pagination.pages}
+          link={{
+            href: (page) => (page === 1 ? "/news" : "/news/page/[page]"),
+            as: (page) => (page === 1 ? null : "/news/page/" + page),
+          }}
+        /> */}
+      </div>
+    </>
+  );
+}

--- a/src/components/guides/GuidesList.tsx
+++ b/src/components/guides/GuidesList.tsx
@@ -4,7 +4,7 @@ import GuidesItem from "./GuidesItem";
 import Pagination from "../news/Pagination";
 
 type Props = {
-  posts: GuidesContent[];
+  guides: GuidesContent[];
   pagination: {
     current: number;
     pages: number;

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -5,20 +5,21 @@ import yaml from "js-yaml";
 
 const guidesDirectory = path.join(process.cwd(), "content/guides");
 
-export type GuideContent = {
+export type GuidesContent = {
   readonly last_updated: string;
   readonly title: string;
   readonly slug: string;
   readonly featured_image: string;
+  readonly author: string;
   //readonly body: string;
   readonly fullPath: string;
 };
 
-let guideCache: GuideContent[];
+let guidesCache: GuidesContent[];
 
-export function fetchGuideContent(): GuideContent[] {
-  if (guideCache) {
-    return guideCache;
+export function fetchGuidesContent(): GuidesContent[] {
+  if (guidesCache) {
+    return guidesCache;
   }
   // Get file names under /posts
   const fileNames = fs.readdirSync(guidesDirectory);
@@ -39,6 +40,7 @@ export function fetchGuideContent(): GuideContent[] {
         last_updated: string;
         title: string;
         featured_image: string;
+        author: string;
         slug: string;
         fullPath: string;
       };
@@ -48,24 +50,24 @@ export function fetchGuideContent(): GuideContent[] {
       return matterData;
     });
   // Sort posts by date
-  guideCache = allGuidesData.sort((a, b) => {
+  guidesCache = allGuidesData.sort((a, b) => {
     if (a.last_updated < b.last_updated) {
       return 1;
     } else {
       return -1;
     }
   });
-  return guideCache;
+  return guidesCache;
 }
 
 export function countGuides(): number {
-  return fetchGuideContent().length;
+  return fetchGuidesContent().length;
 }
 
-export function listGuideContent(
+export function listGuidesContent(
   page: number,
   limit: number
-): GuideContent[] {
-  return fetchGuideContent()
+): GuidesContent[] {
+  return fetchGuidesContent()
     .slice((page - 1) * limit, page * limit);
 }

--- a/src/pages/guides/[guide].tsx
+++ b/src/pages/guides/[guide].tsx
@@ -3,10 +3,9 @@ import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import remarkGfm from "remark-gfm";
 import matter from "gray-matter";
-import { fetchGuideContent } from "../../lib/guides";
+import { fetchGuidesContent } from "@/lib/guides";
 import fs from "fs";
 import yaml from "js-yaml";
-import { parseISO } from "date-fns";
 
 import InstagramEmbed from "react-instagram-embed";
 import YouTube from "react-youtube";
@@ -32,7 +31,7 @@ const slugToGuideContent = ((guideContents) => {
   const hash = {};
   guideContents.forEach((it) => (hash[it.slug] = it));
   return hash;
-})(fetchGuideContent());
+})(fetchGuidesContent());
 
 export default function Guide({
   title,
@@ -60,7 +59,7 @@ export default function Guide({
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = fetchGuideContent().map((it) => "/guides/" + it.slug);
+  const paths = fetchGuidesContent().map((it) => "/guides/" + it.slug);
   return {
     paths,
     fallback: false,

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -13,7 +13,7 @@ import {
 import { listTags, TagContent } from "@/lib/tags";
 
 type Props = {
-  posts: GuidesContent[];
+  guides: GuidesContent[];
   tags: TagContent[];
   pagination: {
     current: number;

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -1,0 +1,50 @@
+import { GetStaticProps } from "next";
+import Layout from "@/components/Layout";
+import Header from "@/components/meta/Header";
+import OpenGraphMeta from "@/components/meta/OpenGraphMeta";
+import TwitterCardMeta from "@/components/meta/TwitterCardMeta";
+import GuidesList from "@/components/guides/GuidesList";
+import config from "@/lib/config";
+import {
+  countGuides,
+  listGuidesContent,
+  GuidesContent
+} from "@/lib/guides";
+import { listTags, TagContent } from "@/lib/tags";
+
+type Props = {
+  posts: GuidesContent[];
+  tags: TagContent[];
+  pagination: {
+    current: number;
+    pages: number;
+  };
+};
+export default function Index({ guides, tags, pagination }: Props) {
+  const url = "/guides";
+  const title = "SDOH Guides";
+  return (
+    <Layout page_header={"SDOH Guides"}>
+      <Header url={url} title={title} />
+      <OpenGraphMeta url={url} title={title} />
+      <TwitterCardMeta url={url} title={title} />
+      <GuidesList guides={guides} pagination={pagination} />
+    </Layout>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const guides = listGuidesContent( 1, config.posts_per_page);
+  const tags = listTags();
+  const pagination = {
+    current: 1,
+    pages: Math.ceil(countGuides() / config.posts_per_page),
+  };
+  return {
+    props: {
+      guides,
+      tags,
+      pagination,
+    },
+  };
+};

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -11,6 +11,7 @@ import {
   GuidesContent
 } from "@/lib/guides";
 import { listTags, TagContent } from "@/lib/tags";
+import {Grid} from "@mui/material";
 
 type Props = {
   guides: GuidesContent[];
@@ -25,10 +26,30 @@ export default function Index({ guides, tags, pagination }: Props) {
   const title = "SDOH Guides";
   return (
     <Layout page_header={"SDOH Guides"}>
-      <Header url={url} title={title} />
-      <OpenGraphMeta url={url} title={title} />
-      <TwitterCardMeta url={url} title={title} />
-      <GuidesList guides={guides} pagination={pagination} />
+      <Grid container spacing={8}>
+        <Grid item xs={4}>
+          <Header url={url} title={title} />
+
+          {/*
+          <OpenGraphMeta url={url} title={title} />
+          <TwitterCardMeta url={url} title={title} />
+          */}
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Proin et erat pellentesque augue consequat
+            tincidunt vulputate ut metus. In mollis, dolor a
+            molestie gravida, diam nunc tincidunt quam, id
+            faucibus magna nisi sollicitudin velit. Sed mollis bibendum ullamcorper. Proin placerat
+            dolor sed sagittis maximus. Pellentesque habitant
+            morbi tristique senectus et netus et malesuada
+            fames ac turpis egestas.
+          </p>
+        </Grid>
+
+        <Grid item xs={12}>
+          <GuidesList guides={guides} pagination={pagination} />
+        </Grid>
+      </Grid>
     </Layout>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -342,3 +342,42 @@ article table td {
     background: 0 0
 }
 
+.sdoh-panel {
+  padding: 1rem 2rem;
+  border-radius: 10px;
+  /*background-color: #ECE6F0;*/
+
+  .sdoh-panel-header {
+    font-family: Nunito;
+    font-weight: 700;
+    font-size: 14pt;
+    line-height: 100%;
+    letter-spacing: 0;
+    margin: 0;
+  }
+  .sdoh-panel-content {
+    display: flex;
+    flex-direction: row;
+    margin: 0.5rem 0 1rem 0;
+
+    .sdoh-panel-image {
+      width: 7rem;
+      height: 7rem;
+      margin: 0 2rem 1rem 0;
+    }
+    .sdoh-panel-body {
+      display: flex;
+      flex-direction: column;
+      .sdoh-panel-markdown {
+
+      }
+      .sdoh-panel-link {
+        width: 7rem;
+        color: #7E1CC4;
+        font-weight: bolder;
+        text-decoration: none;
+      }
+    }
+  }
+}
+

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,7 +9,13 @@
 /* animation for icons on mobile navbar */
 .animate-fade-in{animation:opac 1.4s}@keyframes opac{from{opacity:0} to{opacity:1}}
 
-
+/* Support decorative images in rendered markdown */
+/* Smaller screens will still use 100% width */
+@media (min-width: 769px) {
+  .decorative-image {
+    width: 50%;
+  }
+}
 
 /*  WIP: Scalable background image for top lines?
 


### PR DESCRIPTION
## Problem
We need a generic way to link from SDOH guides to the Discovery App

It would be nice if this solution was generic enough to be reused for other things as well

Fixes #541 

## Approach
* feat: added a custom Panel component to the Markdown editor with the following properties:
    * `title`: Header to display at the top of the panel
    * `content`: Markdown body to display on the right side of the panel
    * `link`: URL for the link at the bottom of the panel
    * `linkText`: Text to display for the link at the bottom of the panel
    * `image`: Image to display on the left side of the panel
    * `backgroundColor`: Background color to use for this panel

### DecapCMS Preview
![CMS___SDOH___Place_Website](https://github.com/user-attachments/assets/3e16d7cd-5b23-4a13-bbdf-940cf97c5a64)

### Rendered Markdown in SDOH&Place
![Screenshot_2025-04-24_at_4_42_04_PM](https://github.com/user-attachments/assets/750b10ba-30a6-45e6-992b-a8dd37ea509b)

## How to Test
TBD