### PR TITLE
fix: Research & Reports - parse Description from Body

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -479,7 +479,7 @@ collections:
         widget: string
         required: false
       - label: "Description"
-        name: "description"
+        name: "body"
         widget: "markdown"
 
   - name: "research-rabbit"


### PR DESCRIPTION
## Problem
When using DecapCMS to edit an entry in Research & Reports, the Description field always shows as empty

If `body` is present in the MDX file, this body markdown text should be parsed as the description

Fixes #708 

<img width="1919" height="957" alt="Screenshot 2025-12-01 at 5 44 45 PM" src="https://github.com/user-attachments/assets/1a04371b-f73d-474d-b9fd-dd837ade99ba" />

## Approach
* fix: change `description` field to be named `body` instead, without changing the label in the UI

<img width="1920" height="959" alt="Screenshot 2025-12-01 at 5 55 16 PM" src="https://github.com/user-attachments/assets/c9002932-eb26-4f4f-9f15-c1e3a43a2d7f" />

## How to Test
1. Navigate to /admin
2. On the left side, choose "Research Outputs"
    * You should see 2 entries listed here
3. Click on one of the entries
    * You should see the full editable metadata for this entry
4. Scroll all the way down
    * You should see the Description field is now populated by the MDX body