### PR TITLE
feat: add Symposium 2025 link to desktop+mobile Navbars

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -185,6 +185,13 @@ const NavBar = (): JSX.Element => {
             />
           </li>
 
+          {/* Symposium Link */}
+          <li
+            className={`mt-4 ml-6`}
+          >
+            <Link href="https://symposium2025.sdohplace.org" target="_blank">Symposium 2025</Link>
+          </li>
+
           {/* News Link */}
           <li
             className={`mt-4 ml-6 ${router.pathname.startsWith("/news") ? "active" : ""}`}
@@ -267,6 +274,11 @@ const NavBar = (): JSX.Element => {
                 dropdownElId="fellows-dd-mobile"
                 items={communityItems}
               />
+            </li>
+
+            {/* Symposium Link */}
+            <li className={'text-uppercase'}>
+              <Link href="https://symposium2025.sdohplace.org" target="_blank">Symposium 2025</Link>
             </li>
 
             {/* News Link */}


### PR DESCRIPTION
## Problem
We would like to add a link in the Navbar to the Symposium 2025 website

Fixes #651

## Approach
* feat: added symposium link to desktop+mobile Navbars
    * expectant link: https://symposium2025.sdohplace.org

## How to Test
Recommend testing both desktop + mobile when the navbar changes

### Desktop
1. Navigate to `/` on a desktop device (or check the "Desktop Site" checkbox on mobile)
    * You should see a new link in the Navbar at the top for "Symposium 2025"
2. Click the "Symposium 2025" nav
    * You should see a new tab open to the "Symposium 2025" website

<img width="1922" height="958" alt="Screenshot 2025-07-29 at 5 15 07 PM" src="https://github.com/user-attachments/assets/f6aac68a-939f-4bbb-9183-d2de5d990476" />

### Mobile
1. Navigate to `/` on a mobile device (or open desktop dev console, toggle the device toolbar, and activate responsive mode)
2. Expand the navbar by clicking the hamburger menu at the top-left
    * You should see a new link in the Navbar at the top for "Symposium 2025"
3. Click the "Symposium 2025" nav
    * You should see a new tab open to the "Symposium 2025" website

<img width="261" height="563" alt="Screenshot 2025-07-29 at 5 15 19 PM" src="https://github.com/user-attachments/assets/0f9581a3-8bf5-40b9-b205-f38ca4031d80" />