### PR TITLE
style: improve styling for sdoh-panel image + text in CMS content

### DIFF
--- a/public/styles/posts.module.css
+++ b/public/styles/posts.module.css
@@ -203,7 +203,7 @@
     margin-top: 0.5rem;
   }
   .sdoh-panel-content {
-    padding: 0 1rem;
+    padding: 0 0.5rem;
     display: flex;
     flex-direction: row;
     margin: 1rem 0 0 0;


### PR DESCRIPTION
## Problem
`sdoh-panel` lacks proper styling, and could use some minor improvements

Related to / discovered during #642 
Partially addresses / related to #637 

Current design specification:
<img width="2316" height="864" alt="image" src="https://github.com/user-attachments/assets/4b6aac31-1e07-4da2-ac2d-360741f9b09f" />

Original implementation - manual HTML:
<img width="1090" height="256" alt="image" src="https://github.com/user-attachments/assets/3fd1fa91-bf6e-4adc-a757-6a9891cbab19" />

Current implementation - CMS-driven Panel:
<img width="1078" height="262" alt="Screenshot 2025-07-30 at 6 17 58 PM" src="https://github.com/user-attachments/assets/fa587bd3-2d8e-4bc7-907d-2f55e5835f6b" />

We would like the implementation to more closely match the design (ignore background color - the panel in the designs is being used for a different context and uses a different color)

## Approach
* wip: discussed using/enhancing this pattern with Shubham
    * the existing styling applied to the "About the Author" images is not general enough to work for all images, and the options to describe the are too broad/complex to capture as a regular expression (e.g. round image, border color, etc)
    * another possibility is to have the border as part of the image, but this would require us to adopt the same border on the Team page or maintain separate images 🤔 
    * compromise: remove the border, always round the image border
* style: implement some simple styling improvements that should apply to both the CMS preview and the rendered version on our site (hooray shared CSS :tada:)
    * slightly larger header font, increased margin
    * image should always be rounded, no border or shadow
    * top-align image with body text
    * `sdoh-content` should have some extra padding to X-offset it from the header slightly
    * remove extra bottom padding

Here is how it looks in the CMS preview (compare these with the initial states above, to provide notes/feedback):
<img width="933" height="268" alt="Screenshot 2025-07-30 at 6 15 51 PM" src="https://github.com/user-attachments/assets/ca500160-5b3a-44ca-b410-f2eea3c0f094" />

However we can't preview this new styling yet with the About the author content because it is in a different branch (see #642)
* CMS changes are being merged to `publish`
* styling changes are being merged to `main`
* next time we perform a publish step (to sync them), we should see both? I think that's how that works anyways 😅 

## How to Test
1. Navigate to https://deploy-preview-654--cheerful-treacle-913a24.netlify.app/admin/index.html#/collections/guides/entries/public-transit-equity
    * You should see the CMS preview of the Public Transit Equity guide
2. Scroll down to the "About the Author" panel/section
    * You should see the new styling applied as described above