### PR TITLE
#655: Add space after the colon of Notes, Warnings, etc

### DIFF
--- a/src/components/search/detailPanel/index.tsx
+++ b/src/components/search/detailPanel/index.tsx
@@ -1,4 +1,3 @@
-import { makeStyles } from "@mui/styles";
 import * as React from "react";
 import tailwindConfig from "../../../../tailwind.config";
 import resolveConfig from "tailwindcss/resolveConfig";

--- a/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
+++ b/src/components/search/detailPanel/paragraphCard/paragraphCard.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles((theme) => ({
     color: `${fullConfig.theme.colors["almostblack"]}`,
     fontFamily: `${fullConfig.theme.fontFamily["sans"]}`,
     fontSize: "0.875rem",
-    marginLeft: "0.25rem",
   },
   link: {
     color: `${fullConfig.theme.colors["frenchviolet"]}`,
@@ -41,7 +40,7 @@ const DisplayNote = ({ title, value }) => {
           className="mr-1"
         />
       )}
-      <b>{title ? title : "Notes"}:</b>
+      <b>{title ? title : "Notes"}:</b>{" "}
       <span
         className={classes.paragraphCard}
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(value) }}
@@ -54,7 +53,7 @@ const UsageTip = ({ value }) => {
   const classes = useStyles();
   return (
     <div className={`container`}>
-      &#128161; <b>Usage Tip:</b>
+      &#128161; <b>Usage Tip:</b>{" "}
       <span
         className={classes.paragraphCard}
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(value) }}
@@ -129,7 +128,7 @@ const ParagraphCard = (props: Props): JSX.Element => {
             </details>
           ) : (
             <>
-              <b className="text-s">{props.title}</b>
+              <b className="text-s">{props.title}</b>{" "}
               <span className={classes.paragraphCard}>{props.value}</span>
             </>
           )}


### PR DESCRIPTION
This PR addresses issue #655. It adds spacing after the starting label in the detail panel.

## How to Test
Run the app and navigate to a result item that includes "Notes", "Warnings", or "Tooltips". There should be a small space after the label:
<img width="866" height="263" alt="Screenshot 2025-08-05 at 1 14 17 PM" src="https://github.com/user-attachments/assets/ea635bd9-645b-47f1-aa30-c21bc7a6bcfe" />
