### PR TITLE
Fix site name in unfurl

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -11,7 +11,7 @@ export default class MyDocument extends Document {
       <Html lang="en">
         <Head>
             <meta name="viewport" content="initial-scale=1, width=device-width" />
-            <meta property="og:site_name" content="SDOH &amp; Place Project" />
+            <meta property="og:site_name" content={config.site_title} />
             {/* Some site-wide JSON-LD entries */}
             <script
                 {...jsonLdScriptProps<WebSite>({

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -42,7 +42,7 @@ export default function Index({ guides, tags, pagination }: Props) {
                           </p>
                           <br />
                           <p>
-                            You can suggest your own guide <Link className={'no-underline'} href={'https://forms.illinois.edu/sec/1493227735'} target={'_blank'} rel={'noreferrer noopener'}>here.</Link>
+                            Interested in writing or reviewing a Research Guide? Learn more <Link className={'no-underline'} href={'/guides/call-for-guides'} target={'_blank'} rel={'noreferrer noopener'}>here</Link>.
                           </p>
                         </div>
                         <GuidesList guides={guides} pagination={pagination} />


### PR DESCRIPTION
Currently, the `&` in the site title is replaced with the HTML entity `&amp;` when Slack unfurls a link to our site.

<img width="1023" height="106" alt="image" src="https://github.com/user-attachments/assets/51ca1766-1ed4-4d46-a1a6-630902c244f7" />

Hopefully this can be fixed, making a pr to test some strategies.