### PR TITLE
676 display multiple descriptions

### DIFF
--- a/meta/interface/SolrObject.ts
+++ b/meta/interface/SolrObject.ts
@@ -8,7 +8,7 @@ export interface SolrObject {
   id: string;
   title: string;
   creator: string[];
-  description: string;
+  description: string[];
   index_year: string[];
   metadata_version: string;
   modified: string;

--- a/src/components/search/detailPanel/headerRow.tsx
+++ b/src/components/search/detailPanel/headerRow.tsx
@@ -58,13 +58,13 @@ const HeaderRow = (props: Props): JSX.Element => {
     alert("The shared link has been copied to the clipboard successfully!");
   };
 
-  const sanitizedDescription = DOMPurify.sanitize(
-    props.resultItem.description,
+  const sanitizedDescriptions = props.resultItem.description.map((d) => {
+    return DOMPurify.sanitize(d,
     {
       ALLOWED_TAGS: ["a", "b", "i", "em", "strong", "p", "div", "span"],
       ALLOWED_ATTR: ["href", "title", "target", "class"],
-    }
-  );
+    })
+  });
 
   const links = ParseReferenceLink(props.resultItem.meta.references)
   return (
@@ -198,14 +198,17 @@ const HeaderRow = (props: Props): JSX.Element => {
           </div>
         </div>
       </Collapse>
-      {props.resultItem.description ? (
-        <div className="flex flex-col sm:flex-row items-center">
-          <div
-            className="text-base"
-            dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
-          />
+      {props.resultItem.description.length > 0 && (
+        <div className="flex flex-col items-center">
+          {props.resultItem.description.map((description, index) => {
+            return <div
+              key={index}
+              className="text-base mb-2"
+            >{description}
+            </div>
+          })}
         </div>
-      ) : null}
+      )}
       {links.archiveUrl ? (
         <div className="mt-2">
           <strong>Data Offline?</strong> Checkout a copy of this dataset in our <a href={links.archiveUrl}>Data Archive</a>


### PR DESCRIPTION
This PR makes a small modification to the data discovery app, specifically the description part of the details page for a result item. Before, the description was pushed into a single div. Now, the description array is iterated, each one sanitized (as before) and then each pushed into its own div.

To test:

- Compare existing rendering:
    - https://sdohplace.org/search?query=Environmental+Justice+Index&show=herop-oqxqog
    <img width="1551" height="698" alt="image" src="https://github.com/user-attachments/assets/246f8727-8c66-4e53-8d50-3bca12a78339" />
- with updated rendering:
    - https://deploy-preview-677--cheerful-treacle-913a24.netlify.app/search?query=Environmental+Justice+Index&show=herop-oqxqog
    <img width="1367" height="916" alt="image" src="https://github.com/user-attachments/assets/328eb490-e08c-4488-8f37-c1d8965ea8d0" />
