### PR TITLE
fix: don't error if there aren't links #588

### DIFF
--- a/src/pages/advisory.tsx
+++ b/src/pages/advisory.tsx
@@ -93,7 +93,7 @@ const Advisory: NextPage = () => {
                   <div className="text-lg font-medium leading-[177.778%] mt-2.5">
                     {modalData.affiliation}
                   </div>
-                  {modalData.links.map((link, index) => (
+                  {modalData.links?.map((link, index) => (
                     <div
                       key={index}
                       className="text-lg font-medium leading-[177.778%] mt-2.5"


### PR DESCRIPTION
There was an expectation on the frontend that advisory board member profiles would always have one or more links attached. This caused the error in #588 because some new entries don't have a link.

Edit: That's not quite correct, the assumption was actually that `links` would always be an array (no problem if it was empty) but on these new entries `links` was just not present as an attribute at all, thus the error with `map` and `undefined`.

closes #588 