### PR TITLE
feat: added cohorts for Fall 2025 and Spring 2026

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -173,7 +173,7 @@ collections:
               - label: "Cohort"
                 name: "cohort"
                 widget: "select"
-                options: ["Spring 2024", "Fall 2024", "Spring 2025"]
+                options: ["Spring 2024", "Fall 2024", "Spring 2025", "Fall 2025", "Spring 2026"]
               - label: "Links"
                 name: "links"
                 widget: "list"


### PR DESCRIPTION
## Problem
We need to add a cohort for Spring 2026

Fall 2025 also appear to be missing as well?

Fixes #755

## Approach
* feat: added new cohort for Spring 2026, also noticed Fall 2025 was missing and added this as well 🤷‍♀️ 

## How to Test
1. Navigate to https://deploy-preview-756--cheerful-treacle-913a24.netlify.app/admin/index.html#/collections/people/entries/fellows
2. At the top-right, click on "Add fellow +"
    * You should see empty fields pop up allowing you to create a new Fellow
3. Scroll down and expand the Cohort dropdown
    * You should see an option here for "Spring 2026"