### PR TITLE
fix: fix problem with guide application link, #633

### DIFF
--- a/src/components/search/mapPanel/mapPanelContent.tsx
+++ b/src/components/search/mapPanel/mapPanelContent.tsx
@@ -206,7 +206,7 @@ const MapPanelContent = (props: Props): JSX.Element => {
               <p className="mb-[1em]">
                 We have a selection of resource guides available for different SDOH topics, like {" "}
                 <Link href="/guides/greenspace-access">Greenspace Access</Link> and {" "}<Link href="/guides/transportation-equity">Transportation Equity</Link>.
-                More guides are in the works! If you would like to collaborate on a research guide, please {" "}<Link href="/contact">get in touch</Link>.
+                More guides are in the works! If you would like to collaborate on a research guide, please {" "}<Link href="https://forms.illinois.edu/sec/1493227735" target="_blank">get in touch</Link>.
               </p>
             </Box>
             <Box className="text-2xl sm:mb-[0.6em]">


### PR DESCRIPTION
close #633. Fixed link to guide suggestion/application form from discovery application front page.

(note: It had already been changed in the `develop` branch, but it had been changed to `/contact` where it should have been changed to the external form link. All set now.)