### PR TITLE
#567: Apply filters to the related result

### DIFF
--- a/src/middleware/actionConfig.ts
+++ b/src/middleware/actionConfig.ts
@@ -102,7 +102,7 @@ export const actionConfig: Record<string, ActionConfig> = {
   "search/setSort": {
     param: "sort",
     syncWithUrl: false,
-    requiresFetch: false,
+    requiresFetch: true,
     isFilter: false,
   },
 

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -147,6 +147,7 @@ export class SearchService {
   async fetchRelatedResults(
     validSuggestions: string[],
     usedQuery: string,
+    filterQueries: Array<any> = [],
     skipCache: boolean = false
   ): Promise<any[]> {
     const uniqueSuggestions = validSuggestions.filter(s => s !== usedQuery);
@@ -155,9 +156,8 @@ export class SearchService {
       if (suggestionManager.hasSuggestion(suggestion)) continue;
       try {
         suggestionManager.addSuggestion(suggestion);
-        const { results: suggestionResults } = await this.queryBuilder
-          .generalQuery(suggestion)
-          .fetchResult(undefined, skipCache);
+        this.queryBuilder.combineQueries(suggestion, filterQueries);
+        const { results: suggestionResults } = await this.queryBuilder.fetchResult(undefined, skipCache);
         suggestionManager.removeSuggestion(suggestion);
         
         if (suggestionResults && suggestionResults.length > 0) {

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -184,9 +184,8 @@ export const fetchSearchAndRelatedResults = createAsyncThunk(
             suggestionManager.addSuggestion(suggestion);
             const queryBuilder = new SolrQueryBuilder();
             queryBuilder.setSchema(schema);
-            const { results: suggestionResults } = await queryBuilder
-              .generalQuery(suggestion)
-              .fetchResult(undefined, false);
+            queryBuilder.combineQueries(suggestion, filterQueries);
+            const { results: suggestionResults } = await queryBuilder.fetchResult(undefined, false);
             suggestionManager.removeSuggestion(suggestion);
             
             if (suggestionResults && suggestionResults.length > 0) {
@@ -336,8 +335,10 @@ export const reloadAiSearchFromUrl = createAsyncThunk(
         dispatch(setRelatedResultsLoading(true));
       }
       
+      const filterQueries = filterService.generateFilterQueries(state.search);
+      
       const searchService = new SearchService(schema);
-      const result = await searchService.performChatGptSearch(query, []);
+      const result = await searchService.performChatGptSearch(query, filterQueries);
       
       if (result.analysis?.thoughts) {
         dispatch(setThoughts(result.analysis.thoughts || ""));


### PR DESCRIPTION
This should apply filter actions to the Keyword Search. Unfortunately, for AI Search, it appears to require additional work. We can revisit this later, as the search side of AI Search with filters triggers a re-fetch for the LLM, potentially resulting in different outcomes.

## How to Test
Run a search with filters. Try different interaction sequences—applying filters first, searching first, or any other combinations—to ensure it functions as expected.