### PR TITLE
fix: change Nav link - Symposium 2025 -> Symposium

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -190,7 +190,7 @@ const NavBar = (): JSX.Element => {
           <li
             className={`mt-4 ml-6`}
           >
-            <Link href="https://symposium2025.sdohplace.org" target="_blank">Symposium 2025</Link>
+            <Link href="https://symposium2025.sdohplace.org" target="_blank">Symposium</Link>
           </li>
 
           {/* News Link */}
@@ -279,7 +279,7 @@ const NavBar = (): JSX.Element => {
 
             {/* Symposium Link */}
             <li className={'text-uppercase'}>
-              <Link href="https://symposium2025.sdohplace.org" target="_blank">Symposium 2025</Link>
+              <Link href="https://symposium2025.sdohplace.org" target="_blank">Symposium</Link>
             </li>
 
             {/* News Link */}


### PR DESCRIPTION
## Problem
The "Symposium 2025" link in the navbar overlaps/wraps strangely on mid-sized screens

We would like the "Symposium 2025" link to instead read "Symposium", which should workaround the text wrapping behavior

## Approach
* style: update link text `Symposium 2025` -> `Symposium`

NOTE: We already made this change in #653, but somehow the "2025" text has come back? 🤔 not clear on why this has resurfaced

## How to Test
1. Navigate to /
    * You should see that the "Symposium" link text in the navbar no longer includes "2025"