### PR TITLE
docs: add note about community asset layer accuracy

### DIFF
--- a/src/components/search/searchArea/helpText/communityAssetsText.tsx
+++ b/src/components/search/searchArea/helpText/communityAssetsText.tsx
@@ -19,6 +19,17 @@ export const CommunityAssetsText = () => {
         <Link href="/contact">get in touch</Link> if you have ideas for more
         layers you would like to see or contribute.
       </Typography>
+      <div className="my-3 mx-3 p-2 bg-lightbisque rounded-lg">
+        <Typography
+          className="pb-1"
+          sx={{
+            fontFamily: fullConfig.theme.fontFamily["sans"],
+            fontSize: "0.8em",
+          }}
+        >
+          Please note, locations are pulled from a global, crowdsourced dataset, and may contain omissions or errors.
+        </Typography>
+      </div>
       <Typography sx={{ fontFamily: fullConfig.theme.fontFamily["sans"] }}>
         <strong>Community asset layers:</strong>
       </Typography>


### PR DESCRIPTION
Added a note to address one part of #626:

<img width="1452" height="619" alt="image" src="https://github.com/user-attachments/assets/b15862ae-d31e-44cb-a7e4-45d0b38b609a" />

@shubhamk008 Let me know how this should be changed to make it ready to go.